### PR TITLE
Enable assertions during building and/or using find-sec-bugs #338

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -68,6 +68,7 @@
                             <value>com.h3xstream.testng.VerboseTestListener</value>
                         </property>
                     </properties>
+  	           <enableAssertions>true</enableAssertions>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
                         <version>2.20</version>
                         <configuration>
                             <argLine>-Xmx3000m -Dbcel.dontCache=true</argLine>
+		           <enableAssertions>true</enableAssertions>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
part I : enabling assertions during testing