### PR TITLE
Validate taint config class and method names as java identifiers

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintClassConfig.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintClassConfig.java
@@ -37,7 +37,8 @@ public class TaintClassConfig implements TaintTypeConfig {
     private static final Pattern taintConfigPattern;
 
     static {
-        String classWithPackageRegex = "([a-z][a-z0-9]*\\/)*(package|[A-Z])[a-zA-Z0-9\\$]*";
+        String javaIdentifierRegex = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
+        String classWithPackageRegex = javaIdentifierRegex+"(\\/"+javaIdentifierRegex+")*";
         String typeRegex = "(\\[)*((L" + classWithPackageRegex + ";)|B|C|D|F|I|J|S|Z)";
         typePattern = Pattern.compile(typeRegex);
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfig.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfig.java
@@ -44,10 +44,12 @@ public class TaintMethodConfig implements TaintTypeConfig {
         SAFE_CONFIG = new TaintMethodConfig(false);
         SAFE_CONFIG.outputTaint = new Taint(Taint.State.SAFE);
 
-        String classWithPackageRegex = "([a-z][a-z0-9]*\\/)*(package|[A-Z])[a-zA-Z0-9\\$]*";
+        String javaIdentifierRegex = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
+        String classWithPackageRegex = javaIdentifierRegex+"(\\/"+javaIdentifierRegex+")*";
+
         String typeRegex = "(\\[)*((L" + classWithPackageRegex + ";)|B|C|D|F|I|J|S|Z)";
         String returnRegex = "(V|(" + typeRegex + "))";
-        String methodRegex = "(([a-zA-Z][a-zA-Z0-9]*(\\$extension)?)|(<init>))";
+        String methodRegex = "(("+javaIdentifierRegex+"(\\$extension)?)|(<init>))";
         String signatureRegex = "\\((" + typeRegex + ")*\\)" + returnRegex;
         String fullMathodNameRegex = classWithPackageRegex + "\\." + methodRegex + signatureRegex;
         fullMethodPattern = Pattern.compile(fullMathodNameRegex);

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfigWithArgumentsAndLocation.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfigWithArgumentsAndLocation.java
@@ -36,15 +36,16 @@ public class TaintMethodConfigWithArgumentsAndLocation extends TaintMethodConfig
     private String location;
 
     static {
-        String classWithPackageRegex = "([a-z][a-z0-9]*\\/)*(package|[A-Z])[a-zA-Z0-9\\$]*";
-        String methodRegex = "(([a-zA-Z][a-zA-Z0-9]*(\\$extension)?)|(<init>))";
+        String javaIdentifierRegex = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
+        String classNameRegex = javaIdentifierRegex+"(\\/"+javaIdentifierRegex+")*";
+        String methodRegex = "(("+javaIdentifierRegex+"(\\$extension)?)|(<init>))";
 
         // javax/servlet/http/HttpServletRequest.getAttribute("applicationConstant"):SAFE@org/apache/jsp/edit_jsp
         // javax/servlet/http/HttpServletRequest.getAttribute(UNKNOWN):SAFE@org/apache/jsp/constants_jsp
         String stringConstantRegex = "\"[^\"]*\"";
         String enumNameRegex = "[A-Z_]+";
         String methodArguments = "(" + stringConstantRegex + ",?|" + enumNameRegex + ",?)*";
-        String methodWithStringConstantOrEnumRegex = classWithPackageRegex + "\\." + methodRegex + "\\(" + methodArguments + "\\)";
+        String methodWithStringConstantOrEnumRegex = classNameRegex + "\\." + methodRegex + "\\(" + methodArguments + "\\)";
         methodWithStringConstantOrEnumPattern = Pattern.compile(methodWithStringConstantOrEnumRegex);
     }
 


### PR DESCRIPTION
Hi @h3xstream,

a small bug fix. 

I encountered valid method name prefixed with underscore but we don't accept it, because the regexp was too specific.

Thanks.