### PR TITLE
Taint tags - support for taint sanitization (strating with XSS)

### DIFF
--- a/plugin-deps/src/main/java/org/owasp/esapi/Encoder.java
+++ b/plugin-deps/src/main/java/org/owasp/esapi/Encoder.java
@@ -2,4 +2,5 @@ package org.owasp.esapi;
 
 public interface Encoder {
     String encodeForHTML(String input);
+    String decodeForHTML(String input);
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
@@ -21,7 +21,6 @@ import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.util.ClassName;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/SinksLoader.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/SinksLoader.java
@@ -1,11 +1,27 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.injection;
-
-import org.apache.bcel.Constants;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.apache.bcel.Constants;
 
 /**
  *

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -21,6 +21,7 @@ import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.util.ClassName;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -75,6 +76,10 @@ public class Taint {
         }
     }
 
+    public enum Tag {
+        XSS_SAFE
+    }
+    
     private State state;
     private static final int INVALID_INDEX = -1;
     private int variableIndex;
@@ -83,6 +88,7 @@ public class Taint {
     private final Set<Integer> parameters;
     private State nonParametricState;
     private ObjectType realInstanceClass;
+    private EnumSet<Tag> tags;
     private String debugInfo = null;
 
     public Taint(State state) {
@@ -95,10 +101,10 @@ public class Taint {
         this.unknownLocations = new HashSet<TaintLocation>();
         this.taintLocations = new HashSet<TaintLocation>();
         this.parameters = new HashSet<Integer>();
-        nonParametricState = State.INVALID;
+        this.nonParametricState = State.INVALID;
         this.realInstanceClass = null;
-
-        if(FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
+        this.tags = EnumSet.noneOf(Tag.class);
+        if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             this.debugInfo = "?";
         }
     }
@@ -113,8 +119,8 @@ public class Taint {
         this.parameters = new HashSet<Integer>(taint.getParameters());
         this.nonParametricState = taint.nonParametricState;
         this.realInstanceClass = taint.realInstanceClass;
-
-        if(FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
+        this.tags = EnumSet.copyOf(taint.tags);
+        if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             this.debugInfo = taint.debugInfo;
         }
     }
@@ -227,6 +233,22 @@ public class Taint {
         return ClassName.toSlashedClassName(realInstanceClass.getClassName());
     }
 
+    public boolean addTag(Tag tag) {
+        return tags.add(tag);
+    }
+    
+    public boolean hasTag(Tag tag) {
+        return tags.contains(tag);
+    }
+    
+    public boolean hasTags() {
+        return !tags.isEmpty();
+    }
+    
+    public boolean removeTag(Tag tag) {
+        return tags.remove(tag);
+    }
+    
     public static Taint valueOf(String stateName) {
         // exceptions thrown from Enum.valueOf
         return valueOf(State.valueOf(stateName));
@@ -284,8 +306,15 @@ public class Taint {
                 AnalysisContext.reportMissingClass(ex);
             }
         }
-
-        if(FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
+        if (a.isSafe()) {
+            result.tags.addAll(b.tags);
+        } else if (b.isSafe()) {
+            result.tags.addAll(a.tags);
+        } else {
+            result.tags.addAll(a.tags);
+            result.tags.retainAll(b.tags);
+        }
+        if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             result.setDebugInfo("[" + a.getDebugInfo() + "]+[" + b.getDebugInfo() + "]");
         }
         return result;
@@ -309,13 +338,14 @@ public class Taint {
                 && this.unknownLocations.equals(other.unknownLocations)
                 && this.parameters.equals(other.parameters)
                 && this.nonParametricState == other.nonParametricState
-                && Objects.equals(this.realInstanceClass, other.realInstanceClass);
+                && Objects.equals(this.realInstanceClass, other.realInstanceClass)
+                && this.tags.equals(other.tags);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(state, variableIndex, taintLocations, unknownLocations,
-                parameters, nonParametricState, realInstanceClass);
+                parameters, nonParametricState, realInstanceClass, tags);
     }
 
     public String getDebugInfo() {

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -281,6 +281,16 @@ public class Taint {
         result.taintLocations.addAll(b.taintLocations);
         result.unknownLocations.addAll(a.unknownLocations);
         result.unknownLocations.addAll(b.unknownLocations);
+        mergeParameters(a, b, result);
+        mergeRealInstanceClass(a, b, result);
+        mergeTags(a, b, result);
+        if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
+            result.setDebugInfo("[" + a.getDebugInfo() + "]+[" + b.getDebugInfo() + "]");
+        }
+        return result;
+    }
+
+    private static void mergeParameters(Taint a, Taint b, Taint result) {
         result.parameters.addAll(a.parameters);
         result.parameters.addAll(b.parameters);
         if (a.hasParameters()) {
@@ -294,6 +304,9 @@ public class Taint {
                 result.nonParametricState = State.merge(a.state, b.nonParametricState);
             }
         }
+    }
+
+    private static void mergeRealInstanceClass(Taint a, Taint b, Taint result) {
         if (a.realInstanceClass != null && b.realInstanceClass != null) {
             try {
                 if (a.realInstanceClass.equals(b.realInstanceClass)
@@ -306,6 +319,9 @@ public class Taint {
                 AnalysisContext.reportMissingClass(ex);
             }
         }
+    }
+    
+    private static void mergeTags(Taint a, Taint b, Taint result) {
         if (a.isSafe()) {
             result.tags.addAll(b.tags);
         } else if (b.isSafe()) {
@@ -314,10 +330,6 @@ public class Taint {
             result.tags.addAll(a.tags);
             result.tags.retainAll(b.tags);
         }
-        if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
-            result.setDebugInfo("[" + a.getDebugInfo() + "]+[" + b.getDebugInfo() + "]");
-        }
-        return result;
     }
 
     @Override

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
@@ -56,7 +56,9 @@ public class TaintAnalysis extends FrameDataflowAnalysis<Taint, TaintFrame> {
     private int parameterStackSize;
     private List<Integer> slotToParameter;
 
-    private static final List<String> TAINTED_ANNOTATIONS = loadFileContent("taint-config/taint-param-annotations.txt");
+    private static final List<String> TAINTED_ANNOTATIONS = loadFileContent(
+            "taint-config/taint-param-annotations.txt"
+    );
     
     public TaintAnalysis(MethodGen methodGen, DepthFirstSearch dfs,
             MethodDescriptor descriptor, TaintMethodSummaryMap methodSummaries) {
@@ -259,5 +261,4 @@ public class TaintAnalysis extends FrameDataflowAnalysis<Taint, TaintFrame> {
         }
         return new ArrayList<String>();
     }
-
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -347,7 +347,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
                 null : methodSummary.getOutputTaint().getRealInstanceClass();
         Taint taint = getMethodTaint(methodSummary);
         assert taint != null;
-        if(FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
+        if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             taint.setDebugInfo(obj.getMethodName(cpg) + "()");
         }
         if (taint.isUnknown()) {
@@ -450,10 +450,21 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
         if (taint.isUnknown() && taint.hasParameters()) {
             Taint merge = mergeTransferParameters(taint.getParameters());
             assert merge != null;
-            return Taint.merge(Taint.valueOf(taint.getNonParametricState()), merge);
+            taint = Taint.merge(Taint.valueOf(taint.getNonParametricState()), merge);
         }
         if (taint.isTainted()) {
             taint.addLocation(getTaintLocation(), true);
+        }
+        // don't add tags to safe values
+        if (!taint.isSafe() && methodSummary.hasAddingTags()) {
+            for (Taint.Tag tag : methodSummary.getAddingTags()) {
+                taint.addTag(tag);
+            }
+        }
+        if (methodSummary.hasRemovingTags()) {
+            for (Taint.Tag tag : methodSummary.getRemovingTags()) {
+                taint.removeTag(tag);
+            }
         }
         return taint;
     }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMap.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMap.java
@@ -17,10 +17,8 @@
  */
 package com.h3xstream.findsecbugs.taintanalysis;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.TreeSet;
@@ -57,6 +55,5 @@ public class TaintMethodSummaryMap extends HashMap<String, TaintMethodSummary> {
                 put(fullMethod, taintMethodSummary);
             }
         });
