### PR TITLE
Spring CSRF: Protection Disabled & Unrestricted RequestMapping

### DIFF
--- a/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1,0 +1,11 @@
+package org.springframework.security.config.annotation.web.builders;
+
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+
+public class HttpSecurity {
+
+    public CsrfConfigurer csrf() throws Exception {
+        return new CsrfConfigurer();
+    }
+
+}

--- a/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
+++ b/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
@@ -1,0 +1,4 @@
+package org.springframework.security.config.annotation.web.configuration;
+
+public @interface EnableWebSecurity {
+}

--- a/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
+++ b/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
@@ -1,0 +1,10 @@
+package org.springframework.security.config.annotation.web.configuration;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+public class WebSecurityConfigurerAdapter {
+
+    protected void configure(HttpSecurity http) throws Exception {
+    }
+
+}

--- a/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractHttpConfigurer.java
+++ b/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractHttpConfigurer.java
@@ -1,0 +1,8 @@
+package org.springframework.security.config.annotation.web.configurers;
+
+abstract class AbstractHttpConfigurer {
+
+    public void disable() {
+    }
+
+}

--- a/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/plugin-deps/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -1,0 +1,5 @@
+package org.springframework.security.config.annotation.web.configurers;
+
+public final class CsrfConfigurer extends AbstractHttpConfigurer {
+
+}

