### PR TITLE
Add JavaBeans Property Injection detector

### DIFF
--- a/plugin-deps/src/main/java/org/apache/commons/beanutils/BeanUtils.java
+++ b/plugin-deps/src/main/java/org/apache/commons/beanutils/BeanUtils.java
@@ -1,0 +1,10 @@
+package org.apache.commons.beanutils;
+
+import java.util.Map;
+
+public class BeanUtils {
+
+    public static void populate(Object bean, Map properties) {
+
+    }
+}

--- a/plugin-deps/src/main/java/org/apache/commons/beanutils/BeanUtilsBean.java
+++ b/plugin-deps/src/main/java/org/apache/commons/beanutils/BeanUtilsBean.java
@@ -1,0 +1,14 @@
+package org.apache.commons.beanutils;
+
+import java.util.Map;
+
+public class BeanUtilsBean {
+
+    public synchronized static BeanUtilsBean getInstance() {
+        return (BeanUtilsBean) null;
+    }
+
+    public void populate(Object bean, Map properties) {
+
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/beans/BeanInjectionDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/beans/BeanInjectionDetector.java
@@ -1,0 +1,29 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.beans;
+
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import edu.umd.cs.findbugs.BugReporter;
+
+public class BeanInjectionDetector extends BasicInjectionDetector {
+
+    public BeanInjectionDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        loadConfiguredSinks("beans.txt", "BEAN_PROPERTY_INJECTION");
+    }
+}

--- a/plugin/src/main/resources/injection-sinks/beans.txt
+++ b/plugin/src/main/resources/injection-sinks/beans.txt
@@ -1,0 +1,2 @@
+org/apache/commons/beanutils/BeanUtils.populate(Ljava/lang/Object;Ljava/util/Map;)V:0
+org/apache/commons/beanutils/BeanUtilsBean.populate(Ljava/lang/Object;Ljava/util/Map;)V:0

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -99,7 +99,9 @@
     <Detector class="com.h3xstream.findsecbugs.cookie.UrlRewritingDetector" reports="URL_REWRITING"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.InsecureSmtpSslDetector" reports="INSECURE_SMTP_SSL"/>
     <Detector class="com.h3xstream.findsecbugs.injection.aws.AwsQueryInjectionDetector" reports="AWS_QUERY_INJECTION"/>
+    <Detector class="com.h3xstream.findsecbugs.injection.beans.BeanInjectionDetector" reports="BEAN_PROPERTY_INJECTION"/>
 
+    <BugPattern type="BEAN_PROPERTY_INJECTION" abbrev="SECBPI" category="SECURITY"/>
     <BugPattern type="AWS_QUERY_INJECTION" abbrev="SECAQI" category="SECURITY"/>
     <BugPattern type="INSECURE_SMTP_SSL" abbrev="SECISC" category="SECURITY"/>
     <BugPattern type="URL_REWRITING" abbrev="SECURLR" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4784,4 +4784,44 @@ This issue is analogical to SQL Injection. Sanitize user input before using it i
     </BugPattern>
     <BugCode abbrev="SECAQI">AWS Query Injection</BugCode>
 
+
+    <!-- JavaBeans Property Injection -->
+    <Detector class="com.h3xstream.findsecbugs.injection.beans.BeanInjectionDetector">
+        <Details>Detect JavaBeans Property Injection
+        </Details>
+    </Detector>
+
+    <BugPattern type="BEAN_PROPERTY_INJECTION">
+        <ShortDescription>JavaBeans Property Injection</ShortDescription>
+        <LongDescription>JavaBeans property name populated with user controlled parameters</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+An attacker can set arbitrary bean properties that can compromise system integrity. Bean population functions allow to set a bean property or a nested property. An attacker can leverage this functionality to access special bean properties like class.classLoader that will allow him to override system properties and potentially execute arbitrary code.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>MyBean bean = ...;
+HashMap map = new HashMap();
+Enumeration names = request.getParameterNames();
+while (names.hasMoreElements()) {
+    String name = (String) names.nextElement();
+    map.put(name, request.getParameterValues(name));
+}
+BeanUtils.populate(bean, map);</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Avoid using user controlled values to populate Bean property names.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/15.html">CWE-15: External Control of System or Configuration Setting</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECBPI">JavaBeans Property Injection</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/beans/BeanInjectionDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/beans/BeanInjectionDetectorTest.java
@@ -1,0 +1,54 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.beans;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+import java.util.Arrays;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class BeanInjectionDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectBeanInjection() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/BeanInjection")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(23, 26)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("BEAN_PROPERTY_INJECTION")
+                            .inClass("BeanInjection").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter, times(2)).doReportBug(
+                bugDefinition().bugType("BEAN_PROPERTY_INJECTION").build()
+        );
+    }
+}

--- a/plugin/src/test/java/testcode/BeanInjection.java
+++ b/plugin/src/test/java/testcode/BeanInjection.java
@@ -1,0 +1,44 @@
+package testcode;
+
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils.BeanUtilsBean;
+import java.util.HashMap;
+import java.util.Enumeration;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServlet;
+
+public class BeanInjection extends HttpServlet{
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        User user = new User();
+        HashMap map = new HashMap();
+        Enumeration names = request.getParameterNames();
+        while (names.hasMoreElements()) {
+            String name = (String) names.nextElement();
+            map.put(name, request.getParameterValues(name));
+        }
+        try{
+            BeanUtils.populate(user, map); //BAD
+
+            BeanUtilsBean beanUtl = BeanUtilsBean.getInstance();
+            beanUtl.populate(user, map); //BAD
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+    }
+
+    private class User implements java.io.Serializable {
+
+        private String name;
+
+        public String getName(){
+            return this.name;
+        }
+        
+        public void setName(String name){
+            this.name = name;
+        }
+    }
+}


### PR DESCRIPTION
There are JavaBeans population methods designed for converting HTTP request parameters into a set of corresponding property setter calls on an arbitrary JavaBean. More info here:
https://commons.apache.org/proper/commons-beanutils/javadocs/v1.9.2/apidocs/org/apache/commons/beanutils/package-summary.html#conversion.beanutils
An attacker can leverage this functionality to access special bean properties like class.classLoader that will allow him to override system properties and potentially execute arbitrary code. Below is an example of a vulnerable code:

```java
MyBean bean = ...;
HashMap map = new HashMap();
Enumeration names = request.getParameterNames();
while (names.hasMoreElements()) {
    String name = (String) names.nextElement();
    map.put(name, request.getParameterValues(name));
}
BeanUtils.populate(bean, map); //reporting BeanUtils.populate() or BeanUtilsBean.populate()
```

Note: The proposed detector will report the above code based on the tainting of both HashMap.put() arguments coming from the request. However let me know if there is a way to customize the HashMap.put() taint so it only reports the "value" argument, which would be ideal in this situation.