### PR TITLE
Anonymous LDAP Bind detector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/AnonymousLdapDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/AnonymousLdapDetector.java
@@ -1,0 +1,93 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.Location;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.LDC;
+import org.apache.bcel.generic.Instruction;
+import java.util.Iterator;
+
+public class AnonymousLdapDetector implements Detector {
+
+    private static final String LDAP_ANONYMOUS = "LDAP_ANONYMOUS";
+
+    private BugReporter bugReporter;
+
+    public AnonymousLdapDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+    
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        JavaClass javaClass = classContext.getJavaClass();
+
+        Method[] methodList = javaClass.getMethods();
+
+        for (Method m : methodList) {
+
+            try {
+                analyzeMethod(m, classContext);
+            } catch (CFGBuilderException e) {
+            } catch (DataflowAnalysisException e) {
+            }
+        }
+    }
+
+    private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException, DataflowAnalysisException {
+
+        ConstantPoolGen cpg = classContext.getConstantPoolGen();
+        CFG cfg = classContext.getCFG(m);
+        
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext(); ) {
+            Location location = i.next();
+
+            Instruction inst = location.getHandle().getInstruction();
+            
+            if (inst instanceof LDC) {
+                LDC ldc = (LDC) inst;
+                if (ldc != null) {
+                    if("java.naming.security.authentication".equals(ldc.getValue(cpg)) &&
+                       "none".equals(ByteCode.getConstantLDC(location.getHandle().getNext(), cpg, String.class))){
+                        JavaClass clz = classContext.getJavaClass();
+                        bugReporter.reportBug(new BugInstance(this, LDAP_ANONYMOUS, Priorities.LOW_PRIORITY) //
+                        .addClass(clz)
+                        .addMethod(clz, m)
+                        .addSourceLine(classContext, m, location));
+                        break;
+                    }
+                }
+            }            
+        }
+    }
+
+    @Override
+    public void report() {
+    }
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -91,7 +91,9 @@
     <Detector class="com.h3xstream.findsecbugs.scala.XssTwirlDetector" reports="SCALA_XSS_TWIRL" />
     <Detector class="com.h3xstream.findsecbugs.template.VelocityDetector" reports="TEMPLATE_INJECTION_VELOCITY" />
     <Detector class="com.h3xstream.findsecbugs.template.FreemarkerDetector" reports="TEMPLATE_INJECTION_FREEMARKER" />
+    <Detector class="com.h3xstream.findsecbugs.AnonymousLdapDetector" reports="LDAP_ANONYMOUS"/>
 
+    <BugPattern type="LDAP_ANONYMOUS" abbrev="LDAPA" category="SECURITY"/>
     <BugPattern type="PREDICTABLE_RANDOM" abbrev="SECPR" category="SECURITY" cweid="330"/>
     <BugPattern type="PREDICTABLE_RANDOM_SCALA" abbrev="SECPRS" category="SECURITY" cweid="330"/>
     <BugPattern type="SERVLET_PARAMETER" abbrev="SECSP" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4236,4 +4236,39 @@ prefer logic-less template engines such as Handlebars or Moustache (See referenc
     </BugPattern>
     <BugCode abbrev="SECFREEM">Potential template injection with Freemarker</BugCode>
 
+    
+    <!-- LDAP anonymous bind detector -->
+    <Detector class="com.h3xstream.findsecbugs.AnonymousLdapDetector">
+        <Details>Identify use of anonymous LDAP bind</Details>
+    </Detector>
+    <BugPattern type="LDAP_ANONYMOUS">
+        <ShortDescription>Anonymous LDAP bind</ShortDescription>
+        <LongDescription>Anonymous LDAP bind</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Without proper access control, executing an LDAP statement that contains a user-controlled value can allow an attacker to abuse poorly configured LDAP environment. All LDAP queries executed against ctx will be performed without authentication and access control. An attacker may be able to manipulate one of these queries in an unexpected way to gain access to records that would otherwise be protected by the directory's access control mechanism.
+</p>
+<p>
+    <b>Vulnerable Code:</b>
+<pre>...
+env.put(Context.SECURITY_AUTHENTICATION, "none");
+DirContext ctx = new InitialDirContext(env);
+...</pre>
+</p>
+<p>
+    <b>Solution:</b>
+<br/>
+Consider other modes of authentication to LDAP and ensure proper access control mechanism.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://docs.oracle.com/javase/tutorial/jndi/ldap/auth_mechs.html">Ldap Authentication Mechanisms</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="LDAPA">Anonymous LDAP bind</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/AnonymousLdapDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/AnonymousLdapDetectorTest.java
@@ -1,0 +1,53 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.testng.annotations.Test;
+
+public class AnonymousLdapDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectAnonymousLdapBind() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/AnonymousLdap")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("LDAP_ANONYMOUS")
+                        .inClass("AnonymousLdap").inMethod("ldapContext").atLine(16)
+                        .build()
+        );
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("LDAP_ANONYMOUS")
+                        .build()
+        );
+    }
+}

--- a/plugin/src/test/java/testcode/AnonymousLdap.java
+++ b/plugin/src/test/java/testcode/AnonymousLdap.java
@@ -1,0 +1,35 @@
+package testcode;
+
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+
+
+public class AnonymousLdap {
+	private final static String ldapURI = "ldaps://ldap.server.com/dc=ldap,dc=server,dc=com";
+	private final static String contextFactory = "com.sun.jndi.ldap.LdapCtxFactory";
+
+	private static DirContext ldapContext (Hashtable <String,String>env) throws Exception {
+		env.put(Context.INITIAL_CONTEXT_FACTORY, contextFactory);
+		env.put(Context.PROVIDER_URL, ldapURI);
+        env.put(Context.SECURITY_AUTHENTICATION, "none");
+		DirContext ctx = new InitialDirContext(env);
+		return ctx;
+	}
+
+	public static boolean testBind (String dn, String password) throws Exception {
+		Hashtable<String,String> env = new Hashtable <String,String>();
+        env.put(Context.SECURITY_AUTHENTICATION, "simple"); //false positive
+		env.put(Context.SECURITY_PRINCIPAL, dn);
+		env.put(Context.SECURITY_CREDENTIALS, password);
+
+		try {
+			ldapContext(env);
+		}
+		catch (javax.naming.AuthenticationException e) {
+			return false;
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
The proposed detector is reporting LDAP authentication method set to "none", like so:
`env.put(Context.SECURITY_AUTHENTICATION, "none");`
`DirContext ctx = new InitialDirContext(env);`