### PR TITLE
Analysis of indirect subclasses of HttpServlet for XSS

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/xss/XssJspDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/xss/XssJspDetector.java
@@ -17,11 +17,11 @@
  */
 package com.h3xstream.findsecbugs.xss;
 
-import com.h3xstream.findsecbugs.common.InterfaceUtils;
 import com.h3xstream.findsecbugs.injection.ConfiguredBasicInjectionDetector;
 import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.ClassContext;
-import org.apache.bcel.classfile.JavaClass;
+import edu.umd.cs.findbugs.ba.Hierarchy;
 
 public class XssJspDetector extends ConfiguredBasicInjectionDetector {
 
@@ -32,9 +32,14 @@ public class XssJspDetector extends ConfiguredBasicInjectionDetector {
         loadConfiguredSinks("xss-jsp.txt", XSS_JSP_PRINT_TYPE);
     }
 
+    @Override
     public boolean shouldAnalyzeClass(ClassContext classContext) {
-        JavaClass javaClass = classContext.getJavaClass();
-        //TODO: Do recursive check on child class inheritance
-        return InterfaceUtils.classExtends(javaClass, "javax.servlet.http.HttpServlet");
+        try {
+            String className = classContext.getClassDescriptor().getDottedClassName();
+            return Hierarchy.isSubtype(className, "javax.servlet.http.HttpServlet");
+        } catch (ClassNotFoundException ex) {
+            AnalysisContext.reportMissingClass(ex);
+            return false;
+        }
     }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/xss/XssServletDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/xss/XssServletDetector.java
@@ -17,16 +17,15 @@
  */
 package com.h3xstream.findsecbugs.xss;
 
-import com.h3xstream.findsecbugs.common.InterfaceUtils;
 import com.h3xstream.findsecbugs.injection.ConfiguredBasicInjectionDetector;
 import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.ClassContext;
-import org.apache.bcel.Repository;
-import org.apache.bcel.classfile.JavaClass;
+import edu.umd.cs.findbugs.ba.Hierarchy;
 
 public class XssServletDetector extends ConfiguredBasicInjectionDetector {
 
-    private static final String XSS_JSP_PRINT_TYPE = "XSS_JSP_PRINT";
+    //private static final String XSS_JSP_PRINT_TYPE = "XSS_JSP_PRINT";
     private static final String XSS_SERVLET_TYPE = "XSS_SERVLET";
 
     public XssServletDetector(BugReporter bugReporter) {
@@ -35,9 +34,14 @@ public class XssServletDetector extends ConfiguredBasicInjectionDetector {
         loadConfiguredSinks("xss-servlet.txt", XSS_SERVLET_TYPE);
     }
 
+    @Override
     public boolean shouldAnalyzeClass(ClassContext classContext) {
-        JavaClass javaClass = classContext.getJavaClass();
-        //TODO: Do recursive check on inheritance
-        return InterfaceUtils.classExtends(javaClass, "javax.servlet.http.HttpServlet");
+        try {
+            String className = classContext.getClassDescriptor().getDottedClassName();
+            return Hierarchy.isSubtype(className, "javax.servlet.http.HttpServlet");
+        } catch (ClassNotFoundException ex) {
+            AnalysisContext.reportMissingClass(ex);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Now it detects many more bugs. But I think it would be still better not to rely on this and check presence of `response.getWriter().println()` directly. 