### PR TITLE
Removed duplicate entry of bug pattern SERVLET_HEADER.

### DIFF
--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -182,17 +182,6 @@ crawler UA) is not recommended.</p>
     </BugPattern>
     <BugCode abbrev="SECSSHUA">>Request Header "User-Agent"</BugCode>
 
-    <BugPattern type="SERVLET_HEADER">
-        <ShortDescription>Request Header</ShortDescription>
-        <LongDescription>Request header can easily be alter by the client</LongDescription>
-        <Details>
-            <![CDATA[
-<p>Request header can easily be alter by the client. No assumption should be make that the request come from a regular browser</p>
-]]>
-        </Details>
-    </BugPattern>
-    <BugCode abbrev="SECSH">Request Header</BugCode>
-
     <!-- Cookie usage -->
     <Detector class="com.h3xstream.findsecbugs.endpoint.CookieDetector">
         <Details>Identy direct cookie usage</Details>


### PR DESCRIPTION
While I integrated your plugin messages in my Jenkins findbugs plug-in I noticed that the SERVLET_HEADER pattern was included twice in the messages file.
