### PR TITLE
Fix false negatives in InsufficientKeySizeRsaDetector

### DIFF
--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/InsufficientKeySizeRsaDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/InsufficientKeySizeRsaDetectorTest.java
@@ -43,13 +43,19 @@ public class InsufficientKeySizeRsaDetectorTest extends BaseDetectorTest {
         for (Integer line : Arrays.asList(14, 21, 29, 37)) {
             verify(reporter).doReportBug(
                     bugDefinition().bugType("RSA_KEY_SIZE")
-                            .inClass("InsufficientKeySizeRsa").atLine(line)
+                            .inClass("InsufficientKeySizeRsa").withPriority("Medium").atLine(line)
                             .build()
             );
         }
 
-        //More than two means a false positive was trigger
-        verify(reporter, times(4)).doReportBug(
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("RSA_KEY_SIZE")
+                        .inClass("InsufficientKeySizeRsa").inMethod("weakKeySize5Recommended").withPriority("Low").atLine(45)
+                        .build()
+        );
+
+        verify(reporter, times(5)).doReportBug(
                 bugDefinition().bugType("RSA_KEY_SIZE").build());
     }
 }

--- a/plugin/src/test/java/testcode/crypto/InsufficientKeySizeRsa.java
+++ b/plugin/src/test/java/testcode/crypto/InsufficientKeySizeRsa.java
@@ -40,9 +40,9 @@ public class InsufficientKeySizeRsa {
         return key;
     }
 
-    public KeyPair okKeySize() throws NoSuchAlgorithmException {
+    public KeyPair weakKeySize5Recommended() throws NoSuchAlgorithmException {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(1024);
+        keyGen.initialize(1024); //BAD with lower priority
 
         return keyGen.generateKeyPair();
     }


### PR DESCRIPTION
1. Key length check up from 1024 to 2048 according to current standards and reflecting the existing bug description from messages.xml. Priority for key length between 1024 and 2048 set to low as opposed to normal for below 1024
2. Fixed the logic allowing for only one bug instance to be reported per file, now reporting all bug instances.