--- a/plugin-deps/src/main/java/org/springframework/web/bind/annotation/RequestMethod.java
+++ b/plugin-deps/src/main/java/org/springframework/web/bind/annotation/RequestMethod.java
@@ -1,5 +1,5 @@
 package org.springframework.web.bind.annotation;
 
 public enum RequestMethod {
-    GET, POST;
+    GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/csrf/SpringCsrfProtectionDisabledDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/csrf/SpringCsrfProtectionDisabledDetector.java
@@ -1,0 +1,56 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.csrf;
+
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Constants;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+/**
+ * Detects the disabling of Spring CSRF protection
+ *
+ * @author Pablo Tamarit
+ */
+public class SpringCsrfProtectionDisabledDetector extends OpcodeStackDetector {
+
+    private static final String SPRING_CSRF_PROTECTION_DISABLED_TYPE = "SPRING_CSRF_PROTECTION_DISABLED";
+
+    private static final InvokeMatcherBuilder CSRF_CONFIGURER_DISABLE_METHOD = invokeInstruction() //
+            .atClass("org/springframework/security/config/annotation/web/configurers/CsrfConfigurer") //
+            .atMethod("disable");
+
+    private BugReporter bugReporter;
+
+    public SpringCsrfProtectionDisabledDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+
+        if (seen == Constants.INVOKEVIRTUAL && CSRF_CONFIGURER_DISABLE_METHOD.matches(this)) {
+            bugReporter.reportBug(new BugInstance(this, SPRING_CSRF_PROTECTION_DISABLED_TYPE, Priorities.HIGH_PRIORITY) //
+                    .addClass(this).addMethod(this).addSourceLine(this));
+        }
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/csrf/SpringCsrfUnrestrictedRequestMappingDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/csrf/SpringCsrfUnrestrictedRequestMappingDetector.java
@@ -1,0 +1,152 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.csrf;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import org.apache.bcel.classfile.AnnotationEntry;
+import org.apache.bcel.classfile.ArrayElementValue;
+import org.apache.bcel.classfile.ElementValue;
+import org.apache.bcel.classfile.ElementValuePair;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Detects Spring CSRF unrestricted RequestMapping
+ *
+ * @author Pablo Tamarit
+ */
+public class SpringCsrfUnrestrictedRequestMappingDetector implements Detector {
+
+    private static final String SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING_TYPE = "SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING";
+
+    private static final String REQUEST_MAPPING_ANNOTATION_TYPE = "Lorg/springframework/web/bind/annotation/RequestMapping;";
+    private static final String METHOD_ANNOTATION_ATTRIBUTE_KEY = "method";
+    private static final List<String> UNPROTECTED_HTTP_REQUEST_METHODS = Arrays.asList("GET", "HEAD", "TRACE", "OPTIONS");
+
+    private BugReporter bugReporter;
+
+    public SpringCsrfUnrestrictedRequestMappingDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        JavaClass javaClass = classContext.getJavaClass();
+
+        for (Method method : javaClass.getMethods()) {
+            if (isVulnerable(method)) {
+                bugReporter.reportBug(new BugInstance(this, SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING_TYPE, Priorities.HIGH_PRIORITY) //
+                        .addClassAndMethod(javaClass, method));
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+
+    }
+
+    private static boolean isVulnerable(Method method) {
+
+        // If the method is not annotated with `@RequestMapping`, there is no vulnerability.
+        AnnotationEntry requestMappingAnnotation = findRequestMappingAnnotation(method);
+        if (requestMappingAnnotation == null) {
+            return false;
+        }
+
+        // If the `@RequestMapping` annotation is used without the `method` annotation attribute,
+        // there is a vulnerability.
+        ElementValuePair methodAnnotationAttribute = findMethodAnnotationAttribute(requestMappingAnnotation);
+        if (methodAnnotationAttribute == null) {
+            return true;
+        }
+
+        // If the `@RequestMapping` annotation is used with the `method` annotation attribute equal to `{}`,
+        // there is a vulnerability.
+        ElementValue methodAnnotationAttributeValue = methodAnnotationAttribute.getValue();
+        if (isEmptyArray(methodAnnotationAttributeValue)) {
+            return true;
+        }
+
+        // If the `@RequestMapping` annotation is used with the `method` annotation attribute but contains a mix of
+        // unprotected and protected HTTP request methods, there is a vulnerability.
+        return isMixOfUnprotectedAndProtectedHttpRequestMethods(methodAnnotationAttributeValue);
+    }
+
+    private static AnnotationEntry findRequestMappingAnnotation(Method method) {
+        for (AnnotationEntry annotationEntry : method.getAnnotationEntries()) {
+            if (REQUEST_MAPPING_ANNOTATION_TYPE.equals(annotationEntry.getAnnotationType())) {
+                return annotationEntry;
+            }
+        }
+        return null;
+    }
+
+    private static ElementValuePair findMethodAnnotationAttribute(AnnotationEntry requestMappingAnnotation) {
+        for (ElementValuePair elementValuePair : requestMappingAnnotation.getElementValuePairs()) {
+            if (METHOD_ANNOTATION_ATTRIBUTE_KEY.equals(elementValuePair.getNameString())) {
+                return elementValuePair;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isEmptyArray(ElementValue methodAnnotationAttributeValue) {
+        if (!(methodAnnotationAttributeValue instanceof ArrayElementValue)) {
+            return false;
+        }
+        ArrayElementValue arrayElementValue = (ArrayElementValue) methodAnnotationAttributeValue;
+
+        return arrayElementValue.getElementValuesArraySize() == 0;
+    }
+
+    private static boolean isMixOfUnprotectedAndProtectedHttpRequestMethods(ElementValue methodAnnotationAttributeValue) {
+        if (!(methodAnnotationAttributeValue instanceof ArrayElementValue)) {
+            return false;
+        }
+        ArrayElementValue arrayElementValue = (ArrayElementValue) methodAnnotationAttributeValue;
+
+        // There cannot be a mix if there is no more than one element.
+        if (arrayElementValue.getElementValuesArraySize() <= 1) {
+            return false;
+        }
+
+        // Return `true` as soon as we find at least one unprotected and at least one protected HTTP request method.
+        boolean atLeastOneUnprotected = false;
+        boolean atLeastOneProtected = false;
+        ElementValue[] elementValues = arrayElementValue.getElementValuesArray();
+        for (ElementValue elementValue : elementValues) {
+            if (UNPROTECTED_HTTP_REQUEST_METHODS.contains(elementValue.stringifyValue())) {
+                atLeastOneUnprotected = true;
+            } else {
+                atLeastOneProtected = true;
+            }
+            if (atLeastOneUnprotected && atLeastOneProtected) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -38,6 +38,7 @@
     <Detector class="com.h3xstream.findsecbugs.endpoint.Struts1EndpointDetector" reports="STRUTS1_ENDPOINT"/>
     <Detector class="com.h3xstream.findsecbugs.endpoint.Struts2EndpointDetector" reports="STRUTS2_ENDPOINT"/>
     <Detector class="com.h3xstream.findsecbugs.endpoint.SpringMvcEndpointDetector" reports="SPRING_ENDPOINT"/>
+    <Detector class="com.h3xstream.findsecbugs.csrf.SpringCsrfProtectionDisabledDetector" reports="SPRING_CSRF_PROTECTION_DISABLED"/>
     <Detector class="com.h3xstream.findsecbugs.injection.custom.CustomInjectionDetector" reports="CUSTOM_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.sql.SqlInjectionDetector" reports="SQL_INJECTION,SQL_INJECTION_TURBINE,SQL_INJECTION_HIBERNATE,SQL_INJECTION_JDO,SQL_INJECTION_JPA,SQL_INJECTION_JDBC,SQL_INJECTION_SPRING_JDBC,SCALA_SQL_INJECTION_SLICK,SCALA_SQL_INJECTION_ANORM"/>
     <Detector class="com.h3xstream.findsecbugs.injection.ldap.LdapInjectionDetector" reports="LDAP_INJECTION"/>
@@ -140,6 +141,7 @@
     <BugPattern type="STRUTS1_ENDPOINT" abbrev="SECSTR1" category="SECURITY"/>
     <BugPattern type="STRUTS2_ENDPOINT" abbrev="SECSTR2" category="SECURITY"/>
     <BugPattern type="SPRING_ENDPOINT" abbrev="SECSC" category="SECURITY"/>
+    <BugPattern type="SPRING_CSRF_PROTECTION_DISABLED" abbrev="SECSPRCSRFPD" category="SECURITY" cweid="352"/>
     <BugPattern type="CUSTOM_INJECTION" abbrev="SECCUSTOMI" category="SECURITY" cweid="74"/>
     <BugPattern type="SQL_INJECTION" abbrev="SECSQLIHIB" category="SECURITY" cweid="564"/>
     <BugPattern type="SQL_INJECTION_TURBINE" abbrev="SECSQLITU" category="SECURITY" cweid="564"/>

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -39,6 +39,7 @@
     <Detector class="com.h3xstream.findsecbugs.endpoint.Struts2EndpointDetector" reports="STRUTS2_ENDPOINT"/>
     <Detector class="com.h3xstream.findsecbugs.endpoint.SpringMvcEndpointDetector" reports="SPRING_ENDPOINT"/>
     <Detector class="com.h3xstream.findsecbugs.csrf.SpringCsrfProtectionDisabledDetector" reports="SPRING_CSRF_PROTECTION_DISABLED"/>
+    <Detector class="com.h3xstream.findsecbugs.csrf.SpringCsrfUnrestrictedRequestMappingDetector" reports="SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING"/>
     <Detector class="com.h3xstream.findsecbugs.injection.custom.CustomInjectionDetector" reports="CUSTOM_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.sql.SqlInjectionDetector" reports="SQL_INJECTION,SQL_INJECTION_TURBINE,SQL_INJECTION_HIBERNATE,SQL_INJECTION_JDO,SQL_INJECTION_JPA,SQL_INJECTION_JDBC,SQL_INJECTION_SPRING_JDBC,SCALA_SQL_INJECTION_SLICK,SCALA_SQL_INJECTION_ANORM"/>
     <Detector class="com.h3xstream.findsecbugs.injection.ldap.LdapInjectionDetector" reports="LDAP_INJECTION"/>
@@ -142,6 +143,7 @@
     <BugPattern type="STRUTS2_ENDPOINT" abbrev="SECSTR2" category="SECURITY"/>
     <BugPattern type="SPRING_ENDPOINT" abbrev="SECSC" category="SECURITY"/>
     <BugPattern type="SPRING_CSRF_PROTECTION_DISABLED" abbrev="SECSPRCSRFPD" category="SECURITY" cweid="352"/>
+    <BugPattern type="SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING" abbrev="SECSPRCSRFURM" category="SECURITY" cweid="352"/>
     <BugPattern type="CUSTOM_INJECTION" abbrev="SECCUSTOMI" category="SECURITY" cweid="74"/>
     <BugPattern type="SQL_INJECTION" abbrev="SECSQLIHIB" category="SECURITY" cweid="564"/>
     <BugPattern type="SQL_INJECTION_TURBINE" abbrev="SECSQLITU" category="SECURITY" cweid="564"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1566,6 +1566,43 @@ This class should be analyzed to make sure that remotely exposed methods are saf
     <BugCode abbrev="SECSC">Spring Endpoint</BugCode>
 
 
+    <!-- Spring CSRF Protection Disabled -->
+    <Detector class="com.h3xstream.findsecbugs.csrf.SpringCsrfProtectionDisabledDetector">
+        <Details>Detect the disabling of Spring CSRF protection</Details>
+    </Detector>
+
+    <BugPattern type="SPRING_CSRF_PROTECTION_DISABLED">
+        <ShortDescription>Spring CSRF protection disabled</ShortDescription>
+        <LongDescription>Disabling Spring Security's CSRF protection is unsafe for standard web applications</LongDescription>
+        <Details>
+            <![CDATA[
+<p>Disabling Spring Security's CSRF protection is unsafe for standard web applications.</p>
+<p>A valid use case for disabling this protection would be a service exposing state-changing operations
+that is guaranteed to be used only by non-browser clients.</p>
+<p>
+    <b>Insecure configuration:</b><br/>
+<pre>@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+    }
+}</pre>
+</p>
+<p>
+<b>References</b><br/>
+<a href="https://docs.spring.io/spring-security/site/docs/current/reference/html/csrf.html#when-to-use-csrf-protection">Spring Security Official Documentation: When to use CSRF protection</a><br/>
+<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29">OWASP: Cross-Site Request Forgery</a><br/>
+<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29_Prevention_Cheat_Sheet">OWASP: CSRF Prevention Cheat Sheet</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/352.html">CWE-352: Cross-Site Request Forgery (CSRF)</a>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSPRCSRFPD">Spring CSRF Protection Disabled</BugCode>
+
+
     <!-- Custom Injection -->
     <Detector class="com.h3xstream.findsecbugs.injection.custom.CustomInjectionDetector">
         <Details>Detector that find injection for custom methods.</Details>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1603,6 +1603,95 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     <BugCode abbrev="SECSPRCSRFPD">Spring CSRF Protection Disabled</BugCode>
 
 
+    <!-- Spring CSRF Unrestricted RequestMapping -->
+    <Detector class="com.h3xstream.findsecbugs.csrf.SpringCsrfUnrestrictedRequestMappingDetector">
+        <Details>Detect Spring CSRF unrestricted RequestMapping</Details>
+    </Detector>
+
+    <BugPattern type="SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING">
+        <ShortDescription>Spring CSRF unrestricted RequestMapping</ShortDescription>
+        <LongDescription>Unrestricted Spring's RequestMapping makes the method vulnerable to CSRF attacks</LongDescription>
+        <Details>
+            <![CDATA[
+<p>Methods annotated with <code>RequestMapping</code> are by default mapped to all the HTTP request methods.
+However, Spring Security's CSRF protection is not enabled by default
+for the HTTP request methods <code>GET</code>, <code>HEAD</code>, <code>TRACE</code>, and <code>OPTIONS</code>
+(as this could cause the tokens to be leaked).
+Therefore, state-changing methods annotated with <code>RequestMapping</code> and not narrowing the mapping
+to the HTTP request methods <code>POST</code>, <code>PUT</code>, <code>DELETE</code>, or <code>PATCH</code>
+are vulnerable to CSRF attacks.</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>@Controller
+public class UnsafeController {
+
+    @RequestMapping("/path")
+    public void writeData() {
+        // State-changing operations performed within this method.
+    }
+}</pre>
+</p>
+<p>
+    <b>Solution (Spring Framework 4.3 and later):</b><br/>
+<pre>@Controller
+public class SafeController {
+
+    /**
+     * For methods without side-effects use @GetMapping.
+     */
+    @GetMapping("/path")
+    public String readData() {
+        // No state-changing operations performed within this method.
+        return "";
+    }
+
+    /**
+     * For state-changing methods use either @PostMapping, @PutMapping, @DeleteMapping, or @PatchMapping.
+     */
+    @PostMapping("/path")
+    public void writeData() {
+        // State-changing operations performed within this method.
+    }
+}</pre>
+</p>
+<p>
+    <b>Solution (Before Spring Framework 4.3):</b><br/>
+<pre>@Controller
+public class SafeController {
+
+    /**
+     * For methods without side-effects use either
+     * RequestMethod.GET, RequestMethod.HEAD, RequestMethod.TRACE, or RequestMethod.OPTIONS.
+     */
+    @RequestMapping(value = "/path", method = RequestMethod.GET)
+    public String readData() {
+        // No state-changing operations performed within this method.
+        return "";
+    }
+
+    /**
+     * For state-changing methods use either
+     * RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, or RequestMethod.PATCH.
+     */
+    @RequestMapping(value = "/path", method = RequestMethod.POST)
+    public void writeData() {
+        // State-changing operations performed within this method.
+    }
+}</pre>
+</p>
+<p>
+<b>References</b><br/>
+<a href="https://docs.spring.io/spring-security/site/docs/current/reference/html/csrf.html#csrf-use-proper-verbs">Spring Security Official Documentation: Use proper HTTP verbs (CSRF protection)</a><br/>
+<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29">OWASP: Cross-Site Request Forgery</a><br/>
+<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29_Prevention_Cheat_Sheet">OWASP: CSRF Prevention Cheat Sheet</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/352.html">CWE-352: Cross-Site Request Forgery (CSRF)</a>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSPRCSRFURM">Spring CSRF Unrestricted RequestMapping</BugCode>
+
+
     <!-- Custom Injection -->
     <Detector class="com.h3xstream.findsecbugs.injection.custom.CustomInjectionDetector">
         <Details>Detector that find injection for custom methods.</Details>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/csrf/SpringCsrfProtectionDisabledDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/csrf/SpringCsrfProtectionDisabledDetectorTest.java
@@ -1,0 +1,46 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.csrf;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SpringCsrfProtectionDisabledDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectSpringCsrfProtectionDisabled() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/csrf/SpringCsrfProtectionDisabled")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_PROTECTION_DISABLED").build());
+    }
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/csrf/SpringCsrfUnrestrictedRequestMappingDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/csrf/SpringCsrfUnrestrictedRequestMappingDetectorTest.java
@@ -1,0 +1,82 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.csrf;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SpringCsrfUnrestrictedRequestMappingDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectSpringCsrfUnrestrictedRequestMapping() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/csrf/UnsafeSpringCsrfRequestMappingController")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").inMethod("requestMappingNoMethod").build());
+
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").inMethod("requestMappingEmptyMethod").build());
+
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").inMethod("requestMappingUnprotectedAndProtectedMethods").build());
+
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").inMethod("requestMappingUnprotectedAndProtectedUncommonMethods").build());
+
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").inMethod("requestMappingAllUnprotectedMethodsAndOneProtectedMethod").build());
+
+        verify(reporter).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").inMethod("requestMappingAllProtectedMethodsAndOneUnprotectedMethod").build());
+
+        verify(reporter, times(6)).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").build());
+    }
+
+    @Test
+    public void avoidFalsePositiveOnSafeSpringCsrfRequestMapping() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/csrf/SafeSpringCsrfRequestMappingController")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING").build());
+    }
+}

--- a/plugin/src/test/java/testcode/csrf/SafeSpringCsrfRequestMappingController.java
+++ b/plugin/src/test/java/testcode/csrf/SafeSpringCsrfRequestMappingController.java
@@ -1,0 +1,99 @@
+package testcode.csrf;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping("/test")
+public class SafeSpringCsrfRequestMappingController {
+
+    /**
+     * Mapping to the HTTP request method `GET` is safe as long as no state-changing operations are performed within this method.
+     */
+    @GetMapping("/get-mapping")
+    public void getMapping() {
+    }
+
+    @PostMapping("/post-mapping")
+    public void postMapping() {
+    }
+
+    @PutMapping("/put-mapping")
+    public void putMapping() {
+    }
+
+    @DeleteMapping("/delete-mapping")
+    public void deleteMapping() {
+    }
+
+    @PatchMapping("/patch-mapping")
+    public void patchMapping() {
+    }
+
+    /**
+     * Mapping to the HTTP request method `GET` is safe as long as no state-changing operations are performed within this method.
+     */
+    @RequestMapping(value = "/request-mapping-get", method = RequestMethod.GET)
+    public void requestMappingGet() {
+    }
+
+    /**
+     * Mapping to the HTTP request method `HEAD` is safe as long as no state-changing operations are performed within this method.
+     */
+    @RequestMapping(value = "/request-mapping-head", method = RequestMethod.HEAD)
+    public void requestMappingHead() {
+    }
+
+    /**
+     * Mapping to the HTTP request method `TRACE` is safe as long as no state-changing operations are performed within this method.
+     */
+    @RequestMapping(value = "/request-mapping-trace", method = RequestMethod.TRACE)
+    public void requestMappingTrace() {
+    }
+
+    /**
+     * Mapping to the HTTP request method `OPTIONS` is safe as long as no state-changing operations are performed within this method.
+     */
+    @RequestMapping(value = "/request-mapping-options", method = RequestMethod.OPTIONS)
+    public void requestMappingOptions() {
+    }
+
+    @RequestMapping(value = "/request-mapping-post", method = RequestMethod.POST)
+    public void requestMappingPost() {
+    }
+
+    @RequestMapping(value = "/request-mapping-put", method = RequestMethod.PUT)
+    public void requestMappingPut() {
+    }
+
+    @RequestMapping(value = "/request-mapping-delete", method = RequestMethod.DELETE)
+    public void requestMappingDelete() {
+    }
+
+    @RequestMapping(value = "/request-mapping-patch", method = RequestMethod.PATCH)
+    public void requestMappingPatch() {
+    }
+
+    /**
+     * Mapping to several HTTP request methods is fine as long as all the HTTP request methods used are unprotected.
+     */
+    @RequestMapping(value = "/request-mapping-several-unprotected-methods",
+            method = {RequestMethod.GET, RequestMethod.HEAD, RequestMethod.TRACE, RequestMethod.OPTIONS})
+    public void requestMappingSeveralUnprotectedMethods() {
+    }
+
+    /**
+     * Mapping to several HTTP request methods is fine as long as all the HTTP request methods used are protected.
+     */
+    @RequestMapping(value = "/request-mapping-several-protected-methods",
+            method = {RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, RequestMethod.PATCH})
+    public void requestMappingSeveralProtectedMethods() {
+    }
+
+}

--- a/plugin/src/test/java/testcode/csrf/SpringCsrfProtectionDisabled.java
+++ b/plugin/src/test/java/testcode/csrf/SpringCsrfProtectionDisabled.java
@@ -1,0 +1,14 @@
+package testcode.csrf;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class SpringCsrfProtectionDisabled extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+    }
+}

