### PR TITLE
Adding overly permissive CORS policy detector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/PermissiveCORSDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/PermissiveCORSDetector.java
@@ -81,8 +81,9 @@ public class PermissiveCORSDetector implements Detector {
 
                     LDC ldc = ByteCode.getPrevInstruction(location.getHandle().getPrev(), LDC.class);
                     if (ldc != null) {
-                        if ("Access-Control-Allow-Origin".equals(ldc.getValue(cpg)) &&
-                            "*".equals(ByteCode.getConstantLDC(location.getHandle().getPrev(), cpg, String.class))) {
+                        String headerValue = ByteCode.getConstantLDC(location.getHandle().getPrev(), cpg, String.class);
+                        if ("Access-Control-Allow-Origin".equalsIgnoreCase((String)ldc.getValue(cpg)) &&
+                            (headerValue.contains("*") || "null".equalsIgnoreCase(headerValue))) {
 
                             JavaClass clz = classContext.getJavaClass();
                             bugReporter.reportBug(new BugInstance(this, PERMISSIVE_CORS, Priorities.HIGH_PRIORITY)

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/PermissiveCORSDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/PermissiveCORSDetector.java
@@ -1,0 +1,103 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.Location;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEINTERFACE;
+import org.apache.bcel.generic.LDC;
+import org.apache.bcel.generic.Instruction;
+import java.util.Iterator;
+
+public class PermissiveCORSDetector implements Detector {
+
+    private static final String PERMISSIVE_CORS = "PERMISSIVE_CORS";
+
+    private BugReporter bugReporter;
+
+    public PermissiveCORSDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+    
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        JavaClass javaClass = classContext.getJavaClass();
+
+        Method[] methodList = javaClass.getMethods();
+
+        for (Method m : methodList) {
+
+            try {
+                analyzeMethod(m, classContext);
+            } catch (CFGBuilderException e) {
+            } catch (DataflowAnalysisException e) {
+            }
+        }
+    }
+
+    private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException, DataflowAnalysisException {
+
+        ConstantPoolGen cpg = classContext.getConstantPoolGen();
+        CFG cfg = classContext.getCFG(m);
+        
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext(); ) {
+            Location location = i.next();
+
+            Instruction inst = location.getHandle().getInstruction();
+
+            if (inst instanceof INVOKEINTERFACE) {
+                INVOKEINTERFACE invoke = (INVOKEINTERFACE) inst;
+                String methodName = invoke.getMethodName(cpg);
+                String className = invoke.getClassName(cpg);
+
+                if (className.equals("javax.servlet.http.HttpServletResponse") &&
+                   (methodName.equals("addHeader") || methodName.equals("setHeader"))) {
+
+                    LDC ldc = ByteCode.getPrevInstruction(location.getHandle().getPrev(), LDC.class);
+                    if (ldc != null) {
+                        if ("Access-Control-Allow-Origin".equals(ldc.getValue(cpg)) &&
+                            "*".equals(ByteCode.getConstantLDC(location.getHandle().getPrev(), cpg, String.class))) {
+
+                            JavaClass clz = classContext.getJavaClass();
+                            bugReporter.reportBug(new BugInstance(this, PERMISSIVE_CORS, Priorities.HIGH_PRIORITY)
+                            .addClass(clz)
+                            .addMethod(clz, m)
+                            .addSourceLine(classContext, m, location));
+                        }
+                    }
+                }
+            }
+        }         
+        
+    }
+
+    @Override
+    public void report() {
+    }
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -91,7 +91,9 @@
     <Detector class="com.h3xstream.findsecbugs.scala.XssTwirlDetector" reports="SCALA_XSS_TWIRL" />
     <Detector class="com.h3xstream.findsecbugs.template.VelocityDetector" reports="TEMPLATE_INJECTION_VELOCITY" />
     <Detector class="com.h3xstream.findsecbugs.template.FreemarkerDetector" reports="TEMPLATE_INJECTION_FREEMARKER" />
+    <Detector class="com.h3xstream.findsecbugs.PermissiveCORSDetector" reports="PERMISSIVE_CORS"/>
 
+    <BugPattern type="PERMISSIVE_CORS" abbrev="SECCORS" category="SECURITY"/>
     <BugPattern type="PREDICTABLE_RANDOM" abbrev="SECPR" category="SECURITY" cweid="330"/>
     <BugPattern type="PREDICTABLE_RANDOM_SCALA" abbrev="SECPRS" category="SECURITY" cweid="330"/>
     <BugPattern type="SERVLET_PARAMETER" abbrev="SECSP" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4236,4 +4236,39 @@ prefer logic-less template engines such as Handlebars or Moustache (See referenc
     </BugPattern>
     <BugCode abbrev="SECFREEM">Potential template injection with Freemarker</BugCode>
 
+
+    <!-- Overly permissive CORS policy -->
+    <Detector class="com.h3xstream.findsecbugs.PermissiveCORSDetector">
+        <Details>Detect overly permissive CORS policy.
+        </Details>
+    </Detector>
+
+    <BugPattern type="PERMISSIVE_CORS">
+        <ShortDescription>Overly permissive CORS policy</ShortDescription>
+        <LongDescription>The program defines an overly permissive Cross-Origin Resource Sharing (CORS) policy</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Prior to HTML5, Web browsers enforced the Same Origin Policy which ensures that in order for JavaScript to access the contents of a Web page, both the JavaScript and the Web page must originate from the same domain. Without the Same Origin Policy, a malicious website could serve up JavaScript that loads sensitive information from other websites using a client's credentials, cull through it, and communicate it back to the attacker. HTML5 makes it possible for JavaScript to access data across domains if a new HTTP header called Access-Control-Allow-Origin is defined. With this header, a Web server defines which other domains are allowed to access its domain using cross-origin requests. However, caution should be taken when defining the header because an overly permissive CORS policy will allow a malicious application to communicate with the victim application in an inappropriate way, leading to spoofing, data theft, relay and other attacks.
+</p>
+<p>
+    <b>Vulnerable Code:</b>
+<pre>response.addHeader("Access-Control-Allow-Origin", "*");</pre>
+</p>
+<p>
+    <b>Solution:</b>
+<br/>
+Avoid using * as the value of the Access-Control-Allow-Origin header, which indicates that the application's data is accessible to JavaScript running on any domain.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a><br/>
+<a href="http://enable-cors.org/">Enable Cross-Origin Resource Sharing</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECCORS">Overly permissive CORS policy</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
@@ -44,15 +44,36 @@ public class PermissiveCORSDetectorTest extends BaseDetectorTest {
                         .inClass("PermissiveCORS").inMethod("addPermissiveCORS").atLine(25)
                         .build()
         );
-        //2nd variation resp.setHeader("Access-Control-Allow-Origin", "*");
+        //2nd - lower case: resp.addHeader("access-control-allow-origin", "*")
         verify(reporter).doReportBug(
                 bugDefinition()
                         .bugType("PERMISSIVE_CORS")
-                        .inClass("PermissiveCORS").inMethod("setPermissiveCORS").atLine(29)
+                        .inClass("PermissiveCORS").inMethod("addPermissiveCORS2").atLine(29)
+                        .build()
+        );
+        //3rd - wildcards: resp.addHeader("Access-Control-Allow-Origin", "*.example.com")
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("PermissiveCORS").inMethod("addWildcardsCORS").atLine(33)
+                        .build()
+        );
+        //4th - null Origin: resp.addHeader("Access-Control-Allow-Origin", "null")
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("PermissiveCORS").inMethod("addNullCORS").atLine(37)
+                        .build()
+        );
+        //5th - set instead of add: resp.setHeader("Access-Control-Allow-Origin", "*");
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("PermissiveCORS").inMethod("setPermissiveCORS").atLine(41)
                         .build()
         );
 
-        verify(reporter, times(2)).doReportBug(
+        verify(reporter, times(5)).doReportBug(
                 bugDefinition()
                         .bugType("PERMISSIVE_CORS")
                         .build()

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
@@ -1,0 +1,61 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import static org.mockito.Mockito.*;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+public class PermissiveCORSDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectPermissiveCORS() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/PermissiveCORS")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+
+        //1rst variation resp.addHeader("Access-Control-Allow-Origin", "*")
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("PermissiveCORS").inMethod("addPermissiveCORS").atLine(25)
+                        .build()
+        );
+        //2nd variation resp.setHeader("Access-Control-Allow-Origin", "*");
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("PermissiveCORS").inMethod("setPermissiveCORS").atLine(29)
+                        .build()
+        );
+
+        verify(reporter, times(2)).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .build()
+        );
+    }
+}

