### PR TITLE
Add AWS Query Injection detector

### DIFF
--- a/plugin-deps/src/main/java/com/amazonaws/auth/BasicAWSCredentials.java
+++ b/plugin-deps/src/main/java/com/amazonaws/auth/BasicAWSCredentials.java
@@ -1,0 +1,29 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.amazonaws.auth;
+
+public class BasicAWSCredentials {
+
+    private final String accessKey;
+    private final String secretKey;
+
+    public BasicAWSCredentials(String accessKey, String secretKey) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+    }
+}

--- a/plugin-deps/src/main/java/com/amazonaws/services/simpledb/AmazonSimpleDBClient.java
+++ b/plugin-deps/src/main/java/com/amazonaws/services/simpledb/AmazonSimpleDBClient.java
@@ -1,0 +1,34 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.amazonaws.services.simpledb;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.simpledb.model.SelectRequest;
+import com.amazonaws.services.simpledb.model.SelectResult;
+
+public class AmazonSimpleDBClient {
+
+    public AmazonSimpleDBClient(BasicAWSCredentials awsCredentials) {
+
+    }
+
+    public SelectResult select(SelectRequest selectRequest) {
+        SelectResult response = null;
+        return response;
+    }
+}

--- a/plugin-deps/src/main/java/com/amazonaws/services/simpledb/model/SelectRequest.java
+++ b/plugin-deps/src/main/java/com/amazonaws/services/simpledb/model/SelectRequest.java
@@ -1,0 +1,43 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.amazonaws.services.simpledb.model;
+
+public class SelectRequest {
+
+    private String selectExpression;
+
+    public SelectRequest() {
+    }
+
+    public SelectRequest(String selectExpression) {
+        setSelectExpression(selectExpression);
+    }
+
+    public SelectRequest(String selectExpression, Boolean consistentRead) {
+        setSelectExpression(selectExpression);
+    }
+
+    public void setSelectExpression(String selectExpression) {
+        this.selectExpression = selectExpression;
+    }
+
+    public SelectRequest withSelectExpression(String selectExpression) {
+        setSelectExpression(selectExpression);
+        return this;
+    }
+}

--- a/plugin-deps/src/main/java/com/amazonaws/services/simpledb/model/SelectResult.java
+++ b/plugin-deps/src/main/java/com/amazonaws/services/simpledb/model/SelectResult.java
@@ -1,0 +1,22 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.amazonaws.services.simpledb.model;
+
+public class SelectResult {
+
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/aws/AwsQueryInjectionDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/aws/AwsQueryInjectionDetector.java
@@ -1,0 +1,29 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.aws;
+
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import edu.umd.cs.findbugs.BugReporter;
+
+public class AwsQueryInjectionDetector extends BasicInjectionDetector {
+
+    public AwsQueryInjectionDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        loadConfiguredSinks("aws.txt", "AWS_QUERY_INJECTION");
+    }
+}

--- a/plugin/src/main/resources/injection-sinks/aws.txt
+++ b/plugin/src/main/resources/injection-sinks/aws.txt
@@ -1,1 +1,3 @@
 com/amazonaws/services/simpledb/model/SelectRequest.<init>(Ljava/lang/String;)V:0
+com/amazonaws/services/simpledb/model/SelectRequest.<init>(Ljava/lang/String;Ljava/lang/Boolean;)V:1
+com/amazonaws/services/simpledb/model/SelectRequest.withSelectExpression(Ljava/lang/String;)Lcom/amazonaws/services/simpledb/model/SelectRequest;:0

--- a/plugin/src/main/resources/injection-sinks/aws.txt
+++ b/plugin/src/main/resources/injection-sinks/aws.txt
@@ -1,0 +1,1 @@
+com/amazonaws/services/simpledb/model/SelectRequest.<init>(Ljava/lang/String;)V:0

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -96,7 +96,9 @@
     <Detector class="com.h3xstream.findsecbugs.cookie.PersistentCookieDetector" reports="COOKIE_PERSISTENT" />
     <Detector class="com.h3xstream.findsecbugs.cookie.UrlRewritingDetector" reports="URL_REWRITING"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.InsecureSmtpSslDetector" reports="INSECURE_SMTP_SSL"/>
+    <Detector class="com.h3xstream.findsecbugs.injection.aws.AwsQueryInjectionDetector" reports="AWS_QUERY_INJECTION"/>
 
+    <BugPattern type="AWS_QUERY_INJECTION" abbrev="SECAQI" category="SECURITY"/>
     <BugPattern type="INSECURE_SMTP_SSL" abbrev="SECISC" category="SECURITY"/>
     <BugPattern type="URL_REWRITING" abbrev="SECURLR" category="SECURITY"/>
     <BugPattern type="COOKIE_PERSISTENT" abbrev="SECCP" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4614,4 +4614,48 @@ Please add the following check to verify the server cerfiticate:
     </BugPattern>
     <BugCode abbrev="SECISC">Insecure SMTP SSL connection</BugCode>
 
