### PR TITLE
Potential fix for issue #182 (INSECURE_COOKIE detector can be fooled by creating two or more cookies)

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetector.java
@@ -81,37 +81,58 @@ public class CookieFlagsDetector implements Detector {
                 if ("javax.servlet.http.Cookie".equals(invoke.getClassName(cpg)) &&
                         "<init>".equals(invoke.getMethodName(cpg))) {
 
+                    // The following call should push the cookie onto the stack
+                    Instruction cookieStoreInstruction = loc.getHandle().getNext().getInstruction();
+                    if (cookieStoreInstruction instanceof ASTORE) {
 
-                    Instruction stackPushInstruction = loc.getHandle().getNext().getInstruction();
-                    ASTORE storeInstruction = (ASTORE)stackPushInstruction;
+                        // We will use the position of the object on the stack to track the cookie
+                        ASTORE storeInstruction = (ASTORE)cookieStoreInstruction;
 
-                    Location setSecureLocation = getSetSecureLocation(cpg, loc, storeInstruction.getIndex());
-                    if (setSecureLocation == null) {
+                        Location setSecureLocation = getSetSecureLocation(cpg, loc, storeInstruction.getIndex());
+                        if (setSecureLocation == null) {
 
-                        JavaClass javaClass = classContext.getJavaClass();
+                            JavaClass javaClass = classContext.getJavaClass();
 
-                        bugReporter.reportBug(new BugInstance(this, INSECURE_COOKIE_TYPE, Priorities.NORMAL_PRIORITY) //
-                                .addClass(javaClass)
-                                .addMethod(javaClass, m)
-                                .addSourceLine(classContext, m, loc));
-                    }
+                            bugReporter.reportBug(new BugInstance(this, INSECURE_COOKIE_TYPE, Priorities.NORMAL_PRIORITY) //
+                                    .addClass(javaClass)
+                                    .addMethod(javaClass, m)
+                                    .addSourceLine(classContext, m, loc));
+                        }
 
-                    Location setHttpOnlyLocation = getSetHttpOnlyLocation(cpg, loc, storeInstruction.getIndex());
-                    if (setHttpOnlyLocation == null) {
+                        Location setHttpOnlyLocation = getSetHttpOnlyLocation(cpg, loc, storeInstruction.getIndex());
+                        if (setHttpOnlyLocation == null) {
 
-                        JavaClass javaClass = classContext.getJavaClass();
+                            JavaClass javaClass = classContext.getJavaClass();
 
-                        bugReporter.reportBug(new BugInstance(this, HTTPONLY_COOKIE_TYPE, Priorities.NORMAL_PRIORITY) //
-                                .addClass(javaClass)
-                                .addMethod(javaClass, m)
-                                .addSourceLine(classContext, m, loc));
+                            bugReporter.reportBug(new BugInstance(this, HTTPONLY_COOKIE_TYPE, Priorities.NORMAL_PRIORITY) //
+                                    .addClass(javaClass)
+                                    .addMethod(javaClass, m)
+                                    .addSourceLine(classContext, m, loc));
+                        }
                     }
                 }
             }
         }
     }
 
