### PR TITLE
UNENCRYPTED_SERVER_SOCKET: use of java.net.ServerSocket

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/UnencryptedServerSocketDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/UnencryptedServerSocketDetector.java
@@ -1,0 +1,47 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.crypto;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Constants;
+
+public class UnencryptedServerSocketDetector extends OpcodeStackDetector {
+
+    private static final boolean DEBUG = false;
+    private static final String UNENCRYPTED_SERVER_SOCKET_TYPE = "UNENCRYPTED_SERVER_SOCKET";
+    private BugReporter bugReporter;
+
+    public UnencryptedServerSocketDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        //printOpCode(seen);
+
+        if (seen == Constants.INVOKESPECIAL && getClassConstantOperand().equals("java/net/ServerSocket") &&
+                getNameConstantOperand().equals("<init>")) {
+            bugReporter.reportBug(new BugInstance(this, UNENCRYPTED_SERVER_SOCKET_TYPE, Priorities.NORMAL_PRIORITY) //
+                    .addClass(this).addMethod(this).addSourceLine(this));
+        }
+    }
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -141,6 +141,7 @@
     <BugPattern type="HAZELCAST_SYMMETRIC_ENCRYPTION" abbrev="SECHAZ" category="SECURITY" cweid="327"/>
     <BugPattern type="NULL_CIPHER" abbrev="SECNC" category="SECURITY" cweid="327"/>
     <BugPattern type="UNENCRYPTED_SOCKET" abbrev="SECUS" category="SECURITY" cweid="319"/>
+    <BugPattern type="UNENCRYPTED_SERVER_SOCKET" abbrev="SECUSS" category="SECURITY" cweid="319"/>
     <BugPattern type="DES_USAGE" abbrev="SECDU" category="SECURITY" cweid="326"/>
     <BugPattern type="RSA_NO_PADDING" abbrev="SECRNP" category="SECURITY" cweid="780"/>
     <BugPattern type="HARD_CODE_PASSWORD" abbrev="SECHCP" category="SECURITY" cweid="259"/>

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -46,7 +46,7 @@
               reports="HAZELCAST_SYMMETRIC_ENCRYPTION"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.NullCipherDetector" reports="NULL_CIPHER"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedSocketDetector" reports="UNENCRYPTED_SOCKET"/>
-    <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedServerSocketDetector" reports="UNENCRYPTED_SOCKET"/>
+    <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedServerSocketDetector" reports="UNENCRYPTED_SERVER_SOCKET"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.DesUsageDetector" reports="DES_USAGE"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector" reports="RSA_NO_PADDING"/>
     <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector" reports="HARD_CODE_PASSWORD,HARD_CODE_KEY"/>

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -46,6 +46,7 @@
               reports="HAZELCAST_SYMMETRIC_ENCRYPTION"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.NullCipherDetector" reports="NULL_CIPHER"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedSocketDetector" reports="UNENCRYPTED_SOCKET"/>
+    <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedServerSocketDetector" reports="UNENCRYPTED_SOCKET"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.DesUsageDetector" reports="DES_USAGE"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector" reports="RSA_NO_PADDING"/>
     <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector" reports="HARD_CODE_PASSWORD,HARD_CODE_KEY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -2307,6 +2307,10 @@ to do this correctly.
         </Details>
     </BugPattern>
     <BugCode abbrev="SECUS">Unencrypted Socket</BugCode>
+    <!-- Unencrypted Server Socket encryption -->
+    <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedServerSocketDetector">
+        <Details>Unencrypted Server Socket</Details>
+    </Detector>
     <BugPattern type="UNENCRYPTED_SERVER_SOCKET">
         <ShortDescription>Unencrypted Server Socket</ShortDescription>
         <LongDescription>Unencrypted server socket (instead of SSLServerSocket)</LongDescription>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -2307,7 +2307,41 @@ to do this correctly.
         </Details>
     </BugPattern>
     <BugCode abbrev="SECUS">Unencrypted Socket</BugCode>
