### PR TITLE
Improve SpringMvcEndpointDetector by detecting new RequestMapping annotation shortcuts

### DIFF
--- a/plugin-deps/src/main/java/org/springframework/web/bind/annotation/DeleteMapping.java
+++ b/plugin-deps/src/main/java/org/springframework/web/bind/annotation/DeleteMapping.java
@@ -1,0 +1,5 @@
+package org.springframework.web.bind.annotation;
+
+public @interface DeleteMapping {
+    String value();
+}

--- a/plugin-deps/src/main/java/org/springframework/web/bind/annotation/GetMapping.java
+++ b/plugin-deps/src/main/java/org/springframework/web/bind/annotation/GetMapping.java
@@ -1,0 +1,5 @@
+package org.springframework.web.bind.annotation;
+
+public @interface GetMapping {
+    String value();
+}

--- a/plugin-deps/src/main/java/org/springframework/web/bind/annotation/PatchMapping.java
+++ b/plugin-deps/src/main/java/org/springframework/web/bind/annotation/PatchMapping.java
@@ -1,0 +1,5 @@
+package org.springframework.web.bind.annotation;
+
+public @interface PatchMapping {
+    String value();
+}

--- a/plugin-deps/src/main/java/org/springframework/web/bind/annotation/PostMapping.java
+++ b/plugin-deps/src/main/java/org/springframework/web/bind/annotation/PostMapping.java
@@ -1,0 +1,5 @@
+package org.springframework.web.bind.annotation;
+
+public @interface PostMapping {
+    String value();
+}

--- a/plugin-deps/src/main/java/org/springframework/web/bind/annotation/PutMapping.java
+++ b/plugin-deps/src/main/java/org/springframework/web/bind/annotation/PutMapping.java
@@ -1,0 +1,5 @@
+package org.springframework.web.bind.annotation;
+
+public @interface PutMapping {
+    String value();
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/SpringMvcEndpointDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/SpringMvcEndpointDetector.java
@@ -26,12 +26,24 @@ import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  *
  */
 public class SpringMvcEndpointDetector implements Detector {
 
     private static final String SPRING_ENDPOINT_TYPE = "SPRING_ENDPOINT";
+
+    private static final List<String> REQUEST_MAPPING_ANNOTATION_TYPES = Arrays.asList(
+            "Lorg/springframework/web/bind/annotation/RequestMapping;", //
+            "Lorg/springframework/web/bind/annotation/GetMapping;", //
+            "Lorg/springframework/web/bind/annotation/PostMapping;", //
+            "Lorg/springframework/web/bind/annotation/PutMapping;", //
+            "Lorg/springframework/web/bind/annotation/DeleteMapping;", //
+            "Lorg/springframework/web/bind/annotation/PatchMapping;");
+
     private BugReporter bugReporter;
 
     public SpringMvcEndpointDetector(BugReporter bugReporter) {
@@ -45,7 +57,7 @@ public class SpringMvcEndpointDetector implements Detector {
 
             for (AnnotationEntry ae : m.getAnnotationEntries()) {
 
-                if (ae.getAnnotationType().equals("Lorg/springframework/web/bind/annotation/RequestMapping;")) {
+                if (REQUEST_MAPPING_ANNOTATION_TYPES.contains(ae.getAnnotationType())) {
                     bugReporter.reportBug(new BugInstance(this, SPRING_ENDPOINT_TYPE, Priorities.LOW_PRIORITY) //
                             .addClassAndMethod(javaClass, m));
                     continue method;

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1558,7 +1558,7 @@ such a setter. The use of these parameters should be reviewed to make sure they 
         <LongDescription>{0} is a Spring endpoint (Controller)</LongDescription>
         <Details>
             <![CDATA[
-<p>This class is a Spring Controller. All methods annotated with <code>RequestMapping</code> are reachable remotely.
+<p>This class is a Spring Controller. All methods annotated with <code>RequestMapping</code> (as well as its shortcut annotations <code>GetMapping</code>, <code>PostMapping</code>, <code>PutMapping</code>, <code>DeleteMapping</code>, and <code>PatchMapping</code>) are reachable remotely.
 This class should be analyzed to make sure that remotely exposed methods are safe to expose to potential attackers.</p>
 ]]>
         </Details>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/SpringMvcEndpointDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/SpringMvcEndpointDetectorTest.java
@@ -58,8 +58,23 @@ public class SpringMvcEndpointDetectorTest extends BaseDetectorTest {
         verify(reporter).doReportBug(
                 bugDefinition().bugType("SPRING_ENDPOINT").inMethod("hello6").build()
         );
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_ENDPOINT").inMethod("helloGet").build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_ENDPOINT").inMethod("helloPost").build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_ENDPOINT").inMethod("helloPut").build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_ENDPOINT").inMethod("helloDelete").build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_ENDPOINT").inMethod("helloPatch").build()
+        );
 
-        verify(reporter, times(6)).doReportBug(
+        verify(reporter, times(11)).doReportBug(
                 bugDefinition().bugType("SPRING_ENDPOINT").build()
         );
     }

--- a/plugin/src/test/java/testcode/SpringTestController.java
+++ b/plugin/src/test/java/testcode/SpringTestController.java
@@ -1,7 +1,12 @@
 package testcode;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,5 +51,30 @@ public class SpringTestController {
     @RequestMapping(value = "/hello6", method = RequestMethod.GET)
     public void hello6(@RequestParam("description") String description, @RequestPart("file") MultipartFile file) {
         logger.fine("hello #6");
+    }
+
+    @GetMapping(value = "/hello-get")
+    public void helloGet() {
+        logger.fine("hello GET");
+    }
+
+    @PostMapping(value = "/hello-post")
+    public void helloPost() {
+        logger.fine("hello POST");
+    }
+
+    @PutMapping(value = "/hello-put")
+    public void helloPut() {
+        logger.fine("hello PUT");
+    }
+
+    @DeleteMapping(value = "/hello-delete")
+    public void helloDelete() {
+        logger.fine("hello DELETE");
+    }
+
+    @PatchMapping(value = "/hello-patch")
+    public void helloPatch() {
+        logger.fine("hello PATCH");
     }
 }


### PR DESCRIPTION
Spring 4.3 introduced new annotation shortcuts for `@RequestMapping`.
For instance, `@GetMapping` is a composed annotation that acts as a shortcut for `@RequestMapping(method = RequestMethod.GET)`.

The full list of new shortcut annotations is:
* `@GetMapping`
* `@PostMapping`
* `@PutMapping`
* `@DeleteMapping`
* `@PatchMapping`

This pull request improves `SpringMvcEndpointDetector` by detecting these new annotations.

Some remarks regarding this pull request:
* I modified the English message, but I don't have the necessary skills to modify the corresponding Japanese one.
* Instead of having a hardcoded list of annotations, a more future-proof solutions would be to rely on the annotations hierarchy. Indeed, `@GetMapping` is annotated with `@RequestMapping`, `@RequestMapping` is annotated with `@Mapping`, and `@Mapping` is described as a "Meta annotation that indicates a web mapping annotation". However, I didn't find a way of going up one annotation's hierarchy with FindBugs.
