### PR TITLE
Add Codacy screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Website : http://find-sec-bugs.github.io/
 
 ![SonarQube](http://find-sec-bugs.github.io/images/screens/sonar.png)
 
+### Codacy
+
+![Codacy](http://find-sec-bugs.github.io/images/screens/codacy.png)
+
 ## License
 
 This software is release under [LGPL](http://www.gnu.org/licenses/lgpl.html).


### PR DESCRIPTION
Codacy Enterprise offers an out-of-the-box solution for running find-sec-bugs.

Depends on https://github.com/find-sec-bugs/find-sec-bugs.github.io/pull/1