### PR TITLE
Add Url rewriting detector

### DIFF
--- a/plugin-deps/src/main/java/javax/servlet/http/HttpServletRequest.java
+++ b/plugin-deps/src/main/java/javax/servlet/http/HttpServletRequest.java
@@ -14,6 +14,8 @@ public interface HttpServletRequest extends ServletRequest {
 
     String getRequestedSessionId();
 
+    String getRequestURI();
+
     Cookie[] getCookies();
 
     HttpSession getSession();

--- a/plugin-deps/src/main/java/javax/servlet/http/HttpServletRequestWrapper.java
+++ b/plugin-deps/src/main/java/javax/servlet/http/HttpServletRequestWrapper.java
@@ -32,6 +32,11 @@ public class HttpServletRequestWrapper extends ServletRequestWrapper implements 
     }
 
     @Override
+    public String getRequestURI() {
+        return null;
+    }
+
+    @Override
     public Cookie[] getCookies() {
         return new Cookie[0];
     }

--- a/plugin-deps/src/main/java/javax/servlet/http/HttpServletResponse.java
+++ b/plugin-deps/src/main/java/javax/servlet/http/HttpServletResponse.java
@@ -12,4 +12,12 @@ public interface HttpServletResponse extends ServletResponse {
     void setHeader(String header, String value);
 
     void sendRedirect(String url) throws IOException;
+
+    String encodeURL(String url);
+
+    String encodeUrl(String url);
+
+    String encodeRedirectURL(String url);
+
+    String encodeRedirectUrl(String url);
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetector.java
@@ -1,0 +1,47 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.cookie;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Constants;
+
+public class UrlRewritingDetector extends OpcodeStackDetector {
+    
+    private static final String URL_REWRITING = "URL_REWRITING";
+
+    private final BugReporter bugReporter;
+
+    public UrlRewritingDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+
+        if (seen == Constants.INVOKEINTERFACE && getClassConstantOperand().equals("javax/servlet/http/HttpServletResponse")
+                && (getNameConstantOperand().equals("encodeURL") || getNameConstantOperand().equals("encodeUrl") ||
+                getNameConstantOperand().equals("encodeRedirectURL") || getNameConstantOperand().equals("encodeRedirectUrl"))) {
+
+            bugReporter.reportBug(new BugInstance(this, URL_REWRITING, Priorities.HIGH_PRIORITY) //
+                    .addClass(this).addMethod(this).addSourceLine(this));
+        }
+    }
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -94,7 +94,9 @@
     <Detector class="com.h3xstream.findsecbugs.AnonymousLdapDetector" reports="LDAP_ANONYMOUS"/>
     <Detector class="com.h3xstream.findsecbugs.PermissiveCORSDetector" reports="PERMISSIVE_CORS"/>
     <Detector class="com.h3xstream.findsecbugs.cookie.PersistentCookieDetector" reports="COOKIE_PERSISTENT" />
+    <Detector class="com.h3xstream.findsecbugs.cookie.UrlRewritingDetector" reports="URL_REWRITING"/>
 
+    <BugPattern type="URL_REWRITING" abbrev="SECURLR" category="SECURITY"/>
     <BugPattern type="COOKIE_PERSISTENT" abbrev="SECCP" category="SECURITY"/>
     <BugPattern type="LDAP_ANONYMOUS" abbrev="LDAPA" category="SECURITY"/>
     <BugPattern type="PERMISSIVE_CORS" abbrev="SECCORS" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4348,4 +4348,46 @@ cookie.setMaxAge(60*60*24*365);
     </BugPattern>
     <BugCode abbrev="SECCP">Persistent Cookie Usage</BugCode>
 
+
+    <!-- URL Rewriting Methods -->
+    <Detector class="com.h3xstream.findsecbugs.cookie.UrlRewritingDetector">
+        <Details>Detect the URL rewriting methods.
+        </Details>
+    </Detector>
+
+    <BugPattern type="URL_REWRITING">
+        <ShortDescription>URL rewriting method</ShortDescription>
+        <LongDescription>Method rewriting session ID into the URL</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+The implementation of this method includes the logic to determine whether the session ID needs to be encoded in the URL.<br/>
+URL rewriting has significant security risks. Since session ID appears in the URL, it may be easily seen by third parties. Session ID in the URL can be disclosed in many ways, for example:<br/>
+<ul>
+    <li>Log files,</li>
+    <li>The browser history,</li>
+    <li>By copy-and-pasting it into an e-mail or posting,</li>
+    <li>The HTTP Referrer.</li>
+</ul>
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>out.println("Click &lt;a href=" + 
+                res.encodeURL(HttpUtils.getRequestURL(req).toString()) + 
+                "&gt;here&lt;/a&gt;");</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Avoid using those methods. If you are looking to encode a URL String or form parameters do not confuse the URL rewriting methods with the URLEncoder class.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2010-A3-Broken_Authentication_and_Session_Management">OWASP Top 10 2010-A3-Broken Authentication and Session Management</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECURLR">URL Rewriting Methods</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetectorTest.java
@@ -1,0 +1,76 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.cookie;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+public class UrlRewritingDetectorTest extends BaseDetectorTest {
+    
+    @Test
+    public void detectUrlRewriting() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/UrlRewriting")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+
+        //1rst variation encodeURL(req.getRequestURI())
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("URL_REWRITING")
+                        .inClass("UrlRewriting").inMethod("encodeURLRewrite").atLine(17)
+                        .build()
+        );
+        //2nd variation, deprecated encodeUrl(req.getRequestURI())
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("URL_REWRITING")
+                        .inClass("UrlRewriting").inMethod("encodeUrlRewrite").atLine(21)
+                        .build()
+        );
+        //3rd variation encodeRedirectURL(req.getRequestURI())
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("URL_REWRITING")
+                        .inClass("UrlRewriting").inMethod("encodeRedirectURLRewrite").atLine(25)
+                        .build()
+        );
+        //4th variation, deprecated encodeRedirectUrl(req.getRequestURI())
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("URL_REWRITING")
+                        .inClass("UrlRewriting").inMethod("encodeRedirectUrlRewrite").atLine(29)
+                        .build()
+        );
+
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition()
+                        .bugType("URL_REWRITING")
+                        .build()
+        );
+    }
+}

--- a/plugin/src/test/java/testcode/cookie/UrlRewriting.java
+++ b/plugin/src/test/java/testcode/cookie/UrlRewriting.java
@@ -1,0 +1,31 @@
+package testcode.cookie;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class UrlRewriting extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        encodeURLRewrite(resp, req.getRequestURI());
+    }
+
+    private String encodeURLRewrite(HttpServletResponse resp, String url) {
+        return resp.encodeURL(url);
+    }
+
+    public String encodeUrlRewrite(HttpServletResponse resp, String url) {
+        return resp.encodeUrl(url); //Deprecated
+    }
+
+    public String encodeRedirectURLRewrite(HttpServletResponse resp, String url) {
+        return resp.encodeRedirectURL(url);
+    }
+    
+    public String encodeRedirectUrlRewrite(HttpServletResponse resp, String url) {
+        return resp.encodeRedirectUrl(url); //Deprecated
+    }
+}


### PR DESCRIPTION
Proposed detector reports URL rewriting methods. These methods determine whether the session ID needs to be included in the URL.