-    private Location getSetSecureLocation(ConstantPoolGen cpg, Location startLocation, int stackLocation) {
+    /**
+     * This method is used to track calls made on a specific object. For instance, this could be used to track if "setHttpOnly(true)"
+     * was executed on a specific cookie object.
+     *
+     * This allows the detector to find interchanged calls like this
+     *
+     * Cookie cookie1 = new Cookie("f", "foo");     <- This cookie is unsafe
+     * Cookie cookie2 = new Cookie("b", "bar");     <- This cookie is safe
+     * cookie1.setHttpOnly(false);
+     * cookie2.setHttpOnly(true);
+     *
+     * @param cpg ConstantPoolGen
+     * @param startLocation The Location of the cookie initialization call.
+     * @param objectStackLocation The index of the cookie on the stack.
+     * @param invokeInstruction The instruction we want to detect.s
+     * @return The location of the invoke instruction provided for the cookie at a specific index on the stack.
+     */
+    private Location getCookieInstructionLocation(ConstantPoolGen cpg, Location startLocation, int objectStackLocation, String invokeInstruction) {
         Location location = startLocation;
         InstructionHandle handle = location.getHandle();
 
@@ -122,18 +143,22 @@ public class CookieFlagsDetector implements Detector {
             handle = handle.getNext();
             Instruction nextInst = handle.getInstruction();
 
+            // We check if the index of the cookie used for this invoke is the same as the one provided
             if (nextInst instanceof ALOAD) {
                 ALOAD loadInst = (ALOAD)nextInst;
                 loadedStackValue = loadInst.getIndex();
             }
 
             if (nextInst instanceof INVOKEVIRTUAL
-                    && loadedStackValue == stackLocation) {
+                    && loadedStackValue == objectStackLocation) {
                 INVOKEVIRTUAL invoke = (INVOKEVIRTUAL) nextInst;
-                if ("javax.servlet.http.Cookie".equals(invoke.getClassName(cpg)) &&
-                        "setSecure".equals(invoke.getMethodName(cpg))) {
+
+                String methodNameWithSignature = invoke.getClassName(cpg) + "." + invoke.getMethodName(cpg);
+
+                if (methodNameWithSignature.equals(invokeInstruction)) {
+
                     Integer val = ByteCode.getConstantInt(handle.getPrev());
-                    //if(val != null) System.out.println("setSecure -> "+val.intValue());
+
                     if (val != null && val == TRUE_INT_VALUE) {
                         return new Location(handle, location.getBasicBlock());
                     }
@@ -144,37 +169,12 @@ public class CookieFlagsDetector implements Detector {
         return null;
     }
 
+    private Location getSetSecureLocation(ConstantPoolGen cpg, Location startLocation, int stackLocation) {
+        return getCookieInstructionLocation(cpg, startLocation, stackLocation, "javax.servlet.http.Cookie.setSecure");
+    }
+
     private Location getSetHttpOnlyLocation(ConstantPoolGen cpg, Location startLocation, int stackLocation) {
-        Location location = startLocation;
-        InstructionHandle handle = location.getHandle();
-
-        int loadedStackValue = 0;
-
-        // Loop until we find the setHttpOnly call for this cookie
-        while (handle.getNext() != null) {
-            handle = handle.getNext();
-            Instruction nextInst = handle.getInstruction();
-
-            if (nextInst instanceof ALOAD) {
-                ALOAD loadInst = (ALOAD)nextInst;
-                loadedStackValue = loadInst.getIndex();
-            }
-
-            if (nextInst instanceof INVOKEVIRTUAL
-                && loadedStackValue == stackLocation) {
-                INVOKEVIRTUAL invoke = (INVOKEVIRTUAL) nextInst;
-                if ("javax.servlet.http.Cookie".equals(invoke.getClassName(cpg)) &&
-                        "setHttpOnly".equals(invoke.getMethodName(cpg))) {
-                    Integer val = ByteCode.getConstantInt(handle.getPrev());
-                    //if(val != null) System.out.println("setSecure -> "+val.intValue());
-                    if (val != null && val == TRUE_INT_VALUE) {
-                        return new Location(handle, location.getBasicBlock());
-                    }
-                }
-            }
-        }
-
-        return null;
+        return getCookieInstructionLocation(cpg, startLocation, stackLocation, "javax.servlet.http.Cookie.setHttpOnly");
     }
 
     @Override

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
@@ -52,7 +52,7 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        List<Integer> lines = Arrays.asList(new Integer[] { 72, 76, 80 });
+        List<Integer> lines = Arrays.asList(new Integer[] { 72, 76, 80, 84 });
         for (int line : lines) {
             verify(reporter).doReportBug(
                     bugDefinition()
@@ -84,18 +84,15 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        verify(reporter,never()).doReportBug(
-                bugDefinition()
-                        .bugType("INSECURE_COOKIE")
-                        .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(68)
-                        .build()
-        );
-        verify(reporter,never()).doReportBug(
-                bugDefinition()
-                        .bugType("HTTPONLY_COOKIE")
-                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(79)
-                        .build()
-        );
+        List<Integer> lines = Arrays.asList(new Integer[] { 68, 79, 88 });
+        for (int line : lines) {
+            verify(reporter, never()).doReportBug(
+                    bugDefinition()
+                            .bugType("INSECURE_COOKIE")
+                            .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(line)
+                            .build()
+            );
+        }
     }
 
     @Test
@@ -119,7 +116,7 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        List<Integer> lines = Arrays.asList(new Integer[] { 75, 79, 83 });
+        List<Integer> lines = Arrays.asList(new Integer[] { 75, 79, 83, 87 });
         for (int line : lines) {
             verify(reporter).doReportBug(
                     bugDefinition()
@@ -151,17 +148,14 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        verify(reporter,never()).doReportBug(
-                bugDefinition()
-                        .bugType("HTTPONLY_COOKIE")
-                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(71)
-                        .build()
-        );
-        verify(reporter,never()).doReportBug(
-                bugDefinition()
-                        .bugType("HTTPONLY_COOKIE")
-                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(82)
-                        .build()
-        );
+        List<Integer> lines = Arrays.asList(new Integer[] { 71, 82, 91 });
+        for (int line : lines) {
+            verify(reporter, never()).doReportBug(
+                    bugDefinition()
+                            .bugType("HTTPONLY_COOKIE")
+                            .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(line)
+                            .build()
+            );
+        }
     }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
@@ -48,6 +48,21 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+
+        // Advanced checks when multiple cookies are set
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(72)
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(76)
+                        .build()
+        );
     }
 
     @Test
@@ -69,6 +84,14 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+
+        // Advanced checks when multiple cookies are set
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(68)
+                        .build()
+        );
     }
 
     @Test
@@ -90,6 +113,21 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+
+        // Advanced checks when multiple cookies are set
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(75)
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(79)
+                        .build()
+        );
     }
 
     @Test
@@ -111,5 +149,13 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+
+        // Advanced checks when multiple cookies are set
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(71)
+                        .build()
+        );
     }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class CookieFlagsDetectorTest extends BaseDetectorTest {
 
@@ -52,7 +53,7 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        List<Integer> lines = Arrays.asList(new Integer[] { 72, 76, 80, 84 });
+        List<Integer> lines = Arrays.asList(new Integer[] { 73, 77, 81, 85 });
         for (int line : lines) {
             verify(reporter).doReportBug(
                     bugDefinition()
@@ -84,15 +85,12 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        List<Integer> lines = Arrays.asList(new Integer[] { 68, 79, 88 });
-        for (int line : lines) {
-            verify(reporter, never()).doReportBug(
-                    bugDefinition()
-                            .bugType("INSECURE_COOKIE")
-                            .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(line)
-                            .build()
-            );
-        }
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("InsecureCookieSamples").inMethod("multipleCookies")
+                        .build()
+        );
     }
 
     @Test
@@ -116,7 +114,7 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        List<Integer> lines = Arrays.asList(new Integer[] { 75, 79, 83, 87 });
+        List<Integer> lines = Arrays.asList(new Integer[] { 76, 80, 84, 88 });
         for (int line : lines) {
             verify(reporter).doReportBug(
                     bugDefinition()
@@ -148,14 +146,12 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        List<Integer> lines = Arrays.asList(new Integer[] { 71, 82, 91 });
-        for (int line : lines) {
-            verify(reporter, never()).doReportBug(
-                    bugDefinition()
-                            .bugType("HTTPONLY_COOKIE")
-                            .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(line)
-                            .build()
-            );
-        }
+        // This method should not contain more than unsafe calls
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies")
+                        .build()
+        );
     }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
@@ -19,6 +19,8 @@ package com.h3xstream.findsecbugs.cookie;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import java.util.List;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -50,19 +52,15 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        verify(reporter).doReportBug(
-                bugDefinition()
-                        .bugType("INSECURE_COOKIE")
-                        .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(72)
-                        .build()
-        );
-
-        verify(reporter).doReportBug(
-                bugDefinition()
-                        .bugType("INSECURE_COOKIE")
-                        .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(76)
-                        .build()
-        );
+        List<Integer> lines = Arrays.asList(new Integer[] { 72, 76, 80 });
+        for (int line : lines) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("INSECURE_COOKIE")
+                            .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(line)
+                            .build()
+            );
+        }
     }
 
     @Test