--- a/plugin/src/test/java/testcode/csrf/UnsafeSpringCsrfRequestMappingController.java
+++ b/plugin/src/test/java/testcode/csrf/UnsafeSpringCsrfRequestMappingController.java
@@ -1,0 +1,56 @@
+package testcode.csrf;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping("/test")
+public class UnsafeSpringCsrfRequestMappingController {
+
+    /**
+     * `RequestMapping` maps to all the HTTP request methods by default, making it vulnerable to CSRF attacks.
+     */
+    @RequestMapping("/request-mapping-no-method")
+    public void requestMappingNoMethod() {
+    }
+
+    /**
+     * The default value of the annotation attribute `method` is an empty array,
+     * so this boils down to the same thing as not specifying at all the annotation attribute `method`.
+     */
+    @RequestMapping(value = "request-mapping-method-empty", method = {})
+    public void requestMappingEmptyMethod() {
+    }
+
+    /**
+     * Mapping to several HTTP request methods is not OK if it's a mix of unprotected and protected HTTP request methods.
+     */
+    @RequestMapping(value = "/request-mapping-unprotected-and-protected-methods", method = {RequestMethod.GET, RequestMethod.POST})
+    public void requestMappingUnprotectedAndProtectedMethods() {
+    }
+
+    /**
+     * Mapping to several HTTP request methods is not OK if it's a mix of unprotected and protected HTTP request methods.
+     */
+    @RequestMapping(value = "/request-mapping-unprotected-and-protected-uncommon-methods", method = {RequestMethod.OPTIONS, RequestMethod.PATCH})
+    public void requestMappingUnprotectedAndProtectedUncommonMethods() {
+    }
+
+    /**
+     * Mapping to several HTTP request methods is not OK if it's a mix of unprotected and protected HTTP request methods.
+     */
+    @RequestMapping(value = "/request-mapping-all-unprotected-methods-and-one-protected-method",
+            method = {RequestMethod.GET, RequestMethod.HEAD, RequestMethod.TRACE, RequestMethod.OPTIONS, RequestMethod.PATCH})
+    public void requestMappingAllUnprotectedMethodsAndOneProtectedMethod() {
+    }
+
+    /**
+     * Mapping to several HTTP request methods is not OK if it's a mix of unprotected and protected HTTP request methods.
+     */
+    @RequestMapping(value = "/request-mapping-all-protected-methods-and-one-unprotected-method",
+            method = {RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, RequestMethod.PATCH, RequestMethod.OPTIONS})
+    public void requestMappingAllProtectedMethodsAndOneUnprotectedMethod() {
+    }
+
+}


