### PR TITLE
Fix false negative SHA in WeakMessageDigestDetector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetector.java
@@ -113,7 +113,7 @@ public class WeakMessageDigestDetector extends OpcodeStackDetector {
             bugReporter.reportBug(new BugInstance(this, WEAK_MESSAGE_DIGEST_MD5_TYPE, Priorities.HIGH_PRIORITY) //
                     .addClass(this).addMethod(this).addSourceLine(this) //
                     .addString(algorithm));
-        } else if ("SHA1".equals(algorithm) || "SHA-1".equals(algorithm)) { //Lower priority for SHA-1
+        } else if ("SHA1".equals(algorithm) || "SHA-1".equals(algorithm) || "SHA".equals(algorithm)) { //Lower priority for SHA-1
             bugReporter.reportBug(new BugInstance(this, WEAK_MESSAGE_DIGEST_SHA1_TYPE, Priorities.NORMAL_PRIORITY) //
                     .addClass(this).addMethod(this).addSourceLine(this) //
                     .addString(algorithm));

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/WeakMessageDigestDetectorTest.java
@@ -49,7 +49,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
             );
         }
         //SHA1
-        for(int line : Arrays.asList(20,24)) {
+        for(int line : Arrays.asList(20,24,28)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("WEAK_MESSAGE_DIGEST_SHA1")
@@ -65,7 +65,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
                         .build()
         );
 
-        verify(reporter,times(2)).doReportBug(
+        verify(reporter,times(3)).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST_SHA1")
                         .inClass("WeakMessageDigest").inMethod("main")
@@ -85,7 +85,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
         analyze(files, reporter);
 
         //Message Digest
-        for(int line = 41; line<=48;line++) {
+        for(int line = 45; line<=52;line++) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("WEAK_MESSAGE_DIGEST_MD5")
@@ -94,7 +94,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
             );
         }
 
-        for(int line = 50; line<=57;line++) {
+        for(int line = 54; line<=61;line++) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("WEAK_MESSAGE_DIGEST_SHA1")
@@ -140,18 +140,18 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
         verify(reporter).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST_MD5")
-                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(28)
+                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(30)
                         .build()
         );
         verify(reporter).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST_MD5")
-                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(29)
+                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(31)
                         .build()
         );
 
         //SHA-1 Assertions
-        for(int line = 21; line <= 24; line++) {
+        for(int line = 21; line <= 26; line++) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("WEAK_MESSAGE_DIGEST_SHA1")
@@ -162,7 +162,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
         verify(reporter).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST_SHA1")
-                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(30)
+                        .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig").atLine(32)
                         .build()
         );
 
@@ -172,7 +172,7 @@ public class WeakMessageDigestDetectorTest extends BaseDetectorTest {
                         .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig")
                         .build()
         );
-        verify(reporter,times(5)).doReportBug(
+        verify(reporter,times(7)).doReportBug(
                 bugDefinition()
                         .bugType("WEAK_MESSAGE_DIGEST_SHA1")
                         .inClass("WeakMessageDigestAdditionalSig").inMethod("weakDigestMoreSig")

--- a/plugin/src/test/java/testcode/crypto/WeakMessageDigest.java
+++ b/plugin/src/test/java/testcode/crypto/WeakMessageDigest.java
@@ -17,13 +17,17 @@ public class WeakMessageDigest {
         md5Digest.update("123".getBytes());
         printHex(md5Digest.digest());
 
-        MessageDigest sha1Digest = MessageDigest.getInstance("SHA1");
+        MessageDigest sha1Digest = MessageDigest.getInstance("SHA");
         sha1Digest.update("123".getBytes());
         printHex(sha1Digest.digest());
-
-        MessageDigest sha1Digest2 = MessageDigest.getInstance("SHA-1");
+        
+        MessageDigest sha1Digest2 = MessageDigest.getInstance("SHA1");
         sha1Digest2.update("123".getBytes());
         printHex(sha1Digest2.digest());
+
+        MessageDigest sha1Digest3 = MessageDigest.getInstance("SHA-1");
+        sha1Digest3.update("123".getBytes());
+        printHex(sha1Digest3.digest());
 
         MessageDigest sha256Digest = MessageDigest.getInstance("SHA256"); //OK!
         sha256Digest.update("123".getBytes());

--- a/plugin/src/test/java/testcode/crypto/WeakMessageDigestAdditionalSig.java
+++ b/plugin/src/test/java/testcode/crypto/WeakMessageDigestAdditionalSig.java
@@ -18,6 +18,8 @@ public class WeakMessageDigestAdditionalSig {
         MessageDigest.getInstance("MD5", new DummyProvider());
         MessageDigest.getInstance("MD4", new DummyProvider());
         MessageDigest.getInstance("MD2", new DummyProvider());
+        MessageDigest.getInstance("SHA", "SUN");
+        MessageDigest.getInstance("SHA", new DummyProvider());
         MessageDigest.getInstance("SHA1", "SUN");
         MessageDigest.getInstance("SHA1", new DummyProvider());
         MessageDigest.getInstance("SHA-1", "SUN");


### PR DESCRIPTION
Fixing WeakMessageDigestDetector not verifying one of the possible sha1 algorithm names:
`MessageDigest.getInstance("SHA");`