### PR TITLE
Fix Maven warnings (missing plugin version, relocation, proprietary API)

### DIFF
--- a/findbugs-test-util/pom.xml
+++ b/findbugs-test-util/pom.xml
@@ -55,7 +55,7 @@
 
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -162,7 +162,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/scala/SslDisablerDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/scala/SslDisablerDetector.java
@@ -17,15 +17,11 @@
  */
 package com.h3xstream.findsecbugs.scala;
 
-import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.ba.XField;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
-import sun.reflect.FieldInfo;
-
-import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
 
 public class SslDisablerDetector extends OpcodeStackDetector {
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,9 +185,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.commons</groupId>
+                <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>1.3.2</version>
+                <version>2.5</version>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>


### PR DESCRIPTION
Running `mvn compile` shows 3 Maven warnings which can be easily fixed.

---

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.h3xstream.findsecbugs:findsecbugs-root-pom:pom:1.6.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ line 86, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

This warning is about the JavaDoc plugin which doesn't have a version specified.
--> I specified the latest version (2.10.4).

---

```
[WARNING] The artifact org.apache.commons:commons-io:jar:1.3.2 has been relocated to commons-io:commons-io:jar:1.3.2
```

This warning tells us that the real coordinates of this artifact has the groupId `commons-io` and not `org.apache.commons`.
Not sure why, but only version 1.3.2 got published with the modern groupId `org.apache.commons`.
The latest version (2.5) uses the archaic groupId `commons-io`.
See: http://commons.apache.org/proper/commons-io/project-summary.html
--> I changed the groupId and specified the latest version (2.5).

---

```
[WARNING] /path/to/find-sec-bugs/plugin/src/main/java/com/h3xstream/findsecbugs/scala/SslDisablerDetector.java:[25,18] FieldInfo is internal proprietary API and may be removed in a future release
```

FieldInfo is an unused import.
--> I removed the unused imports for this class.