@@ -92,6 +90,12 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                         .inClass("InsecureCookieSamples").inMethod("multipleCookies").atLine(68)
                         .build()
         );
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(79)
+                        .build()
+        );
     }
 
     @Test
@@ -115,19 +119,15 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
         }
 
         // Advanced checks when multiple cookies are set
-        verify(reporter).doReportBug(
-                bugDefinition()
-                        .bugType("HTTPONLY_COOKIE")
-                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(75)
-                        .build()
-        );
-
-        verify(reporter).doReportBug(
-                bugDefinition()
-                        .bugType("HTTPONLY_COOKIE")
-                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(79)
-                        .build()
-        );
+        List<Integer> lines = Arrays.asList(new Integer[] { 75, 79, 83 });
+        for (int line : lines) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("HTTPONLY_COOKIE")
+                            .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(line)
+                            .build()
+            );
+        }
     }
 
     @Test
@@ -155,6 +155,12 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                 bugDefinition()
                         .bugType("HTTPONLY_COOKIE")
                         .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(71)
+                        .build()
+        );
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("HttpOnlyCookieSamples").inMethod("multipleCookies").atLine(82)
                         .build()
         );
     }

--- a/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
@@ -77,5 +77,10 @@ public class HttpOnlyCookieSamples {
 
         // The line bellow should stay line 79 - It is used with the .atLine() annotation in the test
         Cookie unsafeCookie = new Cookie("cookie 3", "foo");
+
+        // The lines bellow should stay lines 82 and 83 - It is used with the .atLine() annotation in the test
+        Cookie mixedCookiesSafe = new Cookie("cookie 4", "bar");
+        Cookie mixedCookies = new Cookie("cookie 5", "bar");
+        mixedCookiesSafe.setHttpOnly(true);
     }
 }

