### PR TITLE
SSRF and LFI using RequestDispatcher and URLConnection

### DIFF
--- a/plugin-deps/src/main/java/javax/servlet/RequestDispatcher.java
+++ b/plugin-deps/src/main/java/javax/servlet/RequestDispatcher.java
@@ -1,0 +1,13 @@
+package javax.servlet;
+
+import java.io.IOException;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public interface RequestDispatcher {
+
+    void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException;
+
+    void include(ServletRequest request, ServletResponse response) throws ServletException, IOException;
+}

--- a/plugin-deps/src/main/java/javax/servlet/ServletContext.java
+++ b/plugin-deps/src/main/java/javax/servlet/ServletContext.java
@@ -1,4 +1,6 @@
 package javax.servlet;
 
 public interface ServletContext {
+
+    RequestDispatcher getRequestDispatcher(String path);
 }

--- a/plugin-deps/src/main/java/javax/servlet/ServletRequest.java
+++ b/plugin-deps/src/main/java/javax/servlet/ServletRequest.java
@@ -20,4 +20,7 @@ public interface ServletRequest {
 
     Locale getLocale();
 
+    RequestDispatcher getRequestDispatcher(String path);
+
+    ServletContext getServletContext();
 }

--- a/plugin-deps/src/main/java/javax/servlet/ServletRequestWrapper.java
+++ b/plugin-deps/src/main/java/javax/servlet/ServletRequestWrapper.java
@@ -44,4 +44,14 @@ public class ServletRequestWrapper implements ServletRequest {
     public Locale getLocale() {
         return null;
     }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetector.java
@@ -26,5 +26,6 @@ public class FileDisclosureDetector extends BasicInjectionDetector {
         super(bugReporter);
         loadConfiguredSinks("spring-file-disclosure.txt", "SPRING_FILE_DISCLOSURE");
         loadConfiguredSinks("struts-file-disclosure.txt", "STRUTS_FILE_DISCLOSURE");
+        loadConfiguredSinks("requestdispatcher-file-disclosure.txt", "REQUESTDISPATCHER_FILE_DISCLOSURE");
     }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/scala/SSRFDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/scala/SSRFDetector.java
@@ -26,9 +26,11 @@ import edu.umd.cs.findbugs.Priorities;
 public class SSRFDetector extends BasicInjectionDetector {
 
     private static final String SCALA_PLAY_SSRF_TYPE = "SCALA_PLAY_SSRF";
+    private static final String URLCONNECTION_SSRF_FD = "URLCONNECTION_SSRF_FD";
 
     public SSRFDetector(BugReporter bugReporter) {
         super(bugReporter);
         loadConfiguredSinks("scala-play-ssrf.txt", SCALA_PLAY_SSRF_TYPE);
+        loadConfiguredSinks("urlconnection-ssrf.txt", URLCONNECTION_SSRF_FD);
     }
 }

--- a/plugin/src/main/resources/injection-sinks/requestdispatcher-file-disclosure.txt
+++ b/plugin/src/main/resources/injection-sinks/requestdispatcher-file-disclosure.txt
@@ -1,0 +1,2 @@
+javax/servlet/RequestDispatcher.forward(Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;)V:2
+javax/servlet/RequestDispatcher.include(Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;)V:2

--- a/plugin/src/main/resources/injection-sinks/urlconnection-ssrf.txt
+++ b/plugin/src/main/resources/injection-sinks/urlconnection-ssrf.txt
@@ -1,0 +1,5 @@
+java/net/URL.openConnection()Ljava/net/URLConnection;:0
+java/net/URL.openConnection(Ljava/net/Proxy;)Ljava/net/URLConnection;:0,1
+java/net/URL.openStream()Ljava/io/InputStream;:0
+java/net/URL.getContent()Ljava/lang/Object;:0
+java/net/URL.getContent([Ljava/lang/Class;)Ljava/lang/Object;:1

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -108,7 +108,7 @@
     <Detector class="com.h3xstream.findsecbugs.crypto.InsecureSmtpSslDetector" reports="INSECURE_SMTP_SSL"/>
     <Detector class="com.h3xstream.findsecbugs.injection.aws.AwsQueryInjectionDetector" reports="AWS_QUERY_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.beans.BeanInjectionDetector" reports="BEAN_PROPERTY_INJECTION"/>
-    <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector" reports="STRUTS_FILE_DISCLOSURE,SPRING_FILE_DISCLOSURE"/>
+    <Detector class="com.h3xstream.findsecbugs.injection.fileDisclosure.FileDisclosureDetector" reports="STRUTS_FILE_DISCLOSURE,SPRING_FILE_DISCLOSURE,REQUESTDISPATCHER_FILE_DISCLOSURE"/>
     <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector" reports="FORMAT_STRING_MANIPULATION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.http.HttpParameterPollutionDetector" reports="HTTP_PARAMETER_POLLUTION"/>
     <Detector class="com.h3xstream.findsecbugs.spring.SpringUnvalidatedRedirectDetector" reports="SPRING_UNVALIDATED_REDIRECT"/>
@@ -117,6 +117,7 @@
     <BugPattern type="FORMAT_STRING_MANIPULATION" abbrev="SECFSM" category="SECURITY"/>
     <BugPattern type="SPRING_FILE_DISCLOSURE" abbrev="SECSF" category="SECURITY"/>
     <BugPattern type="STRUTS_FILE_DISCLOSURE" abbrev="SECSFD" category="SECURITY"/>
+    <BugPattern type="REQUESTDISPATCHER_FILE_DISCLOSURE" abbrev="SECSFDR" category="SECURITY"/>
     <BugPattern type="BEAN_PROPERTY_INJECTION" abbrev="SECBPI" category="SECURITY"/>
     <BugPattern type="AWS_QUERY_INJECTION" abbrev="SECAQI" category="SECURITY"/>
     <BugPattern type="INSECURE_SMTP_SSL" abbrev="SECISC" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -94,7 +94,7 @@
     <Detector class="com.h3xstream.findsecbugs.scala.PlayUnvalidatedRedirectDetector" reports="PLAY_UNVALIDATED_REDIRECT" />
     <Detector class="com.h3xstream.findsecbugs.scala.SslDisablerDetector" reports="WEAK_TRUST_MANAGER,WEAK_HOSTNAME_VERIFIER"/>
     <Detector class="com.h3xstream.findsecbugs.scala.ScalaSensitiveDataExposureDetector" reports="SCALA_SENSITIVE_DATA_EXPOSURE"/>
-    <Detector class="com.h3xstream.findsecbugs.scala.SSRFDetector" reports="SCALA_PLAY_SSRF"/>
+    <Detector class="com.h3xstream.findsecbugs.scala.SSRFDetector" reports="SCALA_PLAY_SSRF,URLCONNECTION_SSRF_FD"/>
     <Detector class="com.h3xstream.findsecbugs.scala.XssMvcApiDetector" reports="SCALA_XSS_MVC_API" />
     <Detector class="com.h3xstream.findsecbugs.scala.XssTwirlDetector" reports="SCALA_XSS_TWIRL" />
     <Detector class="com.h3xstream.findsecbugs.template.VelocityDetector" reports="TEMPLATE_INJECTION_VELOCITY" />
@@ -233,5 +233,6 @@
     <BugPattern type="SCALA_XSS_MVC_API" abbrev="SECSXSS" category="SECURITY" cweid="79"/>
     <BugPattern type="TEMPLATE_INJECTION_VELOCITY" abbrev="SECVELO" category="SECURITY" cweid="94"/>
     <BugPattern type="TEMPLATE_INJECTION_FREEMARKER" abbrev="SECFREEM" category="SECURITY" cweid="94"/>
+    <BugPattern type="URLCONNECTION_SSRF_FD" abbrev="SECSSSRFUC" category="SECURITY" cweid="918"/>
 
 </FindbugsPlugin>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -4693,6 +4693,46 @@ Path traversal <sup>[3][4]</sup> are not possible.
             ]]></Details>
     </BugPattern>
     <BugCode abbrev="SECSSSRF">Scala Play Server-Side Request Forgery</BugCode>
