### PR TITLE
Spring Unvalidated Redirect Detector

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetector.java
@@ -1,0 +1,107 @@
+package com.h3xstream.findsecbugs.spring;
+
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.Location;
+import org.apache.bcel.classfile.AnnotationEntry;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEVIRTUAL;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.LDC;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class SpringUnvalidatedRedirectDetector implements Detector {
+    private static final String SPRING_UNVALIDATED_REDIRECT_TYPE = "SPRING_UNVALIDATED_REDIRECT";
+    private static final List<String> REQUEST_MAPPING_ANNOTATION_TYPES = Arrays.asList(
+            "Lorg/springframework/web/bind/annotation/RequestMapping;", //
+            "Lorg/springframework/web/bind/annotation/GetMapping;", //
+            "Lorg/springframework/web/bind/annotation/PostMapping;", //
+            "Lorg/springframework/web/bind/annotation/PutMapping;", //
+            "Lorg/springframework/web/bind/annotation/DeleteMapping;", //
+            "Lorg/springframework/web/bind/annotation/PatchMapping;");
+
+    private BugReporter reporter;
+
+    public SpringUnvalidatedRedirectDetector(BugReporter bugReporter) {
+        this.reporter = bugReporter;
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        JavaClass clazz = classContext.getJavaClass();
+
+        if (hasRequestMapping(clazz)) {
+            Method[] methods = clazz.getMethods();
+            for (Method m: methods) {
+
+                try {
+                    analyzeMethod(m, classContext);
+                } catch (CFGBuilderException e){
+                }
+            }
+        }
+    }
+
+    private boolean hasRequestMapping(JavaClass clazz) {
+        Method[] methods = clazz.getMethods();
+        for (Method m: methods) {
+            AnnotationEntry[] annotations = m.getAnnotationEntries();
+
+            for (AnnotationEntry ae: annotations) {
+                if (REQUEST_MAPPING_ANNOTATION_TYPES.contains(ae.getAnnotationType())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException{
+        JavaClass clazz = classContext.getJavaClass();
+        ConstantPoolGen cpg = classContext.getConstantPoolGen();
+        CFG cfg = classContext.getCFG(m);
+
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext(); ) {
+            Location loc = i.next();
+            Instruction inst = loc.getHandle().getInstruction();
+
+            if (inst instanceof INVOKEVIRTUAL) {
+                INVOKEVIRTUAL invoke = (INVOKEVIRTUAL)inst;
+                if( "java.lang.StringBuilder".equals(invoke.getClassName(cpg)) && "append".equals(invoke.getMethodName(cpg))) {
+                    Instruction prev = loc.getHandle().getPrev().getInstruction();
+
+                    if (prev instanceof LDC) {
+                        LDC ldc = (LDC)prev;
+                        Object value = ldc.getValue(cpg);
+
+                        if (value instanceof String) {
+                            String v = (String)value;
+
+                            if ("redirect:".equals(v)) {
+                                BugInstance bug = new BugInstance(this, SPRING_UNVALIDATED_REDIRECT_TYPE, Priorities.NORMAL_PRIORITY);
+                                bug.addClass(clazz).addMethod(clazz,m).addSourceLine(classContext,m,loc);
+                                reporter.reportBug(bug);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetector.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.spring;
 
 

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -105,6 +105,7 @@
     <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector" reports="STRUTS_FILE_DISCLOSURE,SPRING_FILE_DISCLOSURE"/>
     <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector" reports="FORMAT_STRING_MANIPULATION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.http.HttpParameterPollutionDetector" reports="HTTP_PARAMETER_POLLUTION"/>
+    <Detector class="com.h3xstream.findsecbugs.spring.SpringUnvalidatedRedirectDetector" reports="SPRING_UNVALIDATED_REDIRECT"/>
 
     <BugPattern type="HTTP_PARAMETER_POLLUTION" abbrev="SECHPP" category="SECURITY"/>
     <BugPattern type="FORMAT_STRING_MANIPULATION" abbrev="SECFSM" category="SECURITY"/>
@@ -186,6 +187,7 @@
     <BugPattern type="BLOWFISH_KEY_SIZE" abbrev="SECBKS" category="SECURITY" cweid="326"/>
     <BugPattern type="UNVALIDATED_REDIRECT" abbrev="SECUR" category="SECURITY" cweid="601"/>
     <BugPattern type="PLAY_UNVALIDATED_REDIRECT" abbrev="SECPUR" category="SECURITY" cweid="601"/>
+    <BugPattern type="SPRING_UNVALIDATED_REDIRECT" abbrev="SECSUR" category="SECURITY" cweid="601"/>
     <BugPattern type="XSS_JSP_PRINT" abbrev="SECXSS1" category="SECURITY" cweid="79"/>
     <BugPattern type="JSP_INCLUDE" abbrev="SECJSPINC" category="SECURITY" cweid="98"/>
     <BugPattern type="JSP_SPRING_EVAL" abbrev="SECJSPSPRING" category="SECURITY" cweid="917"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -3067,6 +3067,10 @@ keyGen.initialize(2048);
         <Details>Identify unvalidated redirects with Play Framework (Scala)</Details>
     </Detector>
 
+    <Detector class="com.h3xstream.findsecbugs.spring.SpringUnvalidatedRedirectDetector">
+        <Details>Identify unvalidated redirects with Spring Framework</Details>
+    </Detector>
+
     <BugPattern type="UNVALIDATED_REDIRECT">
         <ShortDescription>Unvalidated Redirect</ShortDescription>
         <LongDescription>The following redirection could be use by an attacker to redirect users to a fishing website.</LongDescription>
@@ -3165,6 +3169,57 @@ keyGen.initialize(2048);
         </Details>
     </BugPattern>
     <BugCode abbrev="SECPUR">Unvalidated Redirect (Play Framewok)</BugCode>
+
+    <BugPattern type="SPRING_UNVALIDATED_REDIRECT">
+        <ShortDescription>Spring Unvalidated Redirect</ShortDescription>
+        <LongDescription>The following redirection could be use by an attacker to redirect users to a fishing website.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+    Unvalidated redirects occur when an application redirects a user to a destination URL specified by a user supplied
+    parameter that is not validated. Such vulnerabilities can be used to facilitate phishing attacks.
+</p>
+<p>
+    <b>Scenario</b><br/>
+    1. A user is tricked into visiting the malicious URL: <code>http://website.com/login?redirect=http://evil.vvebsite.com/fake/login</code><br/>
+    2. The user is redirected to a fake login page that looks like a site they trust. (<code>http://evil.vvebsite.com/fake/login</code>)<br/>
+    3. The user enters his credentials.<br/>
+    4. The evil site steals the user's credentials and redirects him to the original website.<br/>
+    <br/>
+    This attack is plausible because most users don't double check the URL after the redirection. Also, redirection to
+    an authentication page is very common.
+</p>
+<p>
+    <b>Vulnerable Code:</b></br/>
+    <pre>@RequestMapping("/redirect")
+    public String redirect(@RequestParam("url") String url) {
+    [...]
+    return "redirect:" + url;
+    }
+</pre>
+</p>
+<p>
+    <b>Solution/Countermeasures:</b><br/>
+    <ul>
+        <li>Don't accept redirection destinations from users</li>
+        <li>Accept a destination key, and use it to look up the target (legal) destination</li>
+        <li>Accept only relative paths</li>
+        <li>White list URLs (if possible)</li>
+        <li>Validate that the beginning of the URL is part of a white list</li>
+    </ul>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="http://projects.webappsec.org/w/page/13246981/URL%20Redirector%20Abuse">WASC-38: URL Redirector Abuse</a><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2013-A10-Unvalidated_Redirects_and_Forwards">OWASP: Top 10 2013-A10: Unvalidated Redirects and Forwards</a><br/>
+<a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">OWASP: Unvalidated Redirects and Forwards Cheat Sheet</a><br/>
+<a href="http://cwe.mitre.org/data/definitions/601.html">CWE-601: URL Redirection to Untrusted Site ('Open Redirect')</a>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSUR">Spring Unvalidated Redirect</BugCode>
 
 
     <!-- JSP Include -->

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -3192,11 +3192,10 @@ keyGen.initialize(2048);
 <p>
     <b>Vulnerable Code:</b></br/>
     <pre>@RequestMapping("/redirect")
-    public String redirect(@RequestParam("url") String url) {
+public String redirect(@RequestParam("url") String url) {
     [...]
     return "redirect:" + url;
-    }
-</pre>
+}</pre>
 </p>
 <p>
     <b>Solution/Countermeasures:</b><br/>

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetectorTest.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.spring;
 
 
@@ -27,7 +44,7 @@ public class SpringUnvalidatedRedirectDetectorTest extends BaseDetectorTest {
                         .bugType("SPRING_UNVALIDATED_REDIRECT")
                         .inClass("SpringUnvalidatedRedirectController")
                         .inMethod("redirect1")
-                        .atLine(12)
+                        .atLine(13)
                         .build()
         );
 
@@ -36,7 +53,7 @@ public class SpringUnvalidatedRedirectDetectorTest extends BaseDetectorTest {
                         .bugType("SPRING_UNVALIDATED_REDIRECT")
                         .inClass("SpringUnvalidatedRedirectController")
                         .inMethod("redirect2")
-                        .atLine(17)
+                        .atLine(18)
                         .build()
         );
 
@@ -45,7 +62,25 @@ public class SpringUnvalidatedRedirectDetectorTest extends BaseDetectorTest {
                         .bugType("SPRING_UNVALIDATED_REDIRECT")
                         .inClass("SpringUnvalidatedRedirectController")
                         .inMethod("buildRedirect")
-                        .atLine(27)
+                        .atLine(28)
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SPRING_UNVALIDATED_REDIRECT")
+                        .inClass("SpringUnvalidatedRedirectController")
+                        .inMethod("redirect4")
+                        .atLine(33)
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SPRING_UNVALIDATED_REDIRECT")
+                        .inClass("SpringUnvalidatedRedirectController")
+                        .inMethod("redirect5")
+                        .atLine(38)
                         .build()
         );
     }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringUnvalidatedRedirectDetectorTest.java
@@ -1,0 +1,52 @@
+package com.h3xstream.findsecbugs.spring;
+
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class SpringUnvalidatedRedirectDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectSpringUnvalidatedRedirect() throws Exception {
+        //Locate test code
+        String[] files = {
+          getClassFilePath("testcode/spring/SpringUnvalidatedRedirectController")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SPRING_UNVALIDATED_REDIRECT")
+                        .inClass("SpringUnvalidatedRedirectController")
+                        .inMethod("redirect1")
+                        .atLine(12)
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SPRING_UNVALIDATED_REDIRECT")
+                        .inClass("SpringUnvalidatedRedirectController")
+                        .inMethod("redirect2")
+                        .atLine(17)
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SPRING_UNVALIDATED_REDIRECT")
+                        .inClass("SpringUnvalidatedRedirectController")
+                        .inMethod("buildRedirect")
+                        .atLine(27)
+                        .build()
+        );
+    }
+}

--- a/plugin/src/test/java/testcode/spring/SpringUnvalidatedRedirectController.java
+++ b/plugin/src/test/java/testcode/spring/SpringUnvalidatedRedirectController.java
@@ -3,6 +3,7 @@ package testcode.spring;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 public class SpringUnvalidatedRedirectController {
@@ -14,8 +15,8 @@ public class SpringUnvalidatedRedirectController {
 
     @RequestMapping("/redirect2")
     public String redirect2(@RequestParam("url") String url) {
-        String val = "redirect:" + url;
-        return val;
+        String view = "redirect:" + url;
+        return view;
     }
 
     @RequestMapping("/redirect3")
@@ -25,6 +26,17 @@ public class SpringUnvalidatedRedirectController {
 
     private String buildRedirect(String u) {
         return "redirect:" + u;
+    }
+
+    @RequestMapping("/redirect4")
+    public ModelAndView redirect4(@RequestParam("url") String url) {
+        return new ModelAndView("redirect:" + url);
+    }
+
+    @RequestMapping("/redirect5")
+    public ModelAndView redirect5(@RequestParam("url") String url) {
+        String view = "redirect:" + url;
+        return new ModelAndView(view);
     }
 
     @RequestMapping("/redirectfp")

--- a/plugin/src/test/java/testcode/spring/SpringUnvalidatedRedirectController.java
+++ b/plugin/src/test/java/testcode/spring/SpringUnvalidatedRedirectController.java
@@ -1,0 +1,34 @@
+package testcode.spring;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class SpringUnvalidatedRedirectController {
+
+    @RequestMapping("/redirect1")
+    public String redirect1(@RequestParam("url") String url) {
+        return "redirect:" + url;
+    }
+
+    @RequestMapping("/redirect2")
+    public String redirect2(@RequestParam("url") String url) {
+        String val = "redirect:" + url;
+        return val;
+    }
+
+    @RequestMapping("/redirect3")
+    public String redirect3(@RequestParam("url") String url) {
+        return buildRedirect(url);
+    }
+
+    private String buildRedirect(String u) {
+        return "redirect:" + u;
+    }
+
+    @RequestMapping("/redirectfp")
+    public String redirectfp() {
+        return "redirect:/";
+    }
+}


### PR DESCRIPTION
This adds a detector for unvalidated redirects in Spring MVC web applications.  The detector looks for a view prefix of "redirect:", which instructs the controller to perform a redirect to a specified URL.  The detector only looks at classes with "RequestMapping" annotations.  This should limit inspection to controllers and abstract classes that define endpoints.