### PR TITLE
Improvement to bug descriptions (Public Website)

### DIFF
--- a/website/templates/bugs.htm
+++ b/website/templates/bugs.htm
@@ -8,10 +8,19 @@
     </div>
 </div>
 
-
-
-
-
+<div class="container">
+    <h2>Table of Contents</h2>
+    <ul>
+        <% bugPatterns.each { b->
+        print """
+          <li><a href="#${b.type}">
+              ${b.title} (${b.type})
+          </a></li>
+        """
+        }
+        %>
+    </ul>
+</div>
 
 <div class="container">
     <div class="row">

--- a/website/templates/bugs.htm
+++ b/website/templates/bugs.htm
@@ -24,7 +24,12 @@
     bugPatterns.each {b->
     print """
     <section>
-        <a class="anchor" name="${b.type}"></a><h2 class="page-header">${b.title}  <a href="#${b.type}" title="Permanent link"><small><i class="fa fa-link"></i></small></a></h2>
+        <a class="anchor" name="${b.type}"></a>
+        <h2 class="page-header">
+            ${b.title}
+            <a href="#${b.type}" title="Permanent link"><small><i class="fa fa-link"></i></small></a>
+        </h2>
+        <p><b>Bug Pattern:</b> <tt>${b.type}</tt></p>
 
         ${b.description}
     </section>


### PR DESCRIPTION
Two fixes in one (sorry, I would create two PRs, but they'd just conflict):

#345 add the "bug pattern" to the bugs documentation page, as people will likely be searching for these strings (since they appear in the findbugs output)

#160 add a table of contents to bugs page