-
+    <BugPattern type="UNENCRYPTED_SERVER_SOCKET">
+        <ShortDescription>Unencrypted Server Socket</ShortDescription>
+        <LongDescription>Unencrypted server socket (instead of SSLServerSocket)</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+The communication channel used is not encrypted. The traffic could be read by an attacker intercepting the network traffic.
+</p>
+<p>
+<b>Vulnerable Code:</b><br/>
+Plain server socket (Cleartext communication):
+<pre>ServerSocket soc = new ServerSocket(1234);</pre>
+</p>
+<p>
+<b>Solution:</b><br/>
+SSL Server Socket (Secure communication):
+<pre>ServerSocket soc = SSLServerSocketFactory.getDefault().createServerSocket(1234);</pre>
+</p>
+<p>Beyond using an SSL server socket, you need to make sure your use of SSLServerSocketFactory does all the appropriate certificate validation checks to
+make sure you are not subject to man-in-the-middle attacks. Please read the OWASP Transport Layer Protection Cheat Sheet for details on how
+to do this correctly.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2010-A9">OWASP: Top 10 2010-A9-Insufficient Transport Layer Protection</a><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure">OWASP: Top 10 2013-A6-Sensitive Data Exposure</a><br/>
+<a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">OWASP: Transport Layer Protection Cheat Sheet</a><br/>
+<a href="http://projects.webappsec.org/w/page/13246945/Insufficient%20Transport%20Layer%20Protection">WASC-04: Insufficient Transport Layer Protection</a><br/>
+<a href="http://cwe.mitre.org/data/definitions/319.html">CWE-319: Cleartext Transmission of Sensitive Information</a>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECUSS">Unencrypted Server Socket</BugCode>
 
     <!-- DES usage -->
     <Detector class="com.h3xstream.findsecbugs.crypto.DesUsageDetector">

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/UnencryptedServerSocketDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/UnencryptedServerSocketDetectorTest.java
@@ -33,7 +33,7 @@ public class UnencryptedServerSocketDetectorTest extends BaseDetectorTest {
     public void detectUnencryptedSocket() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/crypto/UnencryptedSocket")
+                getClassFilePath("testcode/crypto/UnencryptedServerSocket")
         };
 
         //Run the analysis

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/UnencryptedServerSocketDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/UnencryptedServerSocketDetectorTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class UnencryptedSocketDetectorTest extends BaseDetectorTest {
+public class UnencryptedServerSocketDetectorTest extends BaseDetectorTest {
 
     @Test
     public void detectUnencryptedSocket() throws Exception {
@@ -42,18 +42,18 @@ public class UnencryptedSocketDetectorTest extends BaseDetectorTest {
 
         verify(reporter).doReportBug(
                 bugDefinition()
-                        .bugType("UNENCRYPTED_SOCKET")
-                        .inClass("UnencryptedSocket")
-                        .inMethod("plainSocket")
-                        .atLine(23)
+                        .bugType("UNENCRYPTED_SERVER_SOCKET")
+                        .inClass("UnencryptedServerSocket")
+                        .inMethod("plainServerSocket")
+                        .atLine(16)
                         .build()
         );
 
-        for (Integer line : Arrays.asList(28, 31, 34)) {
+        for (Integer line : Arrays.asList(21, 23, 26)) {
             verify(reporter).doReportBug(
                     bugDefinition()
-                            .bugType("UNENCRYPTED_SOCKET")
-                            .inClass("UnencryptedSocket")
+                            .bugType("UNENCRYPTED_SERVER_SOCKET")
+                            .inClass("UnencryptedServerSocket")
                             .inMethod("otherConstructors")
                             .atLine(line)
                             .build()

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/UnencryptedSocketDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/UnencryptedSocketDetectorTest.java
@@ -42,18 +42,18 @@ public class UnencryptedSocketDetectorTest extends BaseDetectorTest {
 
         verify(reporter).doReportBug(
                 bugDefinition()
-                        .bugType("UNENCRYPTED_SOCKET")
-                        .inClass("UnencryptedSocket")
-                        .inMethod("plainSocket")
-                        .atLine(23)
+                        .bugType("UNENCRYPTED_SERVER_SOCKET")
+                        .inClass("UnencryptedServerSocket")
+                        .inMethod("plainServerSocket")
+                        .atLine(16)
                         .build()
         );
 
-        for (Integer line : Arrays.asList(28, 31, 34)) {
+        for (Integer line : Arrays.asList(21, 23, 26)) {
             verify(reporter).doReportBug(
                     bugDefinition()
-                            .bugType("UNENCRYPTED_SOCKET")
-                            .inClass("UnencryptedSocket")
+                            .bugType("UNENCRYPTED_SERVER_SOCKET")
+                            .inClass("UnencryptedServerSocket")
                             .inMethod("otherConstructors")
                             .atLine(line)
                             .build()

--- a/plugin/src/test/java/testcode/crypto/UnencryptedServerSocket.java
+++ b/plugin/src/test/java/testcode/crypto/UnencryptedServerSocket.java
@@ -1,0 +1,30 @@
+package testcode.crypto;
+
+import javax.net.ssl.SSLServerSocketFactory;
+import java.io.*;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+public class UnencryptedServerSocket {
+
+    static void sslServerSocket() throws IOException {
+        ServerSocket ssoc = SSLServerSocketFactory.getDefault().createServerSocket(1234);
+        ssoc.close();
+    }
+
+    static void plainServerSocket() throws IOException {
+        ServerSocket ssoc = new ServerSocket(1234);
+        ssoc.close();
+    }
+
+    static void otherConstructors() throws IOException {
+        ServerSocket ssoc1 = new ServerSocket();
+        ssoc1.close();
+        ServerSocket ssoc2 = new ServerSocket(1234, 10);
+        ssoc2.close();
+        byte[] address = {127, 0, 0, 1};
+        ServerSocket ssoc3 = new ServerSocket(1234, 10, InetAddress.getByAddress(address));
+        ssoc3.close();
+    }
+
+}


### PR DESCRIPTION
I added support for detecting the use of plain java.net.ServerSocket instances, similar to the one already in place for java.net.Socket, and suggesting the use of SSL server sockets (through SSLServerSocketFactory). 

The new UNENCRYPTED_SERVER_SOCKET vulnerability was relatively straightforward to integrate, it is similar to the one for UNENCRYPTED_SOCKET.
 
Please check if this is correct and can be integrated. The tests are passing, including the new one for UNENCRYPTED_SERVER_SOCKET.  (I just did not update the Japanese translation metadata). 

Best,
Eduardo Marques



