### PR TITLE
Add Format String Manipulation Injection Detector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/formatter/FormatStringManipulationDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/formatter/FormatStringManipulationDetector.java
@@ -1,0 +1,44 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.formatter;
+
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+
+public class FormatStringManipulationDetector extends BasicInjectionDetector {
+
+    public FormatStringManipulationDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        loadConfiguredSinks("formatter.txt", "FORMAT_STRING_MANIPULATION");
+    }
+
+    @Override
+    protected int getPriority(Taint taint) {
+        if (taint.isTainted()) {
+            return Priorities.NORMAL_PRIORITY;
+        }
+        else if (!taint.isSafe()) {
+            return Priorities.LOW_PRIORITY;
+        }
+        else {
+            return Priorities.IGNORE_PRIORITY;
+        }
+    }
+}

--- a/plugin/src/main/resources/injection-sinks/formatter.txt
+++ b/plugin/src/main/resources/injection-sinks/formatter.txt
@@ -1,0 +1,11 @@
+java/util/Formatter.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/Formatter;:1
+java/util/Formatter.format(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/Formatter;:1
+
+java/io/PrintStream.printf(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;:1
+java/io/PrintStream.printf(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;:1
+
+java/io/PrintStream.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;:1
+java/io/PrintStream.format(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;:1
+
+java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;:1
+java/lang/String.format(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;:1

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -101,7 +101,9 @@
     <Detector class="com.h3xstream.findsecbugs.injection.aws.AwsQueryInjectionDetector" reports="AWS_QUERY_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.beans.BeanInjectionDetector" reports="BEAN_PROPERTY_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector" reports="STRUTS_FILE_DISCLOSURE,SPRING_FILE_DISCLOSURE"/>
+    <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector" reports="FORMAT_STRING_MANIPULATION"/>
 
+    <BugPattern type="FORMAT_STRING_MANIPULATION" abbrev="SECFSM" category="SECURITY"/>
     <BugPattern type="SPRING_FILE_DISCLOSURE" abbrev="SECSF" category="SECURITY"/>
     <BugPattern type="STRUTS_FILE_DISCLOSURE" abbrev="SECSFD" category="SECURITY"/>
     <BugPattern type="BEAN_PROPERTY_INJECTION" abbrev="SECBPI" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4893,4 +4893,41 @@ Avoid constructing server-side redirects using user controlled input.
     </BugPattern>
     <BugCode abbrev="SECSF">Spring File Disclosure</BugCode>
 
+
+    <!-- Format String Manipulation -->
+    <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector">
+        <Details>Detect user input in format string argument.
+        </Details>
+    </Detector>
+
+    <BugPattern type="FORMAT_STRING_MANIPULATION">
+        <ShortDescription>Format String Manipulation</ShortDescription>
+        <LongDescription>Format string argument allowing user controlled parameters</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Allowing user input to control format parameters could enable an attacker to cause exceptions to be thrown or leak information.<br/>
+Attackers may be able to modify the format string argument, such that an exception is thrown. If this exception is left uncaught, it may crash the application. Alternatively, if sensitive information is used within the unused arguments, attackers may change the format string to reveal this information.<br/>
+The example code below lets the user specify the decimal points to which it shows the balance. The user can in fact specify anything causing an exception to be thrown which could lead to application failure. Even more critical within this example, if an attacker can specify the user input "2f %3$s %4$.2", the format string would be "The customer: %s %s has the balance %4$.2f %3$s %4$.2". This would then lead to the sensitive accountNo to be included within the resulting string.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>Formatter formatter = new Formatter(Locale.US);
+String format = "The customer: %s %s has the balance %4$." + userInput + "f";
+formatter.format(format, firstName, lastName, accountNo, balance);</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Avoid using user controlled values in the format string argument.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="http://cwe.mitre.org/data/definitions/134.html">CWE-134: Use of Externally-Controlled Format String</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECFSM">Format String Manipulation</BugCode>
+
 </MessageCollection>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/formatter/FormatStringManipulationDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/formatter/FormatStringManipulationDetectorTest.java
@@ -1,0 +1,56 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.formatter;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+import java.util.Arrays;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class FormatStringManipulationDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectFormatStringManipulation() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/FormatStringManipulation")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(20, 21, 25, 26, 28, 29, 31, 32)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("FORMAT_STRING_MANIPULATION")
+                            .inClass("FormatStringManipulation").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+
+        //Out of 9 calls, 8 are suspicious
+        verify(reporter, times(8)).doReportBug(
+                bugDefinition().bugType("FORMAT_STRING_MANIPULATION").build()
+        );
+    }
+
+}

--- a/plugin/src/test/java/testcode/FormatStringManipulation.java
+++ b/plugin/src/test/java/testcode/FormatStringManipulation.java
@@ -1,0 +1,35 @@
+package testcode;
+
+import java.util.Formatter;
+import java.util.Locale;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServlet;
+
+public class FormatStringManipulation extends HttpServlet{
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+
+    // create a new formatter
+    StringBuffer buffer = new StringBuffer();
+    Formatter formatter = new Formatter(buffer, Locale.US);
+    String format = "The customer: %s %s" + request.getParameter("suffix");
+
+    //test cases
+    formatter.format(format, "John", "Smith", "Jr"); //BAD
+    formatter.format(Locale.US, format, "John", "Smith"); //BAD
+    //false positive test
+    formatter.format("The customer: %s %s", "John", request.getParameter("testParam")); //OK
+    
+    System.out.printf(format, "John", "Smith"); //BAD
+    System.out.printf(Locale.US, format, "John", "Smith"); //BAD
+
+    System.out.format(format, "John", "Smith"); //BAD
+    System.out.format(Locale.US, format, "John", "Smith"); //BAD
+
+    String.format(format, "John", "Smith"); //BAD
+    String.format(Locale.US, format, "John", "Smith"); //BAD
+
+    }
+}


### PR DESCRIPTION
Proposed detector reports format string argument allowing user controlled parameters like so:
```java
...
+String format = "The customer: %s %s has the balance %4$." + userInput + "f";
+formatter.format(format, firstName, lastName, accountNo, balance);
```
Allowing user input to control format parameters could enable an attacker to leak information or cause exceptions to be thrown which could lead to application failure.

Affected APIs:
java/util/Formatter.format
java/io/PrintStream.printf
java/io/PrintStream.format
java/lang/String.format