### PR DESCRIPTION
This pull request includes 2 related detectors, each in a separated commit.

# SpringCsrfProtectionDisabledDetector

Recent versions of Spring Security protect *by default* Spring endpoints against CSRF attacks.
Since it does require some initial work from the developers on the client-side to make form submissions and/or AJAX requests work, it can be tempting to disable the CSRF protection temporarily in an initial development phase, with the risk of forgetting to re-enable it later on.

This detector detects the deactivation of Spring Security's CSRF protection via Spring JavaConfig.
It does not however detects the deactivation of CSRF protection via Spring XML config.

# SpringCsrfUnrestrictedRequestMappingDetector

Although it can be customized, out of the box Spring Security *doesn't* protect endpoints with the HTTP request methods `GET`, `HEAD`, `TRACE`, and `OPTIONS` against CSRF attacks.

It's very easy to use `@RequestMapping` and to forget to restrict it to only the needed HTTP request methods. If this happens for a state-changing method, then this method will be vulnerable to CSRF attacks as the `GET` method will be mapped.

This detector detects unrestricted `@RequestMapping`, as well as unlikely suspicious cases where a user would restrict a given mapping to a mix of unprotected HTTP request methods (e.g. `GET`) and protected HTTP request methods (e.g. `POST`).

# General Remarks

* I was not really sure of where to put the new rules in findbugs.xml and messages.xml (as I didn't find any consistent logical ordering).
* I chose to use high priorities for both detectors.
