### PR TITLE
Add Insecure SMTP SSL detector

### DIFF
--- a/plugin-deps/src/main/java/org/apache/commons/mail/Email.java
+++ b/plugin-deps/src/main/java/org/apache/commons/mail/Email.java
@@ -1,0 +1,25 @@
+package org.apache.commons.mail;
+
+public abstract class Email {
+
+    protected String hostName;
+
+    private boolean sslOnConnect;
+
+    private boolean sslCheckServerIdentity;
+
+
+    public void setHostName(final String aHostName) {
+        this.hostName = aHostName;
+    }
+
+    public Email setSSLOnConnect(final boolean ssl) {
+        this.sslOnConnect = ssl;
+        return this;
+    }
+
+    public Email setSSLCheckServerIdentity(final boolean sslCheckServerIdentity) {
+        this.sslCheckServerIdentity = sslCheckServerIdentity;
+        return this;
+    }
+}

--- a/plugin-deps/src/main/java/org/apache/commons/mail/HtmlEmail.java
+++ b/plugin-deps/src/main/java/org/apache/commons/mail/HtmlEmail.java
@@ -1,0 +1,5 @@
+package org.apache.commons.mail;
+
+public class HtmlEmail extends MultiPartEmail {
+
+}

--- a/plugin-deps/src/main/java/org/apache/commons/mail/ImageHtmlEmail.java
+++ b/plugin-deps/src/main/java/org/apache/commons/mail/ImageHtmlEmail.java
@@ -1,0 +1,5 @@
+package org.apache.commons.mail;
+
+public class ImageHtmlEmail extends HtmlEmail {
+
+}

--- a/plugin-deps/src/main/java/org/apache/commons/mail/MultiPartEmail.java
+++ b/plugin-deps/src/main/java/org/apache/commons/mail/MultiPartEmail.java
@@ -1,0 +1,5 @@
+package org.apache.commons.mail;
+
+public class MultiPartEmail extends Email {
+
+}

