### PR TITLE
Add scala.util.Random to PredictableRandomDetector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/PredictableRandomDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/PredictableRandomDetector.java
@@ -41,6 +41,12 @@ public class PredictableRandomDetector extends OpcodeStackDetector {
                     .addClass(this).addMethod(this).addSourceLine(this) //
                     .addString("java.util.Random"));
 
+        } else if (seen == Constants.INVOKESPECIAL && getClassConstantOperand().equals("scala/util/Random")
+                && getNameConstantOperand().equals("<init>")) {
+            bugReporter.reportBug(new BugInstance(this, PREDICTABLE_RANDOM_TYPE, Priorities.NORMAL_PRIORITY) //
+                    .addClass(this).addMethod(this).addSourceLine(this) //
+                    .addString("scala.util.Random"));
+
         } else if (seen == Constants.INVOKESTATIC && getClassConstantOperand().equals("java/lang/Math")
                 && getNameConstantOperand().equals("random")) {
             bugReporter.reportBug(new BugInstance(this, PREDICTABLE_RANDOM_TYPE, Priorities.NORMAL_PRIORITY) //


### PR DESCRIPTION
I'm just looking around the code so far... I might contribute more later.

`scala.util.Random` is just a wrapper for `java.util.Random`, so the warning applies. I've tested the detector, but I haven't written a test, as that would likely mean adding the scala compiler and library to the build.
