### PR TITLE
Test for TaintMethodConfigWithArgumentsAndLocation with examples

### DIFF
--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/custom/CustomInjectionDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/custom/CustomInjectionDetectorTest.java
@@ -19,18 +19,24 @@ package com.h3xstream.findsecbugs.injection.custom;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.testng.annotations.BeforeTest;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 public class CustomInjectionDetectorTest extends BaseDetectorTest {
 
-    @BeforeTest
-    public void before() {
+    @BeforeClass
+    public void beforeClass() {
         String path = this.getClass().getResource("/com/h3xstream/findsecbugs/injection/custom/CustomInjectionSource.txt").getPath();
         System.setProperty("findsecbugs.injection.sources", path);
+    }
+
+    @AfterClass
+    public void afterClass() {
+        System.setProperty("findsecbugs.injection.sources", "");
     }
 
     @Test

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xss/JspXssDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xss/JspXssDetectorTest.java
@@ -20,9 +20,7 @@ package com.h3xstream.findsecbugs.xss;
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
 import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 import java.util.Arrays;
 
@@ -210,6 +208,39 @@ public class JspXssDetectorTest extends BaseDetectorTest {
 
         //No alert should be trigger
         verify(reporter, never()).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
+    }
+
+    @Test
+    public void detectXssRequestAttribute() throws Exception {
+        //Locate test code
+        String[] files = {
+                getJspFilePath("xss/xss_8_request_attribute.jsp")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+
+        String customConfigFile = FindSecBugsGlobalConfig.getInstance().getCustomConfigFile();
+        String path = this.getClass().getResource("/com/h3xstream/findsecbugs/xss/CustomConfig.txt").getPath();
+        FindSecBugsGlobalConfig.getInstance().setCustomConfigFile(path);
+
+        try {
+            analyze(files, reporter);
+        } finally {
+            FindSecBugsGlobalConfig.getInstance().setCustomConfigFile(customConfigFile == null ? "" : customConfigFile);
+        }
+
+        for (Integer line : Arrays.asList(16, 17)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("XSS_JSP_PRINT")
+                            .inJspFile("xss/xss_8_request_attribute.jsp")
+                            .atJspLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter, times(2)).doReportBug(bugDefinition().bugType("XSS_JSP_PRINT").build());
     }
 
 }

--- a/plugin/src/test/resources/com/h3xstream/findsecbugs/xss/CustomConfig.txt
+++ b/plugin/src/test/resources/com/h3xstream/findsecbugs/xss/CustomConfig.txt
@@ -1,0 +1,6 @@
+javax/servlet/http/HttpServletRequest.getAttribute("safe"):SAFE@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+javax/servlet/http/HttpServletRequest.getAttribute("tainted"):TAINTED@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+
+javax/servlet/http/HttpSession.getAttribute(UNKNOWN):SAFE@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+
+org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp.suffix(TAINTED,SAFE,"_suffix"):SAFE@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp

--- a/plugin/src/test/webapp/xss/xss_8_request_attribute.jsp
+++ b/plugin/src/test/webapp/xss/xss_8_request_attribute.jsp
@@ -1,0 +1,44 @@
+<%--
+    Definitions are inside /src/test/resources/com/h3xstream/findsecbugs/xss/CustomConfig.txt
+--%>
+
+<%
+    //Let's say it's safe: javax/servlet/http/HttpServletRequest.getAttribute("safe"):SAFE@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+    String safe = (String) request.getAttribute("safe");
+
+    //Let's say this is tainted: javax/servlet/http/HttpServletRequest.getAttribute("tainted"):TAINTED@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+    String tainted = (String) request.getAttribute("tainted");
+%>
+
+<%= safe %>
+<%= request.getAttribute("safe") %>
+
+<%= tainted %>
+<%= request.getAttribute("tainted") %>
+
+<%
+    // TEST unknown
+
+    String variableWithUnknownTaint = (String) request.getAttribute("example");
+
+    // javax/servlet/http/HttpSession.getAttribute(UNKNOWN):SAFE@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+    String safeExampleObject = (String) request.getSession().getAttribute(variableWithUnknownTaint);
+    out.println(safeExampleObject);
+%>
+
+<%
+    // TEST multiple arguments
+
+    String fileName = tainted + ".ext";
+
+    // org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp.suffix(TAINTED,SAFE,"_suffix"):SAFE@org/apache/jsp/xss/xss_005f8_005frequest_005fattribute_jsp
+    String extensionWithSuffix = suffix(fileName, 3, "_suffix");
+
+    out.println(extensionWithSuffix);
+%>
+
+<%!
+    String suffix(String s, int length, String suffix) {
+        return s.substring(s.length() - length, s.length()) + suffix;
+    }
+%>


### PR DESCRIPTION
Hi @h3xstream,

test for `TaintMethodConfigWithArgumentsAndLocation` with examples (https://github.com/find-sec-bugs/find-sec-bugs/pull/330#issuecomment-323161835)

I hope it improves the coverage.

I also fixed an unrelated bug in `CustomInjectionDetectorTest`. Beside the configuration reset I had to move the code into `@After/BeforeClass`, with `@After/BeforeTest` it didn't work, I'm not sure why.

Thanks.