### PR TITLE
Accept environment variables spelled with underscores

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
@@ -50,6 +50,11 @@ public class FindSecBugsGlobalConfig {
 
     public static String loadFromSystem(String key, String defaultValue) {
         String value = System.getenv(key);
+        if (value == null) {
+            // Environment variables containing dots are difficult to setup in
+            // bash. Thus also accept underscores instead of dots.
+            value = System.getenv(key.replace('.', '_'));
+        }
         value = SystemProperties.getProperty(key, value);
 
         if (value == null) {

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -18,6 +18,7 @@
 package com.h3xstream.findsecbugs.taintanalysis;
 
 import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.ba.CFG;
 import edu.umd.cs.findbugs.ba.DepthFirstSearch;
@@ -26,6 +27,7 @@ import edu.umd.cs.findbugs.classfile.IAnalysisCache;
 import edu.umd.cs.findbugs.classfile.IMethodAnalysisEngine;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.io.IO;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,6 +40,7 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.apache.bcel.generic.MethodGen;
 
 /**
@@ -136,6 +139,12 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
                 stream = new FileInputStream(file);
             } else {
                 stream = getClass().getClassLoader().getResourceAsStream(path);
+            }
+            if (stream == null) {
+                String message = String.format("Could not add custom config. "
+                        + "Neither file %s nor resource matching %s found.",
+                        file.getAbsolutePath(), path);
+                throw new IllegalArgumentException(message);
             }
             taintConfig.load(stream, false);
             LOGGER.log(Level.INFO, "Custom taint config loaded from {0}", path);


### PR DESCRIPTION
Environment variables with dots are hard to handle in unix shells (e.g. bash). A quick google search for 'environment variables dots' shows that many people struggle with such variables, e.g.:

http://unix.stackexchange.com/questions/93532/exporting-a-variable-with-dot-in-it
http://askubuntu.com/questions/65638/how-to-set-env-with-a-dot
http://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names

To make custom configurations easier on unix systems, this PR makes find-sec-bugs also accept environment variables spelled with underscores (`_`) instead of dots (`.`). E.g. `findsecbugs_taint_customconfigfile` instead of `findsecbugs.taint.customconfigfile`. Using environment variables (rather than system properties) for configuration is e.g. helpful when using find-sec-bugs with gradle.

Additionally, I've added a small change that fails early if some custom file/resource cannot be found. Otherwise it would just fail a bit later with an NPE not telling which file/resource could not be found.