--- a/plugin-deps/src/main/java/org/apache/commons/mail/SimpleEmail.java
+++ b/plugin-deps/src/main/java/org/apache/commons/mail/SimpleEmail.java
@@ -1,0 +1,5 @@
+package org.apache.commons.mail;
+
+public class SimpleEmail extends Email {
+
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsecureSmtpSslDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsecureSmtpSslDetector.java
@@ -1,0 +1,127 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.crypto;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import edu.umd.cs.findbugs.ba.Location;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEVIRTUAL;
+import org.apache.bcel.generic.LDC;
+import org.apache.bcel.generic.Instruction;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Iterator;
+
+
+public class InsecureSmtpSslDetector implements Detector {
+    private static final String INSECURE_SMTP_SSL = "INSECURE_SMTP_SSL";
+
+    private static final List<String> INSECURE_APIS = Arrays.asList(
+            "org.apache.commons.mail.Email", //
+            "org.apache.commons.mail.HtmlEmail", //
+            "org.apache.commons.mail.ImageHtmlEmail", //
+            "org.apache.commons.mail.MultiPartEmail");
+
+    private final BugReporter bugReporter;
+
+    public InsecureSmtpSslDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        JavaClass javaClass = classContext.getJavaClass();
+        for (Method m : javaClass.getMethods()) {
+            try {
+                analyzeMethod(m, classContext);
+            } catch (CFGBuilderException e) {
+            } catch (DataflowAnalysisException e) {
+            }
+        }
+    }
+
+    private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException, DataflowAnalysisException {
+
+        HashMap<Location, String> sslConnMap = new HashMap<Location, String>();
+        HashSet<String> sslCertVerSet = new HashSet<String>();
+        Location locationWeakness = null;
+        String hostName = null;
+
+        ConstantPoolGen cpg = classContext.getConstantPoolGen();
+        CFG cfg = classContext.getCFG(m);
+
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext(); ) {
+            Location location = i.next();
+
+            Instruction inst = location.getHandle().getInstruction();
+
+            if (inst instanceof INVOKEVIRTUAL) {
+                INVOKEVIRTUAL invoke = (INVOKEVIRTUAL) inst;
+                if (INSECURE_APIS.contains(invoke.getClassName(cpg)) &&
+                        "setHostName".equals(invoke.getMethodName(cpg))) {
+                    hostName = ByteCode.getConstantLDC(location.getHandle().getPrev(), cpg, String.class);
+                }
+                if (INSECURE_APIS.contains(invoke.getClassName(cpg)) &&
+                        "setSSLOnConnect".equals(invoke.getMethodName(cpg))) {
+                    Integer sslOn = ByteCode.getConstantInt(location.getHandle().getPrev());
+                    if (sslOn != null && sslOn == 1) {
+                        sslConnMap.put(location, invoke.getClassName(cpg)+hostName);
+                    }
+                }
+                if (INSECURE_APIS.contains(invoke.getClassName(cpg)) &&
+                        "setSSLCheckServerIdentity".equals(invoke.getMethodName(cpg))) {
+                    Integer checkOn = ByteCode.getConstantInt(location.getHandle().getPrev());
+                    if (checkOn != null && checkOn == 1) {
+                        sslCertVerSet.add(invoke.getClassName(cpg)+hostName);
+                    }
+                }
+            }
+        }
+
+        //Both conditions - setSSLOnConnect and setSSLCheckServerIdentity
+        //haven't been found in the same instance (verifing instance by class name + host name)
+        sslConnMap.values().removeAll(sslCertVerSet);
+
+        if (!sslConnMap.isEmpty()) {
+            for (Location key : sslConnMap.keySet()) {
+                JavaClass clz = classContext.getJavaClass();
+                bugReporter.reportBug(new BugInstance(this, INSECURE_SMTP_SSL, Priorities.HIGH_PRIORITY)
+                        .addClass(clz)
+                        .addMethod(clz, m)
+                        .addSourceLine(classContext, m, key));
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+    }
+
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -95,7 +95,9 @@
     <Detector class="com.h3xstream.findsecbugs.PermissiveCORSDetector" reports="PERMISSIVE_CORS"/>
     <Detector class="com.h3xstream.findsecbugs.cookie.PersistentCookieDetector" reports="COOKIE_PERSISTENT" />
     <Detector class="com.h3xstream.findsecbugs.cookie.UrlRewritingDetector" reports="URL_REWRITING"/>
+    <Detector class="com.h3xstream.findsecbugs.crypto.InsecureSmtpSslDetector" reports="INSECURE_SMTP_SSL"/>
 
+    <BugPattern type="INSECURE_SMTP_SSL" abbrev="SECISC" category="SECURITY"/>
     <BugPattern type="URL_REWRITING" abbrev="SECURLR" category="SECURITY"/>
     <BugPattern type="COOKIE_PERSISTENT" abbrev="SECCP" category="SECURITY"/>
     <BugPattern type="LDAP_ANONYMOUS" abbrev="LDAPA" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4569,4 +4569,49 @@ Avoid using those methods. If you are looking to encode a URL String or form par
     </BugPattern>
     <BugCode abbrev="SECURLR">URL Rewriting Methods</BugCode>
 
+
+    <!-- Insecure SMTP SSL connection -->
+    <Detector class="com.h3xstream.findsecbugs.crypto.InsecureSmtpSslDetector">
+        <Details>Detect Insecure SMTP SSL connection.
+        </Details>
+    </Detector>
+
+    <BugPattern type="INSECURE_SMTP_SSL">
+        <ShortDescription>Insecure SMTP SSL connection</ShortDescription>
+        <LongDescription> This SMTP SSL conncection does not verify the server certificate</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Server identity verification is disabled when making SSL connections. Some email libraries that enable SSL connections do not verify the server certificate by default. This is equivalent to trusting all certificates. When trying to connect to the server, this application would readily accept a certificate issued to "hackedserver.com". The application would now potentially leak sensitive user information on a broken SSL connection to the hacked server.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>...
+Email email = new SimpleEmail();
+email.setHostName("smtp.servermail.com");
+email.setSmtpPort(465);
+email.setAuthenticator(new DefaultAuthenticator(username, password));
+email.setSSLOnConnect(true);
+email.setFrom("user@gmail.com");
+email.setSubject("TestMail");
+email.setMsg("This is a test mail ... :-)");
+email.addTo("foo@bar.com");
+email.send();
+...</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Please add the following check to verify the server cerfiticate:
+<pre>email.setSSLCheckServerIdentity(true);</pre>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/297.html">CWE-297: Improper Validation of Certificate with Host Mismatch</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECISC">Insecure SMTP SSL connection</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/InsecureSmtpSslDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/InsecureSmtpSslDetectorTest.java
@@ -1,0 +1,55 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.crypto;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class InsecureSmtpSslDetectorTest extends BaseDetectorTest {
+    @Test
+    public void detectBadKeySize() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/crypto/InsecureSmtpSsl")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        for (Integer line : Arrays.asList(18, 29, 33, 47)) {
+            verify(reporter).doReportBug(
+                    bugDefinition().bugType("INSECURE_SMTP_SSL")
+                            .inClass("InsecureSmtpSsl").inMethod("main").atLine(line)
+                            .build()
+            );
+        }
+
+        //More than 4 means a false positive was triggered
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition().bugType("INSECURE_SMTP_SSL").inClass("InsecureSmtpSsl").build());
+    }
+}

