### PR TITLE
Java source and target from 1.6 to 1.7 & API compatibility check

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -117,7 +117,33 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.2.0</version>
             </plugin>
-            
+
+            <!--
+              Verify that the sources of this module are API compatible
+              with the Java version officially used by FindBugs.
+              The test sources are not checked by this plugin
+              (see https://github.com/mojohaus/animal-sniffer/issues/5),
+              so more recent Java APIs can be used in the tests.
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.15</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java17</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
                     The current deployment process will fail.
                     (https://github.com/find-sec-bugs/find-sec-bugs/wiki/Compiling#release-process) -->
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
# Java source and target from 1.6 to 1.7

The sources of the module "findsecbugs-plugin" are using some Java 7 APIs (e.g. `Objects#requireNonNull`, `Objects#equals`, `Objects#hash`). We could easily get rid of them to maintain compatibility with Java 6. However, FindBugs 3.0.1 requires Java 7, and fb-contrib 6.8.2 requires FindBugs 3.0.1, so moving the minimum required version to Java 7 probably makes sense.

# Java 1.7 API compatibility check

Even though the plugin itself is compatible with Java 7, the project needs to be built with Java 8, as the *test* sources of the module "findsecbugs-plugin" are using some new Java 8 APIs (e.g. `String#join`, `Statement#executeLargeUpdate`, `java.util.function.Supplier`).

This introduces the risk that the *sources* of the module "findsecbugs-plugin" might end up using some Java 8 APIs by inadvertence. As documented in the [maven-compiler-plugin's documentation](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html):

> Merely setting the target option does not guarantee that your code actually runs on a JRE with the specified version. The pitfall is unintended usage of APIs that only exist in later JREs which would make your code fail at runtime with a linkage error.

Introducing the animal-sniffer plugin for the module "findsecbugs-plugin" makes sure that the sources "findsecbugs-plugin" will stay API-compatible with Java 7. Luckily, the animal-sniffer plugin doesn't [yet](https://github.com/mojohaus/animal-sniffer/issues/5) check the *test* sources, so it perfectly matches our use case.

# Remark

Maybe the README, the website, and/or the ["Compiling" wiki page](https://github.com/find-sec-bugs/find-sec-bugs/wiki/Compiling) should clarify the minimum requirements for using the plugin (Java 7 and FindBugs 3.0.1) and for development (Java 8 and FindBugs 3.0.1)?