+    <BugPattern type="URLCONNECTION_SSRF_FD">
+        <ShortDescription>URLConnection Server-Side Request Forgery (SSRF) and File Disclosure</ShortDescription>
+        <LongDescription>This web server request could be used by an attacker to expose internal services and filesystem.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+    Server-Side Request Forgery occur when a web server executes a request to a user supplied destination
+    parameter that is not validated. Such vulnerabilities could allow an attacker to access internal services
+    or to launch attacks from your web server.
+</p>
+<p>
+    URLConnection can be used with file:// protocol or other protocols to access local filesystem and potentially other services.
+<p>
+    <b>Vulnerable Code:</b>
+<pre>
+new URL(String url).openConnection()
+new URL(String url).openStream()
+new URL(String url).getContent()
+</pre>
+</p>
+<p>
+    <b>Solution/Countermeasures:</b><br/>
+    <ul>
+        <li>Don't accept URL destinations from users</li>
+        <li>Accept a destination key, and use it to look up the target (legal) destination</li>
+        <li>White list URLs (if possible)</li>
+        <li>Validate that the beginning of the URL is part of a white list</li>
+    </ul>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/918.html">CWE-918: Server-Side Request Forgery (SSRF)</a><br/>
+<a href="https://www.bishopfox.com/blog/2015/04/vulnerable-by-design-understanding-server-side-request-forgery/">Understanding Server-Side Request Forgery</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/73.html">CWE-73: External Control of File Name or Path</a><br/>
+<a href="https://www.pwntester.com/blog/2013/11/28/abusing-jar-downloads/">Abusing jar:// downloads</a><br />
+</p>
+            ]]></Details>
+    </BugPattern>
+    <BugCode abbrev="SECSSSRFUC">URLConnection Server-Side Request Forgery</BugCode>
 
     <!-- XSS in Scala Play Twirl template engine -->
     <Detector class="com.h3xstream.findsecbugs.scala.XssTwirlDetector">

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -5260,6 +5260,36 @@ Avoid constructing server-side redirects using user controlled input.
     </BugPattern>
     <BugCode abbrev="SECSF">Spring File Disclosure</BugCode>
 
