### PR TITLE
Add File Disclosure Injection detector

### DIFF
--- a/plugin-deps/src/main/java/org/apache/struts/action/ActionForward.java
+++ b/plugin-deps/src/main/java/org/apache/struts/action/ActionForward.java
@@ -1,4 +1,23 @@
 package org.apache.struts.action;
 
-public interface ActionForward {
+public class ActionForward {
+
+    public ActionForward() {
+    }
+
+    public ActionForward(String path) {
+    }
+
+    public ActionForward(String path, boolean redirect) {
+    }
+
+    public ActionForward(String name, String path, boolean redirect) {
+    }
+
+    public ActionForward(String name, String path, boolean redirect,
+                         boolean contextRelative) {
+    }
+
+    public void setPath(String path) {
+    }
 }

--- a/plugin-deps/src/main/java/org/springframework/web/servlet/ModelAndView.java
+++ b/plugin-deps/src/main/java/org/springframework/web/servlet/ModelAndView.java
@@ -1,0 +1,21 @@
+package org.springframework.web.servlet;
+
+import java.util.Map;
+
+public class ModelAndView {
+
+	public ModelAndView() {
+	}
+
+	public ModelAndView(String viewName) {
+	}
+
+	public ModelAndView(String viewName, Map model) {
+	}
+
+	public ModelAndView(String viewName, String modelName, Object modelObject) {
+	}
+
+	public void setViewName(String viewName) {
+	}
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetector.java
@@ -1,0 +1,30 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.fileDisclosure;
+
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import edu.umd.cs.findbugs.BugReporter;
+
+public class FileDisclosureDetector extends BasicInjectionDetector {
+
+    public FileDisclosureDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        loadConfiguredSinks("spring-file-disclosure.txt", "SPRING_FILE_DISCLOSURE");
+        loadConfiguredSinks("struts-file-disclosure.txt", "STRUTS_FILE_DISCLOSURE");
+    }
+}

--- a/plugin/src/main/resources/injection-sinks/spring-file-disclosure.txt
+++ b/plugin/src/main/resources/injection-sinks/spring-file-disclosure.txt
@@ -1,0 +1,4 @@
+org/springframework/web/servlet/ModelAndView.<init>(Ljava/lang/String;)V:0
+org/springframework/web/servlet/ModelAndView.<init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V:2
+org/springframework/web/servlet/ModelAndView.<init>(Ljava/lang/String;Ljava/util/Map;)V:1
+org/springframework/web/servlet/ModelAndView.setViewName(Ljava/lang/String;)V:0

--- a/plugin/src/main/resources/injection-sinks/struts-file-disclosure.txt
+++ b/plugin/src/main/resources/injection-sinks/struts-file-disclosure.txt
@@ -1,0 +1,5 @@
+org/apache/struts/action/ActionForward.<init>(Ljava/lang/String;)V:0
+org/apache/struts/action/ActionForward.<init>(Ljava/lang/String;Z)V:1
+org/apache/struts/action/ActionForward.<init>(Ljava/lang/String;Ljava/lang/String;Z)V:1
+org/apache/struts/action/ActionForward.<init>(Ljava/lang/String;Ljava/lang/String;ZZ)V:2
+org/apache/struts/action/ActionForward.setPath(Ljava/lang/String;)V:0

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -100,7 +100,10 @@
     <Detector class="com.h3xstream.findsecbugs.crypto.InsecureSmtpSslDetector" reports="INSECURE_SMTP_SSL"/>
     <Detector class="com.h3xstream.findsecbugs.injection.aws.AwsQueryInjectionDetector" reports="AWS_QUERY_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.beans.BeanInjectionDetector" reports="BEAN_PROPERTY_INJECTION"/>
+    <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector" reports="STRUTS_FILE_DISCLOSURE,SPRING_FILE_DISCLOSURE"/>
 
+    <BugPattern type="SPRING_FILE_DISCLOSURE" abbrev="SECSF" category="SECURITY"/>
+    <BugPattern type="STRUTS_FILE_DISCLOSURE" abbrev="SECSFD" category="SECURITY"/>
     <BugPattern type="BEAN_PROPERTY_INJECTION" abbrev="SECBPI" category="SECURITY"/>
     <BugPattern type="AWS_QUERY_INJECTION" abbrev="SECAQI" category="SECURITY"/>
     <BugPattern type="INSECURE_SMTP_SSL" abbrev="SECISC" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4824,4 +4824,73 @@ Avoid using user controlled values to populate Bean property names.
     </BugPattern>
     <BugCode abbrev="SECBPI">JavaBeans Property Injection</BugCode>
 
+
+    <!-- Struts and Spring File Disclosure -->
+    <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector">
+        <Details>Detect Struts and Spring File Disclosure
+        </Details>
+    </Detector>
+    
+    <!-- Struts File Disclosure -->
+    <BugPattern type="STRUTS_FILE_DISCLOSURE">
+        <ShortDescription>Struts File Disclosure</ShortDescription>
+        <LongDescription>ActionForward populated with user controlled parameters</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Constructing a server-side redirect path with user input could allow an attacker to download application binaries (including application classes or jar files) or view arbitrary files within protected directories.<br/>
+An attacker may be able to forge a request parameter to match sensitive file locations. For example, requesting "http://example.com/?returnURL=WEB-INF/applicationContext.xml" would display the application's applicationContext.xml file. The attacker would be able to locate and download the applicationContext.xml referenced in the other configuration files, and even class files or jar files, obtaining sensitive information and launching other types of attacks.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>... 
+String returnURL = request.getParameter("returnURL"); 
+Return new ActionForward(returnURL); 
+...</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Avoid constructing server-side redirects using user controlled input.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/552.html">CWE-552: Files or Directories Accessible to External Parties</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSFD">Struts File Disclosure</BugCode>
+
+    <!-- Spring File Disclosure -->
+    <BugPattern type="SPRING_FILE_DISCLOSURE">
+        <ShortDescription>Spring File Disclosure</ShortDescription>
+        <LongDescription>ModelAndView populated with user controlled parameters</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Constructing a server-side redirect path with user input could allow an attacker to download application binaries (including application classes or jar files) or view arbitrary files within protected directories.<br/>
+An attacker may be able to forge a request parameter to match sensitive file locations. For example, requesting "http://example.com/?returnURL=WEB-INF/applicationContext.xml" would display the application's applicationContext.xml file. The attacker would be able to locate and download the applicationContext.xml referenced in the other configuration files, and even class files or jar files, obtaining sensitive information and launching other types of attacks.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>... 
+String returnURL = request.getParameter("returnURL");
+return new ModelAndView(returnURL); 
+...</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Avoid constructing server-side redirects using user controlled input.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/552.html">CWE-552: Files or Directories Accessible to External Parties</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSF">Spring File Disclosure</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetectorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.fileDisclosure;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+import java.util.Arrays;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class FileDisclosureDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectFileDisclosure() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/FileDisclosure")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(18, 20, 22, 24, 27)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("STRUTS_FILE_DISCLOSURE")
+                            .inClass("FileDisclosure").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+
+        for (Integer line : Arrays.asList(33, 35, 37, 40)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("SPRING_FILE_DISCLOSURE")
+                            .inClass("FileDisclosure").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+
+        //Out of 6 Struts ActionForward calls, 5 are suspicious
+        verify(reporter, times(5)).doReportBug(
+                bugDefinition().bugType("STRUTS_FILE_DISCLOSURE").build()
+        );
+
+        //Out of 5 Spring ModelAndView calls, 4 are suspicious
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition().bugType("SPRING_FILE_DISCLOSURE").build()
+        );
+    }
+
+}