--- a/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
@@ -82,5 +82,13 @@ public class HttpOnlyCookieSamples {
         Cookie mixedCookiesSafe = new Cookie("cookie 4", "bar");
         Cookie mixedCookies = new Cookie("cookie 5", "bar");
         mixedCookiesSafe.setHttpOnly(true);
+
+        // The line bellow should stay line 87 - It is used with the .atLine() annotation in the test
+        Cookie unsafeHttpOnlyCookie2 = new Cookie("c1", "foo");
+        unsafeHttpOnlyCookie2.setHttpOnly(false);
+
+        // The line bellow should stay line 91 - It is used with the .atLine() annotation in the test
+        Cookie safeHttpOnlyCookie2 = new Cookie("c2", "bar");
+        safeHttpOnlyCookie2.setHttpOnly(true);
     }
 }

--- a/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
@@ -66,28 +66,28 @@ public class HttpOnlyCookieSamples {
         cookieOther.setHttpOnly(false); //Unrelated
     }
 
+    // If you add unsafe calls in this method, you must change the CookieFlagsDetectorTest - It is validated with the
+    // times(X) annotation
     void multipleCookies() {
-        // The line bellow should stay line 71 - It is used with the .atLine() annotation in the test
         Cookie safeHttpOnlyCookie = new Cookie("cookie 1", "foo");
         safeHttpOnlyCookie.setHttpOnly(true);
 
-        // The line bellow should stay line 75 - It is used with the .atLine() annotation in the test
+        // The line bellow should stay line 74 - It is used with the .atLine() annotation in the test
         Cookie unsafeHttpOnlyCookie = new Cookie("cookie 2", "bar");
         unsafeHttpOnlyCookie.setHttpOnly(false);
 
-        // The line bellow should stay line 79 - It is used with the .atLine() annotation in the test
+        // The line bellow should stay line 78 - It is used with the .atLine() annotation in the test
         Cookie unsafeCookie = new Cookie("cookie 3", "foo");
 
-        // The lines bellow should stay lines 82 and 83 - It is used with the .atLine() annotation in the test
         Cookie mixedCookiesSafe = new Cookie("cookie 4", "bar");
+        // The line bellow should stay line 82 - It is used with the .atLine() annotation in the test
         Cookie mixedCookies = new Cookie("cookie 5", "bar");
         mixedCookiesSafe.setHttpOnly(true);
 
-        // The line bellow should stay line 87 - It is used with the .atLine() annotation in the test
+        // The line bellow should stay line 86 - It is used with the .atLine() annotation in the test
         Cookie unsafeHttpOnlyCookie2 = new Cookie("c1", "foo");
         unsafeHttpOnlyCookie2.setHttpOnly(false);
 
-        // The line bellow should stay line 91 - It is used with the .atLine() annotation in the test
         Cookie safeHttpOnlyCookie2 = new Cookie("c2", "bar");
         safeHttpOnlyCookie2.setHttpOnly(true);
     }

--- a/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/HttpOnlyCookieSamples.java
@@ -65,4 +65,17 @@ public class HttpOnlyCookieSamples {
         Cookie newCookie = new Cookie("test1","1234");
         cookieOther.setHttpOnly(false); //Unrelated
     }
+
+    void multipleCookies() {
+        // The line bellow should stay line 71 - It is used with the .atLine() annotation in the test
+        Cookie safeHttpOnlyCookie = new Cookie("cookie 1", "foo");
+        safeHttpOnlyCookie.setHttpOnly(true);
+
+        // The line bellow should stay line 75 - It is used with the .atLine() annotation in the test
+        Cookie unsafeHttpOnlyCookie = new Cookie("cookie 2", "bar");
+        unsafeHttpOnlyCookie.setHttpOnly(false);
+
+        // The line bellow should stay line 79 - It is used with the .atLine() annotation in the test
+        Cookie unsafeCookie = new Cookie("cookie 3", "foo");
+    }
 }

