### PR TITLE
Fix URL shown for CUSTOM_INJECTION bug warning

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/custom/CustomInjectionSource.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/custom/CustomInjectionSource.java
@@ -94,7 +94,7 @@ public class CustomInjectionSource implements InjectionSource {
         if (url == null && FindSecBugsGlobalConfig.getInstance().isPrintCustomInjectionWarning()) {
             LOG.info("The optional configuration for additional injection sources (" + resourceName + ") was not found. " +
                     "This message can be ignored if no custom API are intended to be configured. " +
-                    "For more info: http://h3xstream.github.io/find-sec-bugs/bugs.htm#CUSTOM_INJECTION");
+                    "For more info: http://find-sec-bugs.github.io/bugs.htm#CUSTOM_INJECTION");
         }
         return loadProperties(urls.toArray(new URL[urls.size()]), loadProperties(url, null));
     }


### PR DESCRIPTION
http://h3xstream.github.io/find-sec-bugs/bugs.htm#CUSTOM_INJECTION redirects to http://find-sec-bugs.github.io/bugs.htm and not to http://find-sec-bugs.github.io/bugs.htm#CUSTOM_INJECTION.   Since this is part of the find-sec-bugs site now, it makes more sense to directly use the find-sec-bugs.github.io URL.