+    <!-- RequestDispatcher File Disclosure -->
+    <BugPattern type="REQUESTDISPATCHER_FILE_DISCLOSURE">
+        <ShortDescription>RequestDispatcher File Disclosure</ShortDescription>
+        <LongDescription>RequestDispatcher populated with user controlled parameters</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Constructing a server-side redirect path with user input could allow an attacker to download application binaries (including application classes or jar files) or view arbitrary files within protected directories.<br/>
+An attacker may be able to forge a request parameter to match sensitive file locations. For example, requesting "http://example.com/?jspFile=../applicationContext.xml%3F" would display the application's applicationContext.xml file. The attacker would be able to locate and download the applicationContext.xml referenced in the other configuration files, and even class files or jar files, obtaining sensitive information and launching other types of attacks.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+<pre>...
+String jspFile = request.getParameter("jspFile");
+request.getRequestDispatcher("/WEB-INF/jsps/" + jspFile + ".jsp").include(request, response);
+...</pre>
+</p>
+<p>
+    <b>Solution:</b><br/>
+Avoid constructing server-side redirects using user controlled input.
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/552.html">CWE-552: Files or Directories Accessible to External Parties</a><br/>
+</p>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSFDR">RequestDispatcher File Disclosure</BugCode>
 
     <!-- Format String Manipulation -->
     <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector">

--- a/plugin/src/main/resources/taint-config/java-ee.txt
+++ b/plugin/src/main/resources/taint-config/java-ee.txt
@@ -11,6 +11,7 @@ javax/servlet/ServletRequest.getProtocol()Ljava/lang/String;:SAFE
 javax/servlet/ServletRequest.getRealPath(Ljava/lang/String;)Ljava/lang/String;:0
 javax/servlet/ServletRequest.getRemoteAddr()Ljava/lang/String;:SAFE
 javax/servlet/ServletRequest.getRemoteHost()Ljava/lang/String;:TAINTED
+javax/servlet/ServletRequest.getRequestDispatcher(Ljava/lang/String;)Ljavax/servlet/RequestDispatcher;:0
 javax/servlet/ServletRequest.getScheme()Ljava/lang/String;:SAFE
 javax/servlet/ServletRequest.getServerName()Ljava/lang/String;:TAINTED
 
@@ -40,6 +41,7 @@ javax/servlet/http/HttpServletRequest.getRealPath(Ljava/lang/String;)Ljava/lang/
 javax/servlet/http/HttpServletRequest.getRemoteAddr()Ljava/lang/String;:SAFE
 javax/servlet/http/HttpServletRequest.getRemoteHost()Ljava/lang/String;:TAINTED
 javax/servlet/http/HttpServletRequest.getRemoteUser()Ljava/lang/String;:TAINTED