--- a/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
@@ -79,5 +79,13 @@ public class InsecureCookieSamples {
         Cookie mixedCookiesSafe = new Cookie("cookie 4", "bar");
         Cookie mixedCookies = new Cookie("cookie 5", "bar");
         mixedCookiesSafe.setSecure(true);
+
+        // The line bellow should stay line 84 - It is used with the .atLine() annotation in the test
+        Cookie unsafeCookie2 = new Cookie("c1", "foo");
+        unsafeCookie2.setSecure(false);
+
+        // The line bellow should stay line 88 - It is used with the .atLine() annotation in the test
+        Cookie safeCookie2 = new Cookie("c2", "bar");
+        safeCookie2.setSecure(true);
     }
 }

--- a/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
@@ -63,8 +63,9 @@ public class InsecureCookieSamples {
         cookieOther.setSecure(false); //Unrelated
     }
 
+    // If you add unsafe calls in this method, you must change the CookieFlagsDetectorTest - It is validated with the
+    // times(X) annotation
     void multipleCookies() {
-        // The line bellow should stay line 68 - It is used with the .atLine() annotation in the test
         Cookie safeSecureCookie = new Cookie("cookie 3", "foo");
         safeSecureCookie.setSecure(true);
 
@@ -75,8 +76,8 @@ public class InsecureCookieSamples {
         // The line bellow should stay line 76 - It is used with the .atLine() annotation in the test
         Cookie unsafeCookie = new Cookie("cookie 3", "foo");
 
-        // The lines bellow should stay lines 79 and 80 - It is used with the .atLine() annotation in the test
         Cookie mixedCookiesSafe = new Cookie("cookie 4", "bar");
+        // The line bellow should stay line 76 - It is used with the .atLine() annotation in the test
         Cookie mixedCookies = new Cookie("cookie 5", "bar");
         mixedCookiesSafe.setSecure(true);
 
@@ -84,7 +85,6 @@ public class InsecureCookieSamples {
         Cookie unsafeCookie2 = new Cookie("c1", "foo");
         unsafeCookie2.setSecure(false);
 
-        // The line bellow should stay line 88 - It is used with the .atLine() annotation in the test
         Cookie safeCookie2 = new Cookie("c2", "bar");
         safeCookie2.setSecure(true);
     }

--- a/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
@@ -63,4 +63,16 @@ public class InsecureCookieSamples {
         cookieOther.setSecure(false); //Unrelated
     }
 
+    void multipleCookies() {
+        // The line bellow should stay line 68 - It is used with the .atLine() annotation in the test
+        Cookie safeSecureCookie = new Cookie("cookie 3", "foo");
+        safeSecureCookie.setSecure(true);
+
+        // The line bellow should stay line 72 - It is used with the .atLine() annotation in the test
+        Cookie unsafeSecureCookie = new Cookie("cookie 4", "bar");
+        unsafeSecureCookie.setSecure(false);
+
+        // The line bellow should stay line 76 - It is used with the .atLine() annotation in the test
+        Cookie unsafeCookie = new Cookie("cookie 3", "foo");
+    }
 }

--- a/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
+++ b/plugin/src/test/java/testcode/cookie/InsecureCookieSamples.java
@@ -74,5 +74,10 @@ public class InsecureCookieSamples {
 
         // The line bellow should stay line 76 - It is used with the .atLine() annotation in the test
         Cookie unsafeCookie = new Cookie("cookie 3", "foo");
+
+        // The lines bellow should stay lines 79 and 80 - It is used with the .atLine() annotation in the test
+        Cookie mixedCookiesSafe = new Cookie("cookie 4", "bar");
+        Cookie mixedCookies = new Cookie("cookie 5", "bar");
+        mixedCookiesSafe.setSecure(true);
     }
 }


### PR DESCRIPTION
I changed the behavior of the CookieFlagsDetector and it now covers the example found in bug #182 .

It now behaves as a "mini taint detector", some of the default Find-Bugs checks are working like this (like the SqlInjection one) and they seem to work fine.

It first finds the cookie creation call, saves the position of the cookie on the stack and checks if it can find the .setHttpOnly or setSecure method for this object on the stack.