### PR TITLE
Travis improvements: batch mode and verify phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ jdk:
   - oraclejdk8
 #Activate container based infra https://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
-install: mvn clean -V
-script: mvn test -V -Ptravisci
+install: mvn clean -B -V
+script: mvn verify -B -V -Ptravisci


### PR DESCRIPTION
Some improvements to the Travis build:
* Use Maven batch mode to avoid showing download progress in the logs (`3/20 KB... 9/20 KB... 18/20 KB...`) and to ensures that the build won't hang due to waiting for user input. [Travis uses this by default](https://docs.travis-ci.com/user/languages/java/#Projects-Using-Maven) and it's [recommended by Sonatype](http://blog.sonatype.com/2009/01/maven-continuous-integration-best-practices/).
* Use the Maven phase `verify` instead of the phase `test`, which is further in the [phases lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). This will make Travis check for the licenses headers, as the [license:check goal is attached to the verify phase by default](http://code.mycila.com/license-maven-plugin/#goals).