--- a/plugin/src/test/java/testcode/FileDisclosure.java
+++ b/plugin/src/test/java/testcode/FileDisclosure.java
@@ -1,0 +1,49 @@
+package testcode;
+
+import java.io.IOException;
+import org.apache.struts.action.ActionForward;
+import org.springframework.web.servlet.ModelAndView;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+
+public class FileDisclosure extends HttpServlet{
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        try{
+            String returnURL = request.getParameter("returnURL");
+            
+            /******Struts ActionForward vulnerable code tests******/
+            ActionForward forward = new ActionForward(returnURL); //BAD
+
+            ActionForward forward2 = new ActionForward(returnURL, true); //BAD
+
+            ActionForward forward3 = new ActionForward("name", returnURL, true); //BAD
+
+            ActionForward forward4 = new ActionForward("name", returnURL, true, true); //BAD
+
+            ActionForward forward5 = new ActionForward();
+            forward5.setPath(returnURL); //BAD
+
+            //false positive test - returnURL moved from path to name (safe argument)
+            ActionForward forward6 = new ActionForward(returnURL, "path", true); //OK
+            
+            /******Spring ModelAndView vulnerable code tests******/
+            ModelAndView mv = new ModelAndView(returnURL); //BAD
+                       
+            ModelAndView mv2 = new ModelAndView(returnURL, new HashMap()); //BAD
+
+            ModelAndView mv3 = new ModelAndView(returnURL, "modelName", new Object()); //BAD
+
+            ModelAndView mv4 = new ModelAndView();
+            mv4.setViewName(returnURL); //BAD
+            
+            //false positive test - returnURL moved from viewName to modelName (safe argument)
+            ModelAndView mv5 = new ModelAndView("viewName", returnURL, new Object()); //OK
+
+        }catch(Exception e){
+         System.out.println(e);
+       }
+    }
+}


### PR DESCRIPTION
Proposed detector reports code utilizing ActionForward (Struts) or ModelAndView (Spring) to construct a server-side redirect path with user input. This may allow an attacker to view sensitive files or download application binaries.
Vulnerable code sample:
```java
... 
String returnURL = request.getParameter("returnURL");
return new ModelAndView(returnURL); 
```
or
```java
... 
String returnURL = request.getParameter("returnURL"); 
Return new ActionForward(returnURL);
```