+javax/servlet/http/HttpServletRequest.getRequestDispatcher(Ljava/lang/String;)Ljavax/servlet/RequestDispatcher;:0
 javax/servlet/http/HttpServletRequest.getRequestURI()Ljava/lang/String;:TAINTED
 javax/servlet/http/HttpServletRequest.getRequestURL()Ljava/lang/StringBuffer;:TAINTED
 javax/servlet/http/HttpServletRequest.getScheme()Ljava/lang/String;:SAFE
@@ -71,6 +73,7 @@ javax/servlet/http/HttpServletRequestWrapper.getRealPath(Ljava/lang/String;)Ljav
 javax/servlet/http/HttpServletRequestWrapper.getRemoteAddr()Ljava/lang/String;:SAFE
 javax/servlet/http/HttpServletRequestWrapper.getRemoteHost()Ljava/lang/String;:TAINTED
 javax/servlet/http/HttpServletRequestWrapper.getRemoteUser()Ljava/lang/String;:TAINTED
+javax/servlet/http/HttpServletRequestWrapper.getRequestDispatcher(Ljava/lang/String;)Ljavax/servlet/RequestDispatcher;:0
 javax/servlet/http/HttpServletRequestWrapper.getRequestURI()Ljava/lang/String;:TAINTED
 javax/servlet/http/HttpServletRequestWrapper.getRequestURL()Ljava/lang/StringBuffer;:TAINTED
 javax/servlet/http/HttpServletRequestWrapper.getScheme()Ljava/lang/String;:SAFE
@@ -90,6 +93,7 @@ javax/servlet/ServletRequestWrapper.getProtocol()Ljava/lang/String;:SAFE
 javax/servlet/ServletRequestWrapper.getRealPath(Ljava/lang/String;)Ljava/lang/String;:0
 javax/servlet/ServletRequestWrapper.getRemoteAddr()Ljava/lang/String;:SAFE
 javax/servlet/ServletRequestWrapper.getRemoteHost()Ljava/lang/String;:TAINTED
+javax/servlet/ServletRequestWrapper.getRequestDispatcher(Ljava/lang/String;)Ljavax/servlet/RequestDispatcher;:0
 javax/servlet/ServletRequestWrapper.getScheme()Ljava/lang/String;:SAFE
 javax/servlet/ServletRequestWrapper.getServerName()Ljava/lang/String;:TAINTED
 
@@ -109,6 +113,12 @@ javax/servlet/http/Cookie.getValue()Ljava/lang/String;:TAINTED
 javax/servlet/ServletContext.getContextPath()Ljava/lang/String;:SAFE
 -javax/servlet/ServletContext.getInitParameter(Ljava/lang/String;)Ljava/lang/String;:?
 -javax/servlet/ServletContext.getInitParameterNames()Ljava/util/Enumeration;:?