--- a/plugin/src/test/java/testcode/crypto/InsecureSmtpSsl.java
+++ b/plugin/src/test/java/testcode/crypto/InsecureSmtpSsl.java
@@ -1,0 +1,49 @@
+package testcode.crypto;
+
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.SimpleEmail;
+import org.apache.commons.mail.MultiPartEmail;
+import org.apache.commons.mail.HtmlEmail;
+import org.apache.commons.mail.ImageHtmlEmail;
+
+public class InsecureSmtpSsl {
+
+    public static void main(String[] args) throws Exception {
+        Email email = new SimpleEmail();
+        email.setHostName("smtp.googlemail.com");
+        email.setSSLOnConnect(false); //OK
+
+        Email email2 = new SimpleEmail();
+        email2.setHostName("smtp2.googlemail.com");        
+        email2.setSSLOnConnect(true); //BAD
+        //email2.setSmtpPort(465);
+        //email2.setAuthenticator(new DefaultAuthenticator("username", "password"));
+        //email2.setFrom("user@gmail.com");
+        //email2.setSubject("TestMail");
+        //email2.setMsg("This is a test mail ... :-)");
+        //email2.addTo("foo@bar.com");
+        //email2.send();
+
+        MultiPartEmail emailMulti = new MultiPartEmail();
+        emailMulti.setHostName("mail.myserver.com");
+        emailMulti.setSSLOnConnect(true); //BAD
+
+        HtmlEmail htmlEmail = new HtmlEmail();
+        htmlEmail.setHostName("mail.myserver.com");
+        htmlEmail.setSSLOnConnect(true); //BAD
+
+        ImageHtmlEmail imageEmail = new ImageHtmlEmail();
+        imageEmail.setHostName("mail.myserver.com");
+        imageEmail.setSSLOnConnect(true);
+        imageEmail.setSSLCheckServerIdentity(true); //OK
+        
+        ImageHtmlEmail imageEmail2 = new ImageHtmlEmail();
+        imageEmail2.setHostName("mail2.myserver.com");
+        imageEmail2.setSSLCheckServerIdentity(true); //OK - reversed order
+        imageEmail2.setSSLOnConnect(true);
+
+        ImageHtmlEmail imageEmail3 = new ImageHtmlEmail();
+        imageEmail3.setHostName("mail3.myserver.com");
+        imageEmail3.setSSLOnConnect(true); //BAD
+    }
+}


### PR DESCRIPTION
Proposed detector reports SMTP SSL connections that don't verify the server certificate by default. This is equivalent to trusting all certificates. Affected APIs:
org.apache.commons.mail.Email
org.apache.commons.mail.HtmlEmail
org.apache.commons.mail.ImageHtmlEmail
org.apache.commons.mail.MultiPartEmail

A bug instance would be reported if the sslCheckServerIdentity property wasn't properly set in the below example:
`imageEmail.setSSLOnConnect(true);`
`imageEmail.setSSLCheckServerIdentity(true); //OK`