+
+    <!-- AWS Query Injection -->
+    <Detector class="com.h3xstream.findsecbugs.injection.aws.AwsQueryInjectionDetector">
+        <Details>Detect AWS Query Injection.
+        </Details>
+    </Detector>
+
+    <BugPattern type="AWS_QUERY_INJECTION">
+        <ShortDescription>AWS Query Injection</ShortDescription>
+        <LongDescription>This SimpleDB client accepts data from an untrusted source.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Constructing SimpleDB queries containing user input can allow an attacker to view unauthorized records.<br/>
+The following example dynamically constructs and executes a SimpleDB select() query allowing the user to specify the productCategory. The attacker can modify the query, bypass the required authentication for customerID and view records matching any customer.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>...
+String customerID = getAuthenticatedCustomerID(customerName, customerCredentials);
+String productCategory = request.getParameter("productCategory");
+...
+AmazonSimpleDBClient sdbc = new AmazonSimpleDBClient(appAWSCredentials);
+String query = "select * from invoices where productCategory = '"
+            + productCategory + "' and customerID = '"
+            + customerID + "' order by '"
+            + sortColumn + "' asc";
+SelectResult sdbResult = sdbc.select(new SelectRequest(query));
+</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+This issue is analogical to SQL Injection. Sanitize user input before using it in a SimpleDb query.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/943.html">CWE-943: Improper Neutralization of Special Elements in Data Query Logic</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECAQI">AWS Query Injection</BugCode>
+
 </MessageCollection>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4646,7 +4646,7 @@ SelectResult sdbResult = sdbc.select(new SelectRequest(query));
 </p>
 <p>
     <b>Solution:</b><br/>
-This issue is analogical to SQL Injection. Sanitize user input before using it in a SimpleDb query.
+This issue is analogical to SQL Injection. Sanitize user input before using it in a SimpleDB query.
 </p>
 <br/>
 <p>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/aws/AwsQueryInjectionDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/aws/AwsQueryInjectionDetectorTest.java
@@ -1,0 +1,56 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.aws;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+import java.util.Arrays;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class AwsQueryInjectionDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectAwsQueryInjection() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/AwsQueryInjection")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(23, 25, 28)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("AWS_QUERY_INJECTION")
+                            .inClass("AwsQueryInjection").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+
+        //Out of the 4 calls, 3 are suspicious
+        verify(reporter, times(3)).doReportBug(
+                bugDefinition().bugType("AWS_QUERY_INJECTION").build()
+        );
+    }
+
+}

--- a/plugin/src/test/java/testcode/AwsQueryInjection.java
+++ b/plugin/src/test/java/testcode/AwsQueryInjection.java
@@ -1,0 +1,37 @@
+package testcode;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServlet;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.simpledb.AmazonSimpleDBClient;
+import com.amazonaws.services.simpledb.model.SelectRequest;
+import com.amazonaws.services.simpledb.model.SelectResult;
+
+
+public class AwsQueryInjection extends HttpServlet{
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        try{
+            String customerID = request.getParameter("customerID");
+		    BasicAWSCredentials awsCredentials = new BasicAWSCredentials("test", "test");
+            AmazonSimpleDBClient sdbc = new AmazonSimpleDBClient(awsCredentials);
+            
+            String query = "select * from invoices where customerID = '"
+                + customerID;
+            SelectResult sdbResult = sdbc.select(new SelectRequest(query)); //BAD
+
+            SelectResult sdbResult2 = sdbc.select(new SelectRequest(query, false)); //BAD
+
+            SelectRequest sdbRequest = new SelectRequest();
+            SelectResult sdbResult3 = sdbc.select(sdbRequest.withSelectExpression(query)); //BAD
+            
+            String query2 = "select * from invoices where customerID = 123";
+            SelectResult sdbResult4 = sdbc.select(new SelectRequest(query2)); //OK
+
+        }catch(Exception e){
+            System.out.println(e);
+       }
+    }
+}


### PR DESCRIPTION
Proposed detector reports AWS Query Injection which is analogical to SQL Injection (with the limitations of the AWS SimpleDB Select operation). Simplified concept below:

```java
AmazonSimpleDBClient sdbc = new AmazonSimpleDBClient(appAWSCredentials);
String productCategory = request.getParameter("productCategory");
String query = "select * from invoices where productCategory = '"
            + productCategory + "' and customerID = '"
            + customerID + "' order by '"
            + sortColumn + "' asc";
SelectResult sdbResult = sdbc.select(new SelectRequest(query));
```