### PR TITLE
Add HTTP Parameter Pollution Injection Detector

### DIFF
--- a/plugin-deps/src/main/java/org/apache/commons/httpclient/methods/GetMethod.java
+++ b/plugin-deps/src/main/java/org/apache/commons/httpclient/methods/GetMethod.java
@@ -1,0 +1,13 @@
+package org.apache.commons.httpclient.methods;
+
+public class GetMethod {
+
+    public GetMethod() {
+    }
+
+    public GetMethod(String uri) {
+    }
+
+    public void setQueryString(String queryString) {
+    }
+}

--- a/plugin-deps/src/main/java/org/apache/http/client/methods/HttpGet.java
+++ b/plugin-deps/src/main/java/org/apache/http/client/methods/HttpGet.java
@@ -1,0 +1,7 @@
+package org.apache.http.client.methods;
+
+public class HttpGet {
+
+    public HttpGet(final String uri) {
+    }   
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/http/HttpParameterPollutionDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/http/HttpParameterPollutionDetector.java
@@ -1,0 +1,40 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.http;
+
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+
+public class HttpParameterPollutionDetector extends BasicInjectionDetector {
+
+    public HttpParameterPollutionDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        loadConfiguredSinks("http-parameter-pollution.txt", "HTTP_PARAMETER_POLLUTION");
+    }
+
+    @Override
+    protected int getPriority(Taint taint) {
+        if (!taint.isSafe() && taint.hasTag(Taint.Tag.HTTP_POLLUTION_SAFE)) {
+            return Priorities.IGNORE_PRIORITY;
+        } else {
+            return super.getPriority(taint);
+        }
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -92,6 +92,7 @@ public class Taint {
         COMMAND_INJECTION_SAFE,
         LDAP_INJECTION_SAFE,
         XPATH_INJECTION_SAFE,
+        HTTP_POLLUTION_SAFE,
         CR_ENCODED,
         LF_ENCODED,
         QUOTE_ENCODED,

--- a/plugin/src/main/resources/injection-sinks/http-parameter-pollution.txt
+++ b/plugin/src/main/resources/injection-sinks/http-parameter-pollution.txt
@@ -1,0 +1,4 @@
+org/apache/commons/httpclient/methods/GetMethod.<init>(Ljava/lang/String;)V:0
+org/apache/commons/httpclient/methods/GetMethod.setQueryString(Ljava/lang/String;)V:0
+
+org/apache/http/client/methods/HttpGet.<init>(Ljava/lang/String;)V:0

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -102,7 +102,9 @@
     <Detector class="com.h3xstream.findsecbugs.injection.beans.BeanInjectionDetector" reports="BEAN_PROPERTY_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector" reports="STRUTS_FILE_DISCLOSURE,SPRING_FILE_DISCLOSURE"/>
     <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector" reports="FORMAT_STRING_MANIPULATION"/>
+    <Detector class="com.h3xstream.findsecbugs.injection.http.HttpParameterPollutionDetector" reports="HTTP_PARAMETER_POLLUTION"/>
 
+    <BugPattern type="HTTP_PARAMETER_POLLUTION" abbrev="SECHPP" category="SECURITY"/>
     <BugPattern type="FORMAT_STRING_MANIPULATION" abbrev="SECFSM" category="SECURITY"/>
     <BugPattern type="SPRING_FILE_DISCLOSURE" abbrev="SECSF" category="SECURITY"/>
     <BugPattern type="STRUTS_FILE_DISCLOSURE" abbrev="SECSFD" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4930,4 +4930,40 @@ Avoid using user controlled values in the format string argument.
     </BugPattern>
     <BugCode abbrev="SECFSM">Format String Manipulation</BugCode>
 
+
+    <!-- HTTP Parameter Pollution -->
+    <Detector class="com.h3xstream.findsecbugs.injection.http.HttpParameterPollutionDetector">
+        <Details>Detect concatenating user-controlled input into a URL.
+        </Details>
+    </Detector>
+
+    <BugPattern type="HTTP_PARAMETER_POLLUTION">
+        <ShortDescription>HTTP Parameter Pollution</ShortDescription>
+        <LongDescription>Concatenating user-controlled input into a URL</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Concatenating unvalidated user input into a URL can allow an attacker to override the value of a request parameter. Attacker may be able to override existing parameter values, inject a new parameter or exploit variables out of a direct reach. HTTP Parameter Pollution (HPP) attacks consist of injecting encoded query string delimiters into other existing parameters. If a web application does not properly sanitize the user input, a malicious user may compromise the logic of the application to perform either client-side or server-side attacks.<br/>
+In the following example the programmer has not considered the possibility that an attacker could provide a lang such as en&user_id=1, which would enable him to change the user_id at will.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>String lang = request.getParameter("lang");
+GetMethod get = new GetMethod("http://www.host.com");
+get.setQueryString("lang=" + lang + "&user_id=" + user_id);
+get.execute();</pre>
+<p>
+    <b>Solution:</b><br/>
+Sanitize user input before using it in HTTP parameters.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://capec.mitre.org/data/definitions/460.html">CAPEC-460: HTTP Parameter Pollution (HPP)</a>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECHPP">HTTP Parameter Pollution</BugCode>
+
 </MessageCollection>

--- a/plugin/src/main/resources/safe-encoders/other.txt
+++ b/plugin/src/main/resources/safe-encoders/other.txt
@@ -1,7 +1,7 @@
-java/net/URLEncoder.encode(Ljava/lang/String;)Ljava/lang/String;:0|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE
-java/net/URLEncoder.encode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE
-java/net/URLDecoder.decode(Ljava/lang/String;)Ljava/lang/String;:0|-CR_ENCODED,-LF_ENCODED,-XSS_SAFE
-java/net/URLDecoder.decode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1|-CR_ENCODED,-LF_ENCODED,-XSS_SAFE
+java/net/URLEncoder.encode(Ljava/lang/String;)Ljava/lang/String;:0|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE,+HTTP_POLLUTION_SAFE
+java/net/URLEncoder.encode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE,+HTTP_POLLUTION_SAFE
+java/net/URLDecoder.decode(Ljava/lang/String;)Ljava/lang/String;:0|-CR_ENCODED,-LF_ENCODED,-XSS_SAFE,-HTTP_POLLUTION_SAFE
+java/net/URLDecoder.decode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:1|-CR_ENCODED,-LF_ENCODED,-XSS_SAFE,-HTTP_POLLUTION_SAFE
 
 
 --Spring Framework

--- a/plugin/src/main/resources/safe-encoders/owasp.txt
+++ b/plugin/src/main/resources/safe-encoders/owasp.txt
@@ -33,7 +33,7 @@ org/owasp/encoder/Encode.forJavaScriptAttribute(Ljava/lang/String;)Ljava/lang/St
 org/owasp/encoder/Encode.forJavaScriptBlock(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/owasp/encoder/Encode.forJavaScriptSource(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE
 org/owasp/encoder/Encode.forUri(Ljava/lang/String;)Ljava/lang/String;:0|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE
-org/owasp/encoder/Encode.forUriComponent(Ljava/lang/String;)Ljava/lang/String;:0|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE
+org/owasp/encoder/Encode.forUriComponent(Ljava/lang/String;)Ljava/lang/String;:0|+CR_ENCODED,+LF_ENCODED,+XSS_SAFE,+HTTP_POLLUTION_SAFE
 org/owasp/encoder/Encode.forXml(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE,+XPATH_INJECTION_SAFE
 org/owasp/encoder/Encode.forXmlAttribute(Ljava/lang/String;)Ljava/lang/String;:0|+XSS_SAFE,+XPATH_INJECTION_SAFE
 org/owasp/encoder/Encode.forXmlComment(Ljava/lang/String;)Ljava/lang/String;:0

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/http/HttpParameterPollutionDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/http/HttpParameterPollutionDetectorTest.java
@@ -1,0 +1,56 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.http;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+import java.util.Arrays;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class HttpParameterPollutionDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectHttpParameterPollution() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/HttpParameterPollution")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(19, 21, 22)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("HTTP_PARAMETER_POLLUTION")
+                            .inClass("HttpParameterPollution").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+
+        //Out of 4 calls, 3 are suspicious
+        verify(reporter, times(3)).doReportBug(
+                bugDefinition().bugType("HTTP_PARAMETER_POLLUTION").build()
+        );
+    }
+
+}

--- a/plugin/src/test/java/testcode/HttpParameterPollution.java
+++ b/plugin/src/test/java/testcode/HttpParameterPollution.java
@@ -1,0 +1,29 @@
+package testcode;
+
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.client.methods.HttpGet;
+import java.io.IOException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
+
+public class HttpParameterPollution extends HttpServlet{
+
+   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+       try{
+           String item = request.getParameter("item");
+           
+           //in HttpClient 4.x, there is no GetMethod anymore. Instead there is HttpGet
+           HttpGet httpget = new HttpGet("http://host.com?param=" + URLEncoder.encode(item)); //OK
+           HttpGet httpget2 = new HttpGet("http://host.com?param=" + item); //BAD
+           
+           GetMethod get = new GetMethod("http://host.com?param=" + item); //BAD
+           get.setQueryString("item=" + item); //BAD
+           //get.execute();
+
+       }catch(Exception e){
+         System.out.println(e);
+       }
+   }
+}


### PR DESCRIPTION
Proposed detector reports HTTP Parameter Pollution (HPP), an attack that consist of injecting query string delimiters into other existing parameters. If a web application does not properly sanitize user input, a malicious user may compromise the logic of the application..
In the following example the attacker could provide a lang such as en&user_id=1, which would enable him to change the user_id at will.
```java
String lang = request.getParameter("lang");
+GetMethod get = new GetMethod("http://www.host.com");
+get.setQueryString("lang=" + lang + "&user_id=" + user_id);
+get.execute();
```