+javax/servlet/ServletContext.getNamedDispatcher(Ljava/lang/String;)Ljavax/servlet/RequestDispatcher;:0
+javax/servlet/ServletContext.getRequestDispatcher(Ljava/lang/String;)Ljavax/servlet/RequestDispatcher;:0
+javax/servlet/ServletContext.getRealPath(Ljava/lang/String;)Ljava/lang/String;:0
+javax/servlet/ServletContext.getResource(Ljava/lang/String;)Ljava/net/URL;:0
+javax/servlet/ServletContext.getResourceAsStream(Ljava/lang/String;)Ljava/io/InputStream;:0
+javax/servlet/ServletContext.getResourcePaths(Ljava/lang/String;)Ljava/util/Set;:0
 
 -- The following methods receive arguments but will not alter the objects received
 -- (It avoids tainting the parameters that are not immutable)

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/fileDisclosure/FileDisclosureDetectorTest.java
@@ -38,7 +38,7 @@ public class FileDisclosureDetectorTest extends BaseDetectorTest {
         EasyBugReporter reporter = spy(new SecurityReporter());
         analyze(files, reporter);
 
-        for (Integer line : Arrays.asList(18, 20, 22, 24, 27)) {
+        for (Integer line : Arrays.asList(20, 22, 24, 26, 29)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("STRUTS_FILE_DISCLOSURE")
@@ -47,7 +47,7 @@ public class FileDisclosureDetectorTest extends BaseDetectorTest {
             );
         }
 
-        for (Integer line : Arrays.asList(33, 35, 37, 40)) {
+        for (Integer line : Arrays.asList(35, 37, 39, 42)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("SPRING_FILE_DISCLOSURE")
@@ -67,4 +67,19 @@ public class FileDisclosureDetectorTest extends BaseDetectorTest {
         );
     }
 
+    @Test
+    public void detectFileDisclosureWithRequestDispatcher() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/FileDisclosure")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, times(2)).doReportBug(
+                bugDefinition().bugType("REQUESTDISPATCHER_FILE_DISCLOSURE").inMethod("doGet2").build()
+        );
+    }
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/scala/SSRFDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/scala/SSRFDetectorTest.java
@@ -28,10 +28,12 @@ import java.util.Map;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 public class SSRFDetectorTest extends BaseDetectorTest {
 
     private static final String SCALA_PLAY_SSRF_TYPE = "SCALA_PLAY_SSRF";
+    private static final String URLCONNECTION_SSRF_FD = "URLCONNECTION_SSRF_FD";
 
     @Test
     public void detectSSRFInController() throws Exception {
@@ -90,6 +92,28 @@ public class SSRFDetectorTest extends BaseDetectorTest {
                         .bugType(SCALA_PLAY_SSRF_TYPE)
                         .inClass("SSRFController").inMethod("safePostWithWhitelist")
                         .build()
+        );
+    }
+
+    @Test
+    public void detectURLConnectionSSRF() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/UrlConnectionSSRF")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        verify(reporter, times(7)).doReportBug(bugDefinition()
+                .bugType(URLCONNECTION_SSRF_FD).inClass("UrlConnectionSSRF")
+                .inMethod("testURL").build()
+        );
+        verify(reporter, times(1)).doReportBug(bugDefinition()
+                .bugType(URLCONNECTION_SSRF_FD).inClass("UrlConnectionSSRF")
+                .inMethod("testURI").build()
         );
     }
 }

--- a/plugin/src/test/java/testcode/FileDisclosure.java
+++ b/plugin/src/test/java/testcode/FileDisclosure.java
@@ -3,6 +3,8 @@ package testcode;
 import java.io.IOException;
 import org.apache.struts.action.ActionForward;
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -45,5 +47,22 @@ public class FileDisclosure extends HttpServlet{
         }catch(Exception e){
          System.out.println(e);
        }
+    }
+
+    public void doGet2(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        try{
+            String jspFile = request.getParameter("jspFile");
+
+            RequestDispatcher requestDispatcher = request.getRequestDispatcher(jspFile);
+
+            requestDispatcher.include(request, response);
+
+            requestDispatcher = request.getServletContext().getRequestDispatcher(jspFile);
+
+            requestDispatcher.forward(request, response);
+
+        }catch(Exception e){
+            System.out.println(e);
+        }
     }
 }

--- a/plugin/src/test/java/testcode/UrlConnectionSSRF.java
+++ b/plugin/src/test/java/testcode/UrlConnectionSSRF.java
@@ -1,0 +1,30 @@
+package testcode;
+
+import java.io.IOException;
+import java.net.*;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UrlConnectionSSRF {
+
+    public static void testURL(String url) throws IOException {
+        new URL(url).openConnection().connect();
+
+        new URL("http://safe.com").openConnection(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(url, 8080))).connect();
+
+        new URL(url).openConnection().getInputStream();
+
+        new URL(url).openConnection().getLastModified();
+
+        new URL(url).openStream();
+
+        new URL(url).getContent();
+
+        new URL(url).getContent(new Class[0]);
+    }
+
+    public static void testURI(String url) throws IOException, URISyntaxException {
+        new URI(url).toURL().openConnection().connect();
+    }
+}


### PR DESCRIPTION
Hi @h3xstream,

I extended detectors for vulnerabilities I met recently.

I reused `scala.SSRFDetector` class for the SSRF check even though it's not scala. I'm not sure if you would like to split it into 2 separate detectors - one for Scala and one for Java, or extract the `SSRFDetector` out of `scala` package and have just one class for both.

Thanks.