### PR TITLE
Detect hardcode password and hash based on variable name

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/common/StackUtils.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/common/StackUtils.java
@@ -18,6 +18,8 @@
 package com.h3xstream.findsecbugs.common;
 
 import edu.umd.cs.findbugs.OpcodeStack;
+import org.apache.bcel.generic.LocalVariableGen;
+import org.apache.bcel.generic.MethodGen;
 
 public class StackUtils {
 
@@ -35,6 +37,15 @@ public class StackUtils {
 
     public static boolean isConstantInteger(OpcodeStack.Item item) {
         return item.getConstant() != null && item.getConstant() instanceof Integer;
+    }
+
+    public static LocalVariableGen getLocalVariable(MethodGen methodGen, int index) {
+        for(LocalVariableGen local : methodGen.getLocalVariables()) {
+            if(local.getIndex() == index) {
+                return local;
+            }
+        }
+        return null;
     }
 
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
@@ -18,6 +18,8 @@
 package com.h3xstream.findsecbugs.injection;
 
 import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import com.h3xstream.findsecbugs.taintanalysis.TaintDataflowEngine;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrameAdditionalVisitor;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
 import edu.umd.cs.findbugs.io.IO;
@@ -188,5 +190,9 @@ public abstract class BasicInjectionDetector extends AbstractInjectionDetector {
     private String getFullMethodName(InvokeInstruction invoke, ConstantPoolGen cpg) {
         return ClassName.toSlashedClassName(invoke.getReferenceType(cpg).toString())
                 + "." + invoke.getMethodName(cpg) + invoke.getSignature(cpg);
+    }
+
+    public void registerVisitor(TaintFrameAdditionalVisitor visitor) {
+        TaintDataflowEngine.registerAdditionalVisitor(visitor);
     }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/password/HardcodedPasswordEqualsDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/password/HardcodedPasswordEqualsDetector.java
@@ -1,0 +1,141 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.password;
+
+import com.h3xstream.findsecbugs.common.StackUtils;
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.injection.InjectionPoint;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrameAdditionalVisitor;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.LoadInstruction;
+import org.apache.bcel.generic.LocalVariableGen;
+import org.apache.bcel.generic.MethodGen;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+/**
+ * <p>
+ *     Detect:
+ * </p>
+ *
+ * <pre>
+ * if(password.equals("SuperSecr3t!1")) {
+ *     ....
+ * }
+ * </pre>
+ */
+public class HardcodedPasswordEqualsDetector extends BasicInjectionDetector implements TaintFrameAdditionalVisitor {
+
+    private static final String HARD_CODE_PASSWORD_TYPE = "HARD_CODE_PASSWORD";
+
+    private static final InvokeMatcherBuilder STRING_EQUALS_METHOD = invokeInstruction() //
+            .atClass("java/lang/String").atMethod("equals").withArgs("(Ljava/lang/Object;)Z");
+    private static final boolean DEBUG = false;
+
+    public HardcodedPasswordEqualsDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        registerVisitor(this);
+    }
+
+    @Override
+    protected int getPriorityFromTaintFrame(TaintFrame fact, int offset) throws DataflowAnalysisException {
+
+        Taint rightValue = fact.getStackValue(offset);
+        Taint leftValue = fact.getStackValue(offset == 0 ? 1 : 0);
+
+        boolean passwordVariableLeft = leftValue.isUnknown() && leftValue.hasTag(Taint.Tag.PASSWORD_VARIABLE);
+        boolean passwordVariableRight = rightValue.isUnknown() && rightValue.hasTag(Taint.Tag.PASSWORD_VARIABLE);
+
+        //If a constant value is compare with the variable
+        //Empty constant are ignored.. it is most likely a validation to make sure it is not empty
+        boolean valueHardcodedLeft = leftValue.getConstantValue() != null && !leftValue.getConstantValue().isEmpty();
+        boolean valueHardcodedRight = rightValue.getConstantValue() != null && !rightValue.getConstantValue().isEmpty();
+
+        //Is a constant value that was tag because the value was place in a variable name "password" at some point.
+        if ((passwordVariableLeft && valueHardcodedRight) ||
+                (passwordVariableRight && valueHardcodedLeft)) {
+            return Priorities.NORMAL_PRIORITY;
+        } else {
+            return Priorities.IGNORE_PRIORITY;
+        }
+    }
+
+    @Override
+    protected InjectionPoint getInjectionPoint(InvokeInstruction invoke, ConstantPoolGen cpg,
+                                               InstructionHandle handle) {
+        if(STRING_EQUALS_METHOD.matches(invoke,cpg)) {
+            return new InjectionPoint(new int[]{0,1}, HARD_CODE_PASSWORD_TYPE);
+        }
+        return InjectionPoint.NONE;
+    }
+
+    @Override
+    public void visitInvoke(InvokeInstruction instruction, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType) {
+        //ByteCode.printOpCode(instruction, cpg);
+    }
+
+    @Override
+    public void visitLoad(LoadInstruction instruction, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, int numProduced) {
+        //Extract the name of the variable
+        int index = instruction.getIndex();
+        LocalVariableGen var = StackUtils.getLocalVariable(methodGen, index);
+        if(var == null) {
+            if(DEBUG) System.out.println("Unable to get field name for index "+ index + " in "+methodGen);
+            return;
+        }
+        String fieldName = var.getName();
+
+        boolean isPasswordVariable = false;
+        String fieldNameLower = fieldName.toLowerCase();
+        for (String password : IntuitiveHardcodePasswordDetector.PASSWORD_WORDS) {
+            if (fieldNameLower.contains(password)) {
+                isPasswordVariable = true;
+            }
+        }
+
+        if(!isPasswordVariable) {return;}
+
+        //Mark local variable
+        Taint passwordValue = frameType.getValue(index);
+        passwordValue.addTag(Taint.Tag.PASSWORD_VARIABLE);
+
+        if(numProduced <= 0) {
+            if(DEBUG) System.out.println("Unexpected number of stack variable produced");
+            return;
+        }
+
+        //Mark the stack value
+        try {
+            for(int indexStack=0;indexStack<numProduced;indexStack++) {
+                Taint value = frameType.getStackValue(indexStack);
+                value.addTag(Taint.Tag.PASSWORD_VARIABLE);
+            }
+        } catch (DataflowAnalysisException e) {
+        }
+
+    }
+
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/password/IntuitiveHardcodePasswordDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/password/IntuitiveHardcodePasswordDetector.java
@@ -46,7 +46,7 @@ public class IntuitiveHardcodePasswordDetector extends BasicInjectionDetector {
 
     private static final String HARD_CODE_PASSWORD_TYPE = "HARD_CODE_PASSWORD";
 
-    private static List<String> PASSWORD_WORDS = new ArrayList<String>();
+    public static List<String> PASSWORD_WORDS = new ArrayList<String>();
     static {
         //Passwords in various language
         //http://www.indifferentlanguages.com/words/password

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/InvalidStateException.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/InvalidStateException.java
@@ -1,0 +1,24 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+public class InvalidStateException extends RuntimeException {
+    public InvalidStateException(String msg) {
+        super(msg);
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -107,7 +107,8 @@ public class Taint {
         PATH_TRAVERSAL_SAFE,
 
         CREDIT_CARD_VARIABLE,
-        PASSWORD_VARIABLE;
+        PASSWORD_VARIABLE,
+        HASH_VARIABLE;
     }
 
     private State state;
@@ -594,8 +595,9 @@ public class Taint {
                 && this.parameters.equals(other.parameters)
                 && this.nonParametricState == other.nonParametricState
                 && Objects.equals(this.realInstanceClass, other.realInstanceClass)
-                && this.tags.equals(other.tags)
-                && Objects.equals(this.constantValue, other.constantValue);
+                //&& this.tags.equals(other.tags)
+                //&& Objects.equals(this.constantValue, other.constantValue)
+        ;
     }
 
     @Override

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
@@ -67,11 +67,11 @@ public class TaintAnalysis extends FrameDataflowAnalysis<Taint, TaintFrame> {
      * @param taintConfig configured and derived taint summaries
      */
     public TaintAnalysis(MethodGen methodGen, DepthFirstSearch dfs,
-            MethodDescriptor descriptor, TaintConfig taintConfig) {
+            MethodDescriptor descriptor, TaintConfig taintConfig, List<TaintFrameAdditionalVisitor> visitors) {
         super(dfs);
         this.methodGen = methodGen;
         this.methodDescriptor = (MethodInfo) descriptor;
-        this.visitor = new TaintFrameModelingVisitor(methodGen.getConstantPool(), descriptor, taintConfig);
+        this.visitor = new TaintFrameModelingVisitor(methodGen.getConstantPool(), descriptor, taintConfig, visitors, methodGen);
         computeParametersInfo(descriptor.getSignature(), descriptor.isStatic());
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -38,6 +38,8 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -73,7 +75,9 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
     };
     private final TaintConfig taintConfig = new TaintConfig();
     private static Writer writer = null;
-    
+    private static List<TaintFrameAdditionalVisitor> visitors = new ArrayList<TaintFrameAdditionalVisitor>();
+
+
     static {
         if (CONFIG.isDebugOutputTaintConfigs()) {
             try {
@@ -118,7 +122,11 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
             LOGGER.info("The argument of the main method is not considered tainted");
         }
     }
-    
+
+    public static void registerAdditionalVisitor(TaintFrameAdditionalVisitor visitor) {
+        visitors.add(visitor);
+    }
+
     private void loadTaintConfig(String path, boolean checkRewrite) {
         assert path != null && !path.isEmpty();
         InputStream stream = null;
@@ -165,7 +173,7 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
         CFG cfg = cache.getMethodAnalysis(CFG.class, descriptor);
         DepthFirstSearch dfs = cache.getMethodAnalysis(DepthFirstSearch.class, descriptor);
         MethodGen methodGen = cache.getMethodAnalysis(MethodGen.class, descriptor);
-        TaintAnalysis analysis = new TaintAnalysis(methodGen, dfs, descriptor, taintConfig);
+        TaintAnalysis analysis = new TaintAnalysis(methodGen, dfs, descriptor, taintConfig, visitors);
         TaintDataflow flow = new TaintDataflow(cfg, analysis);
         flow.execute();
         analysis.finishAnalysis();

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameAdditionalVisitor.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameAdditionalVisitor.java
@@ -1,0 +1,44 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.LoadInstruction;
+import org.apache.bcel.generic.MethodGen;
+
+public interface TaintFrameAdditionalVisitor {
+
+    /**
+     *  @param invoke
+     * @param cpg
+     * @param methodGen
+     * @param frameType
+     */
+    void visitInvoke(InvokeInstruction invoke, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType);
+
+    /**
+     * @param load
+     * @param cpg
+     * @param methodGen
+     * @param frameType
+     * @param numProduced
+     */
+    void visitLoad(LoadInstruction load, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, int numProduced);
+
+}

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -57,6 +57,8 @@
     <Detector class="com.h3xstream.findsecbugs.password.GoogleApiKeyDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.password.HardcodePasswordInMapDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.password.IntuitiveHardcodePasswordDetector" reports="HARD_CODE_PASSWORD"/>
+    <Detector class="com.h3xstream.findsecbugs.password.HardcodedPasswordEqualsDetector" reports="HARD_CODE_PASSWORD"/>
+    <Detector class="com.h3xstream.findsecbugs.password.HashUnsafeEqualsDetector" reports="UNSAFE_HASH_EQUALS"/>
     <Detector class="com.h3xstream.findsecbugs.StrutsValidatorFormDetector" reports="STRUTS_FORM_VALIDATION"/>
     <Detector class="com.h3xstream.findsecbugs.xss.XSSRequestWrapperDetector" reports="XSS_REQUEST_WRAPPER"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.InsufficientKeySizeBlowfishDetector" reports="BLOWFISH_KEY_SIZE"/>
@@ -188,6 +190,7 @@
     <BugPattern type="DES_USAGE" abbrev="SECDU" category="SECURITY" cweid="326"/>
     <BugPattern type="RSA_NO_PADDING" abbrev="SECRNP" category="SECURITY" cweid="780"/>
     <BugPattern type="HARD_CODE_PASSWORD" abbrev="SECHCP" category="SECURITY" cweid="259"/>
+    <BugPattern type="UNSAFE_HASH_EQUALS" abbrev="SECUHE" category="SECURITY" cweid="203"/>
     <BugPattern type="HARD_CODE_KEY" abbrev="SECHCK" category="SECURITY" cweid="321"/>
     <BugPattern type="STRUTS_FORM_VALIDATION" abbrev="SECSFV" category="SECURITY" cweid="106"/>
     <BugPattern type="XSS_REQUEST_WRAPPER" abbrev="SECXRW" category="SECURITY" cweid="79"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -2941,6 +2941,10 @@ The code should be replaced with:<br/>
         <Details>Identify hardcoded credentials in custom API.</Details>
     </Detector>
 
+    <Detector class="com.h3xstream.findsecbugs.password.HardcodedPasswordEqualsDetector">
+        <Details>Identify hardcoded credentials when variable named password are compared to a constant value.</Details>
+    </Detector>
+
     <BugPattern type="HARD_CODE_PASSWORD">
         <ShortDescription>Hard Coded Password</ShortDescription>
         <LongDescription>Hard coded password found</LongDescription>
@@ -2997,6 +3001,50 @@ return aesCipher.doFinal(secretData);</pre>
         </Details>
     </BugPattern>
     <BugCode abbrev="SECHCK">Hard Coded Key</BugCode>
+
+
+    <Detector class="com.h3xstream.findsecbugs.password.HashUnsafeEqualsDetector">
+        <Details>Identify unsafe comparison of hash that are susceptible to timing attack.</Details>
+    </Detector>
+
+    <BugPattern type="UNSAFE_HASH_EQUALS">
+        <ShortDescription>Unsafe hash equals</ShortDescription>
+        <LongDescription>Unsafe comparison of hash that are susceptible to timing attack</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+An attacker might be able to detect the value of the secret hash due to the exposure of comparison timing. When the
+functions <code>Arrays.equals()</code> or <code>String.equals()</code> are called, they will exited earlier if less
+bytes are matched.
+</p>
+<p>
+<p><b>Vulnerable Code:</b><br/>
+
+<pre>
+String actualHash = ...
+
+if(userInput.equals(actualHash)) {
+    ...
+}</pre>
+</p>
+<p><b>Solution:</b><br/>
+
+<pre>
+String actualHash = ...
+
+if(MessageDigest.isEqual(userInput.getBytes(),actualHash.getBytes())) {
+    ...
+}</pre>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="https://cwe.mitre.org/data/definitions/203.html">CWE-203: Information Exposure Through DiscrepancyKey</a><br/>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECUHE">Hard Coded Key</BugCode>
 
 
     <!-- Struts Form Validation -->

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/password/HardcodedPasswordEqualsDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/password/HardcodedPasswordEqualsDetectorTest.java
@@ -1,0 +1,56 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.password;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+public class HardcodedPasswordEqualsDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectHardCodePasswordsWithEquals() throws Exception {
+//        FindSecBugsGlobalConfig.getInstance().setDebugPrintInstructionVisited(true);
+//        FindSecBugsGlobalConfig.getInstance().setDebugTaintState(true);
+
+
+        String[] files = {
+//                getClassFilePath("testcode/crypto/BlockCipherList"),
+//                getClassFilePath("testcode/template/FreemarkerUsage"),
+                getClassFilePath("testcode/password/EqualsPasswordField"),
+        };
+
+        EasyBugReporter reporter = spy(new BaseDetectorTest.SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(19, 28, 39)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("HARD_CODE_PASSWORD")
+                            .inClass("EqualsPasswordField").atLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter, times(3)).doReportBug(bugDefinition().bugType("HARD_CODE_PASSWORD").build());
+    }
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/password/HashUnsafeEqualsDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/password/HashUnsafeEqualsDetectorTest.java
@@ -1,0 +1,54 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.password;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+public class HashUnsafeEqualsDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectUnsafeHashEquals() throws Exception {
+//        FindSecBugsGlobalConfig.getInstance().setDebugPrintInstructionVisited(true);
+//        FindSecBugsGlobalConfig.getInstance().setDebugTaintState(true);
+
+
+        String[] files = {
+                getClassFilePath("testcode/password/UnsafeCompareHash")
+        };
+
+        EasyBugReporter reporter = spy(new BaseDetectorTest.SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(10, 19, 28, 37)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("UNSAFE_HASH_EQUALS")
+                            .inClass("UnsafeCompareHash").atLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter, times(4)).doReportBug(bugDefinition().bugType("UNSAFE_HASH_EQUALS").build());
+    }
+}

--- a/plugin/src/test/java/testcode/password/EqualsPasswordField.java
+++ b/plugin/src/test/java/testcode/password/EqualsPasswordField.java
@@ -1,0 +1,85 @@
+package testcode.password;
+
+public abstract class EqualsPasswordField {
+
+    public boolean hardcodedLogin1(String username, String password) {
+
+        if(username.equals("admin")) {
+            System.out.println("OK");
+        }
+        if(username.equals("abc")) {
+            System.out.println("OK");
+        }
+
+        String test=username; //This code block is only there to make sure the stack is properly tracked..
+        String abc=test+"def";
+        String test2="abcdef";
+        String abc2=test2+"def";
+
+        if(password.equals("@dm1n")) { //!!
+            return true;
+        }
+
+        return validateDb(username,password);
+    }
+
+    public boolean hardcodedLogin2(String username, String password) {
+
+        if("adm1nL3ft".equals(password)) { //!!
+            return true;
+        }
+
+        return validateDb(username,password);
+    }
+
+
+    public boolean hardcodedLogin3(String username, String p1) {
+
+        String password = p1;
+        if("adm1nL3ft!!!!".equals(password)) { //!! (Not supported at the moment)
+            return true;
+        }
+
+        return validateDb(username,password);
+    }
+
+    public boolean safeLogin1(String username, String password) {
+
+        if(password.equals("")) {
+            return true;
+        }
+
+        return validateDb(username,password);
+    }
+
+    public boolean safeLogin2(String username, String password) {
+
+        if("".equals(password)) {
+            return false;
+        }
+
+        return validateDb(username,password);
+    }
+
+    public boolean safeLogin3(String username, String password) {
+
+        if(getPassword(username).equals(password)) {
+            return false;
+        }
+
+        return validateDb(username,password);
+    }
+
+    public boolean safeLogin4(String username, String password) {
+
+        if(password.equals(getPassword(username))) {
+            return false;
+        }
+
+        return validateDb(username,password);
+    }
+
+
+    public abstract boolean validateDb(String username, String password);
+    public abstract String getPassword(String username);
+}

--- a/plugin/src/test/java/testcode/password/UnsafeCompareHash.java
+++ b/plugin/src/test/java/testcode/password/UnsafeCompareHash.java
@@ -1,0 +1,57 @@
+package testcode.password;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+public abstract class UnsafeCompareHash {
+
+    public boolean unsafeLogin1(String username, String hash) {
+
+        if(hash.equals(getHash(username))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean unsafeLogin2(String username, String hash) {
+
+        if(getHash(username).equals(hash)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean unsafeLogin3(String username, byte[] md5) {
+
+        if(Arrays.equals(getHashBytes(username), md5)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean unsafeLogin4(String username, byte[] sha1) {
+
+        if(Arrays.equals(sha1, getHashBytes(username))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean safeLogin1(String username, byte[] hash) {
+
+        if(MessageDigest.isEqual(hash, getHash(username).getBytes())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public abstract String getHash(String username);
+    public abstract byte[] getHashBytes(String username);
+
+
+}


### PR DESCRIPTION
New detector for hardcode password but also new API for custom dataflow tagging beyond injection based bug patterns.

@formanek If you have some time, you could look at this new API and give me your toughs.

 - Detectors register to be able to intercept dataflow events : https://github.com/find-sec-bugs/find-sec-bugs/pull/343/commits/bccb39c1e758a72624bb87a1b7940369c086a6d2#diff-380c845ae06beefe8f07d853659ce8c0R60
 - Model Visitor call detector's `TaintFrameAdditionalVisitor` after the instruction was process with the normal logic https://github.com/find-sec-bugs/find-sec-bugs/pull/343/commits/bccb39c1e758a72624bb87a1b7940369c086a6d2#diff-c1d98326cbc7a19685ad97d009b12372R272
 - Visitors can additional tag  https://github.com/find-sec-bugs/find-sec-bugs/pull/343/commits/bccb39c1e758a72624bb87a1b7940369c086a6d2#diff-8bcdb32618913fd1b522ce76a0c05cabR133

The objective is to decouple new logic that create tag and create bug instance. This will avoid making a big monolithic class that meet several needs.
The small danger is that detector could introduce side effect that affect all the other detectors. ⚠️ 