-
     }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMapLoader.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMapLoader.java
@@ -1,14 +1,28 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.taintanalysis;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.util.TreeSet;
 
 public class TaintMethodSummaryMapLoader {
-
 
     public void load(InputStream input, TaintMethodSummaryReceiver receiver) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(input, "UTF-8"));
@@ -24,7 +38,6 @@ public class TaintMethodSummaryMapLoader {
             putFromLine(line, receiver);
         }
     }
-
 
     private void putFromLine(String line, TaintMethodSummaryReceiver receiver) throws IOException {
         if (line.startsWith("-")) {

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMapLoader.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodSummaryMapLoader.java
@@ -48,7 +48,6 @@ public class TaintMethodSummaryMapLoader {
         if (tuple.length != 2) {
             throw new IOException("Line format is not 'method name:summary info'");
         }
-
         receiver.receiveTaintMethodSummary(tuple[0].trim(), TaintMethodSummary.load(tuple[1]));
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintSink.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintSink.java
@@ -30,10 +30,12 @@ public class TaintSink {
     private final BugInstance bugInstance;
 
     public TaintSink(Taint taint, BugInstance bugInstance) {
-        //Invalid arguments
-        if (taint == null) throw new NullPointerException("taint is null");
-        if (bugInstance == null) throw new NullPointerException("bugInstance is null");
-
+        if (taint == null) {
+            throw new NullPointerException("taint is null");
+        }
+        if (bugInstance == null) {
+            throw new NullPointerException("bugInstance is null");
+        }
         this.taint = taint;
         this.bugInstance = bugInstance;
     }

--- a/plugin/src/main/resources/safe-encoders/xss-encoders.txt
+++ b/plugin/src/main/resources/safe-encoders/xss-encoders.txt
@@ -1,32 +1,77 @@
 -Safe encoder for XSS
 
 --ESAPI
+org/owasp/esapi/Encoder.encodeForBase64([BZ):SAFE
 org/owasp/esapi/Encoder.encodeForCSS(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+-org/owasp/esapi/Encoder.encodeForDN(Ljava/lang/String;)Ljava/lang/String;:0|+?
 org/owasp/esapi/Encoder.encodeForHTML(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.decodeForHTML(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/owasp/esapi/Encoder.encodeForHTMLAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/owasp/esapi/Encoder.encodeForJavaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+-org/owasp/esapi/Encoder.encodeForLDAP(Ljava/lang/String;)Ljava/lang/String;:0|+?
+-org/owasp/esapi/Encoder.encodeForOS(Lorg/owasp/esapi/codecs/Codec;Ljava/lang/String;)Ljava/lang/String;:0|+?
+-org/owasp/esapi/Encoder.encodeForSQL(Lorg/owasp/esapi/codecs/Codec;Ljava/lang/String;)Ljava/lang/String;:0|+?
 org/owasp/esapi/Encoder.encodeForURL(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeFromURL(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/owasp/esapi/Encoder.encodeForVBScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/owasp/esapi/Encoder.encodeForXML(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/owasp/esapi/Encoder.encodeForXMLAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForXPath(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+
+--OWASP Encoder
+-org/owasp/encoder/Encode.forCDATA(Ljava/lang/String;)Ljava/lang/String;:+?
+org/owasp/encoder/Encode.forCssString(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forCssUrl(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forHtml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forHtmlAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forHtmlContent(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forHtmlUnquotedAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forJava(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forJavaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forJavaScriptAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forJavaScriptBlock(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forJavaScriptSource(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forUri(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forUriComponent(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forXml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/encoder/Encode.forXmlAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+-org/owasp/encoder/Encode.forXmlComment(Ljava/lang/String;)Ljava/lang/String;:+?
+org/owasp/encoder/Encode.forXmlContent(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 
 --Apache Commons Lang 2
+-org/apache/commons/lang/StringEscapeUtils.escapeCsv(Ljava/lang/String;)Ljava/lang/String;:0|+?
+-org/apache/commons/lang/StringEscapeUtils.unescapeCsv(Ljava/lang/String;)Ljava/lang/String;:0|-?
 org/apache/commons/lang/StringEscapeUtils.escapeHtml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang/StringEscapeUtils.unescapeHtml(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
+org/apache/commons/lang/StringEscapeUtils.escapeJava(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang/StringEscapeUtils.unescapeJava(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang/StringEscapeUtils.escapeJavaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang/StringEscapeUtils.unescapeJavaScript(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
+-org/apache/commons/lang/StringEscapeUtils.escapeSql(Ljava/lang/String;)Ljava/lang/String;:0|+?
 org/apache/commons/lang/StringEscapeUtils.escapeXml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
-
+org/apache/commons/lang/StringEscapeUtils.unescapeXml(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 
 --Apache Commons Lang 3
+-org/apache/commons/lang3/StringEscapeUtils.escapeCsv(Ljava/lang/String;)Ljava/lang/String;:0|+?
+-org/apache/commons/lang3/StringEscapeUtils.unescapeCsv(Ljava/lang/String;)Ljava/lang/String;:0|-?
 org/apache/commons/lang3/StringEscapeUtils.escapeEcmaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.unescapeEcmaScript(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeHtml3(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.unescapeHtml3(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeHtml4(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.unescapeHtml4(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeJava(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.unescapeJava(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeJson(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.unescapeJson(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeXml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.unescapeXml(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeXml10(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/apache/commons/lang3/StringEscapeUtils.escapeXml11(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 
 --Spring Framework
 org/springframework/web/util/HtmlUtils.htmlEscape(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/springframework/web/util/HtmlUtils.htmlUnescape(Ljava/lang/String;)Ljava/lang/String;:0|-XSS_SAFE
 org/springframework/web/util/HtmlUtils.htmlEscapeDecimal(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/springframework/web/util/HtmlUtils.htmlEscapeHex(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/springframework/web/util/JavaScriptUtils.javaScriptEscape(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE

--- a/plugin/src/main/resources/safe-encoders/xss-encoders.txt
+++ b/plugin/src/main/resources/safe-encoders/xss-encoders.txt
@@ -1,32 +1,32 @@
 -Safe encoder for XSS
 
 --ESAPI
-org/owasp/esapi/Encoder.encodeForCSS(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForHTML(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForHTMLAttribute(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForJavaScript(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForURL(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForVBScript(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForXML(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/owasp/esapi/Encoder.encodeForXMLAttribute(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/owasp/esapi/Encoder.encodeForCSS(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForHTML(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForHTMLAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForJavaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForURL(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForVBScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForXML(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/owasp/esapi/Encoder.encodeForXMLAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 
 --Apache Commons Lang 2
-org/apache/commons/lang/StringEscapeUtils.escapeHtml(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang/StringEscapeUtils.escapeJavaScript(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang/StringEscapeUtils.escapeXml(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/apache/commons/lang/StringEscapeUtils.escapeHtml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang/StringEscapeUtils.escapeJavaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang/StringEscapeUtils.escapeXml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 
 
 --Apache Commons Lang 3
-org/apache/commons/lang3/StringEscapeUtils.escapeEcmaScript(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeHtml3(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeHtml4(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeJava(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeJson(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeXml(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeXml10(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/apache/commons/lang3/StringEscapeUtils.escapeXml11(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeEcmaScript(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeHtml3(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeHtml4(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeJava(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeJson(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeXml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeXml10(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/apache/commons/lang3/StringEscapeUtils.escapeXml11(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 
 --Spring Framework
-org/springframework/web/util/HtmlUtils.htmlEscape(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/springframework/web/util/HtmlUtils.htmlEscapeDecimal(Ljava/lang/String;)Ljava/lang/String;:SAFE
-org/springframework/web/util/HtmlUtils.htmlEscapeHex(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/web/util/HtmlUtils.htmlEscape(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/springframework/web/util/HtmlUtils.htmlEscapeDecimal(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
+org/springframework/web/util/HtmlUtils.htmlEscapeHex(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE

--- a/plugin/src/main/resources/taint-config/other.txt
+++ b/plugin/src/main/resources/taint-config/other.txt
@@ -183,3 +183,15 @@ org/jboss/seam/log/Log.trace(Ljava/lang/Object;[Ljava/lang/Object;)V:UNKNOWN
 org/jboss/seam/log/Log.trace(Ljava/lang/Object;Ljava/lang/Throwable;[Ljava/lang/Object;)V:UNKNOWN
 org/jboss/seam/log/Log.warn(Ljava/lang/Object;[Ljava/lang/Object;)V:UNKNOWN
 org/jboss/seam/log/Log.warn(Ljava/lang/Object;Ljava/lang/Throwable;[Ljava/lang/Object;)V:UNKNOWN
+
+
+flexjson/JSONSerializer.deepSerialize(Ljava/lang/Object;)Ljava/lang/String;:0
+flexjson/JSONSerializer.deepSerialize(Ljava/lang/Object;Lflexjson/OutputHandler;)Ljava/lang/String;:1
+flexjson/JSONSerializer.deepSerialize(Ljava/lang/Object;Ljava/lang/StringBuffer;)Ljava/lang/String;:1
+flexjson/JSONSerializer.deepSerialize(Ljava/lang/Object;Ljava/lang/StringBuilder;)Ljava/lang/String;:1
+flexjson/JSONSerializer.serialize(Ljava/lang/Object;)Ljava/lang/String;:0
+flexjson/JSONSerializer.serialize(Ljava/lang/Object;Lflexjson/OutputHandler;)Ljava/lang/String;:1
+flexjson/JSONSerializer.serialize(Ljava/lang/Object;Lflexjson/SerializationType;Lflexjson/OutputHandler;)Ljava/lang/String;:2
+flexjson/JSONSerializer.serialize(Ljava/lang/Object;Ljava/lang/StringBuffer;)Ljava/lang/String;:1
+flexjson/JSONSerializer.serialize(Ljava/lang/Object;Ljava/lang/StringBuilder;)Ljava/lang/String;:1
+

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/SinkFilesValidationTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/SinkFilesValidationTest.java
@@ -1,13 +1,29 @@
-package com.h3xstream.findsecbugs.injection;
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 
-import org.testng.annotations.Test;
+package com.h3xstream.findsecbugs.injection;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
 import static org.testng.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 public class SinkFilesValidationTest {
     private static final boolean DEBUG = false;

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/jsp/JspXssDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/jsp/JspXssDetectorTest.java
@@ -53,8 +53,19 @@ public class JspXssDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+        
+        for (Integer line : Arrays.asList(12, 17)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("XSS_JSP_PRINT")
+                            .inJspFile("xss/xss_1_direct_use.jsp")
+                            .atJspLine(line)
+                            .withPriority("Low")
+                            .build()
+            );
+        }
 
-        verify(reporter, times(2)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
+        verify(reporter, times(4)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
     }
 
     @Test
@@ -77,8 +88,17 @@ public class JspXssDetectorTest extends BaseDetectorTest {
                         .atJspLine(10)
                         .build()
         );
+        
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_JSP_PRINT")
+                        .inJspFile("xss/xss_2_transfer_local.jsp")
+                        .atJspLine(14)
+                        .withPriority("Low")
+                        .build()
+        );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
+        verify(reporter, times(2)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
     }
 
     @Test
@@ -93,7 +113,7 @@ public class JspXssDetectorTest extends BaseDetectorTest {
         analyze(files, reporter);
 
         //No alert should be trigger
-        verify(reporter, times(0)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
+        verify(reporter, never()).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
     }
 
     @Test
@@ -129,8 +149,17 @@ public class JspXssDetectorTest extends BaseDetectorTest {
                         .atJspLine(13)
                         .build()
         );
+        
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_JSP_PRINT")
+                        .inJspFile("xss/xss_5_multiple_transfer_local.jsp")
+                        .atJspLine(17)
+                        .withPriority("Low")
+                        .build()
+        );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
+        verify(reporter, times(2)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
     }
 
     @Test
@@ -152,7 +181,7 @@ public class JspXssDetectorTest extends BaseDetectorTest {
                         .build()
         );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
+        verify(reporter, times(1)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
     }
 
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/MethodSummaryValidationTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/MethodSummaryValidationTest.java
@@ -1,15 +1,30 @@
-package com.h3xstream.findsecbugs.taintanalysis;
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 
-import com.h3xstream.findsecbugs.injection.SinksLoader;
-import org.testng.annotations.Test;
+package com.h3xstream.findsecbugs.taintanalysis;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
-
 import static org.testng.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 public class MethodSummaryValidationTest {
     private static final boolean DEBUG = true;
@@ -22,15 +37,16 @@ public class MethodSummaryValidationTest {
             InputStream in = getClass().getResourceAsStream(directory);
             assertNotNull(in, "Unable list the resources in the taint-config directory");
 
-
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
-            String file = null;
+            String file;
             while ((file = br.readLine()) != null) {
-                if (DEBUG) System.out.println("File : " + file);
+                if (DEBUG) {
+                    System.out.println("File : " + file);
+                }
 
                 ////////////
                 // Validate annotation (list of annotation with parameters)
-                if("taint-param-annotations.txt".equals(file)) {
+                if ("taint-param-annotations.txt".equals(file)) {
 
                     BufferedReader br2 = new BufferedReader(new InputStreamReader(in));
                     String line;
@@ -56,7 +72,9 @@ public class MethodSummaryValidationTest {
         loader.load(inFile, new TaintMethodSummaryMapLoader.TaintMethodSummaryReceiver() {
             @Override
             public void receiveTaintMethodSummary(String fullMethodName, TaintMethodSummary taintMethodSummary) {
-                if (DEBUG) System.out.println("[?] fmn: " + fullMethodName);
+                if (DEBUG) {
+                    System.out.println("[?] fmn: " + fullMethodName);
+                }
                 String[] methodParts = fullMethodName.split("\\.");
 
                 //Test the validity of the class name
@@ -67,7 +85,9 @@ public class MethodSummaryValidationTest {
     }
 
     public void validateClass(String className) {
-        if(className.startsWith("scala")) return;
+        if (className.startsWith("scala")) {
+            return;
+        }
         try {
             Class.forName(className);
         } catch (ClassNotFoundException e) {

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
@@ -98,6 +98,12 @@ public class XssServletDetectorTest extends BaseDetectorTest {
                         .inClass("XssServlet3").inMethod("writeWithEncoders").withPriority("High").atLine(24)
                         .build()
         );
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_SERVLET")
+                        .inClass("XssServlet3").inMethod("writeWithEncoders").withPriority("High").atLine(28)
+                        .build()
+        );
 
         verify(reporter).doReportBug(
                 bugDefinition()
@@ -112,7 +118,7 @@ public class XssServletDetectorTest extends BaseDetectorTest {
                         .build()
         );
         
-        verify(reporter, times(3)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+        verify(reporter, times(4)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
 
 

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
@@ -43,8 +43,21 @@ public class XssServletDetectorTest extends BaseDetectorTest {
                         .inClass("XssServlet1").inMethod("doGet").withPriority("High").atLine(17)
                         .build()
         );
+        
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_SERVLET")
+                        .inClass("XssServlet1").inMethod("doGet").withPriority("Low").atLine(19)
+                        .build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_SERVLET")
+                        .inClass("XssServlet1").inMethod("doGet").withPriority("Low").atLine(20)
+                        .build()
+        );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+        verify(reporter, times(3)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
 
     @Test
@@ -65,7 +78,7 @@ public class XssServletDetectorTest extends BaseDetectorTest {
                         .build()
         );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+        verify(reporter, times(1)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
 
     @Test
@@ -82,11 +95,24 @@ public class XssServletDetectorTest extends BaseDetectorTest {
         verify(reporter).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
-                        .inClass("XssServlet3").inMethod("writeWithEncoders").withPriority("High")
+                        .inClass("XssServlet3").inMethod("writeWithEncoders").withPriority("High").atLine(24)
                         .build()
         );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_SERVLET")
+                        .inClass("XssServlet3").inMethod("writeWithEncoders").withPriority("Low").atLine(26)
+                        .build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_SERVLET")
+                        .inClass("XssServlet3").inMethod("writeWithEncoders").withPriority("Low").atLine(27)
+                        .build()
+        );
+        
+        verify(reporter, times(3)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
 
 
@@ -108,7 +134,7 @@ public class XssServletDetectorTest extends BaseDetectorTest {
                         .build()
         );
 
-        verify(reporter,times(1)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+        verify(reporter, times(1)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
 
     @Test
@@ -122,62 +148,62 @@ public class XssServletDetectorTest extends BaseDetectorTest {
         EasyBugReporter reporter = spy(new EasyBugReporter());
         analyze(files, reporter);
 
-        verify(reporter,times(4)).doReportBug(
+        verify(reporter, times(4)).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testWrite")
                         .build()
         );
 
-        verify(reporter,times(6)).doReportBug(
+        verify(reporter, times(6)).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testFormatUnsafe")
                         .build()
         );
 
-        verify(reporter,never()).doReportBug(
+        verify(reporter, never()).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testFormatSafe")
                         .build()
         );
 
-        verify(reporter,times(4 * 2)).doReportBug(
+        verify(reporter, times(4 * 2)).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testPrintUnsafe")
                         .build()
         );
 
-        verify(reporter,never()).doReportBug(
+        verify(reporter, never()).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testPrintSafe")
                         .build()
         );
 
-        verify(reporter,times(6)).doReportBug(
+        verify(reporter, times(6)).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testPrintfUnsafe")
                         .build()
         );
 
-        verify(reporter,never()).doReportBug(
+        verify(reporter, never()).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testPrintfSafe")
                         .build()
         );
 
-        verify(reporter,times(3)).doReportBug(
+        verify(reporter, times(3)).doReportBug(
                 bugDefinition()
                         .bugType("XSS_SERVLET")
                         .inClass("XssServlet5").inMethod("testAppend")
                         .build()
         );
 
-        verify(reporter,times(27)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+        verify(reporter, times(27)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
 }

--- a/plugin/src/test/java/testcode/xss/servlets/XssServlet3.java
+++ b/plugin/src/test/java/testcode/xss/servlets/XssServlet3.java
@@ -22,8 +22,9 @@ public class XssServlet3 extends HttpServlet {
 
     public void writeWithEncoders(PrintWriter pw, String input1) {
         pw.write(input1);
-
-        pw.write(ESAPI.encoder().encodeForHTML(input1));
+        String encoded = ESAPI.encoder().encodeForHTML(input1);
+        pw.write(encoded.toLowerCase() + SAFE_VALUE);
         pw.write(StringEscapeUtils.escapeHtml(input1));
+        pw.write(ESAPI.encoder().decodeForHTML(encoded) + SAFE_VALUE);
     }
 }


### PR DESCRIPTION
First version of sanitization support - methods can be configured to add or remove tags for method output and detectors can read them to decide whether to report the bug. Currently, only XSS_SAFE tag is supported, but I'm going to add more before the new release.

Sanitized values for XSS are reported with low priority (less than for inputs with unknown taint state). I don't want to exclude those detections completely, because configured escape methods are context specific and there is still a risk of a successful XSS if an inappropriate sanitization method is chosen. 