### PR TITLE
Bug fix for BadHexadecimalConversionDetector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/BadHexadecimalConversionDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/BadHexadecimalConversionDetector.java
@@ -62,7 +62,7 @@ public class BadHexadecimalConversionDetector implements Detector {
             boolean invokeToHexString = false;
 
             ConstantPoolGen cpg = classContext.getConstantPoolGen();
-            if(methodGen.getInstructionList() == null || methodGen.getInstructionList().getInstructions() == null) {
+            if(methodGen == null || methodGen.getInstructionList() == null || methodGen.getInstructionList().getInstructions() == null) {
                 continue; //No instruction .. nothing to do
             }
             for (Instruction inst : methodGen.getInstructionList().getInstructions()) {


### PR DESCRIPTION
Hi, 
I've just noticed a little bug in the BadHexadecimalConversionDetector when I was using the find-sec-bugs in my project. Actually, a nullPointerEx was notified by maven and eclipse (in the log view) when I scanned my project. 
It seemed like "classContext.getMethodGen(m)" return null for any method in any interfaces.

I hope it can help you and thanks for your findbugs plugin.

Patrice CAVEZZAN