--- a/plugin/src/test/java/testcode/PermissiveCORS.java
+++ b/plugin/src/test/java/testcode/PermissiveCORS.java
@@ -25,6 +25,18 @@ public class PermissiveCORS extends HttpServlet {
         resp.addHeader("Access-Control-Allow-Origin", "*");
     }
 
+    public void addPermissiveCORS2(HttpServletResponse resp) {
+        resp.addHeader("access-control-allow-origin", "*");
+    }
+
+    public void addWildcardsCORS(HttpServletResponse resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "*.example.com");
+    }
+
+    public void addNullCORS(HttpServletResponse resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "null");
+    }
+
     public void setPermissiveCORS(HttpServletResponse resp) {
         resp.setHeader("Access-Control-Allow-Origin", "*");
     }

--- a/plugin/src/test/java/testcode/PermissiveCORS.java
+++ b/plugin/src/test/java/testcode/PermissiveCORS.java
@@ -10,9 +10,22 @@ public class PermissiveCORS extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        //Cross-domain request accepted
-        resp.addHeader("Access-Control-Allow-Origin", "*");
+        falsePositiveCORS(resp);
 
         resp.getWriter().print(req.getSession().getAttribute("secret"));
+    }
+
+    //False positive test
+    private void falsePositiveCORS(HttpServletResponse resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "http://example.com");
+    }
+    
+    //Overly permissive Cross-domain requests accepted
+    public void addPermissiveCORS(HttpServletResponse resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "*");
+    }
+
+    public void setPermissiveCORS(HttpServletResponse resp) {
+        resp.setHeader("Access-Control-Allow-Origin", "*");
     }
 }


### PR DESCRIPTION
Detector reports overly permissive CORS policy that sets asterisk as the value of the Access-Control-Allow-Origin header, like in the following examples:
response.addHeader("Access-Control-Allow-Origin", "\*");
response.setHeader("Access-Control-Allow-Origin", "\*");