### PR TITLE
Added some XXE Coverage for TransformerFactory

### DIFF
--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -106,9 +106,6 @@ public class Taint {
         URL_ENCODED,
         PATH_TRAVERSAL_SAFE,
 
-        XML_DTD_SAFE,
-        XML_STYLESHEET_SAFE,
-
         CREDIT_CARD_VARIABLE,
         PASSWORD_VARIABLE,
         HASH_VARIABLE;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -106,6 +106,9 @@ public class Taint {
         URL_ENCODED,
         PATH_TRAVERSAL_SAFE,
 
+        XML_DTD_SAFE,
+        XML_STYLESHEET_SAFE,
+
         CREDIT_CARD_VARIABLE,
         PASSWORD_VARIABLE,
         HASH_VARIABLE;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetector.java
@@ -1,0 +1,151 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.xml;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import com.h3xstream.findsecbugs.common.InterfaceUtils;
+import com.h3xstream.findsecbugs.common.StackUtils;
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.injection.InjectionPoint;
+import com.h3xstream.findsecbugs.password.IntuitiveHardcodePasswordDetector;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrameAdditionalVisitor;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.*;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Constants;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.generic.*;
+
+import java.util.Iterator;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+/**
+ * Currently the detector look for a specific code sequence. If the value is not hardcoded or computed at runtime, it will
+ * be consider has possible unsafe.
+ *
+ * Minimal effort was put in this detector to avoid giving alot of resource for code section that usually all look the
+ * same.
+ */
+public class TransformerFactoryDetector extends OpcodeStackDetector {
+
+    private static final String XXE_DTD_TRANSFORM_FACTORY_TYPE = "XXE_DTD_TRANSFORM_FACTORY";
+    private static final String XXE_XSLT_TRANSFORM_FACTORY_TYPE = "XXE_XSLT_TRANSFORM_FACTORY";
+
+    private static final String PROPERTY_SUPPORT_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD";
+    private static final String PROPERTY_SUPPORT_STYLESHEET = "http://javax.xml.XMLConstants/property/accessExternalStylesheet";
+    private static final String PROPERTY_SECURE_PROCESSING = "http://javax.xml.XMLConstants/feature/secure-processing";
+
+    private static final InvokeMatcherBuilder TRANSFORM_METHOD = invokeInstruction() //
+            .atClass("javax/xml/transform/Transformer").atMethod("transform").withArgs("(Ljavax/xml/transform/Source;Ljavax/xml/transform/Result;)V");
+
+    private final BugReporter bugReporter;
+
+    public TransformerFactoryDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen != Constants.INVOKEVIRTUAL && seen != INVOKEINTERFACE && seen != INVOKESTATIC) {
+            return;
+        }
+        String fullClassName = getClassConstantOperand();
+        String method = getNameConstantOperand();
+        //The method call is doing XML parsing (see class javadoc)
+        if (seen == Constants.INVOKESTATIC && fullClassName.equals("javax/xml/transform/TransformerFactory")
+                && method.equals("newInstance")) {
+            ClassContext classCtx = getClassContext();
+            ConstantPoolGen cpg = classCtx.getConstantPoolGen();
+            CFG cfg;
+            try {
+                cfg = classCtx.getCFG(getMethod());
+            } catch (CFGBuilderException e) {
+                AnalysisContext.logError("Cannot get CFG", e);
+                return;
+            }
+
+            //The combination of the 2 following is consider safe
+            boolean hasFeatureDTD = false;
+            boolean hasFeatureStylesheet = false;
+
+            boolean hasSecureProcessing = false;
+
+            for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
+                Location location = i.next();
+                Instruction inst = location.getHandle().getInstruction();
+                //ByteCode.printOpCode(inst, cpg);
+
+                //DTD disallow
+                //factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                //factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+                if(inst instanceof INVOKEVIRTUAL || inst instanceof INVOKEINTERFACE) {
+                    InvokeInstruction invoke = (InvokeInstruction) inst;
+                    if ("setAttribute".equals(invoke.getMethodName(cpg))) {
+                        LDC propertyConst = ByteCode.getPrevInstruction(location.getHandle().getPrev(), LDC.class);
+                        LDC loadConst = ByteCode.getPrevInstruction(location.getHandle(), LDC.class);
+                        if (propertyConst != null && loadConst != null) {
+                            if (PROPERTY_SUPPORT_DTD.equals(propertyConst.getValue(cpg))) {
+                                // Values "" and "all" disable external DTD processing. All other
+                                // values are considered vulnerable
+                                hasFeatureDTD = ("".equals(loadConst.getValue(cpg)) || "all".equals(loadConst.getValue(cpg)));
+                            } else if (PROPERTY_SUPPORT_STYLESHEET.equals(propertyConst.getValue(cpg))){
+                                // Values "" and "all" disable external Stylesheet processing. All other
+                                // values are considered vulnerable
+                                hasFeatureStylesheet = ("".equals(loadConst.getValue(cpg)) || "all".equals(loadConst.getValue(cpg)));
+                            }
+                        }
+                    } else if ("setFeature".equals(invoke.getMethodName(cpg))) {
+                        LDC propertyConst = ByteCode.getPrevInstruction(location.getHandle().getPrev(), LDC.class);
+                        ICONST loadConst = ByteCode.getPrevInstruction(location.getHandle(), ICONST.class);
+                        if (propertyConst != null && loadConst != null
+                                && PROPERTY_SECURE_PROCESSING.equals(propertyConst.getValue(cpg))){
+                            // If SecureProcessing is set to true (loadConst == 1), the call is not vulnerable
+                            hasSecureProcessing = loadConst.getValue().equals(1);
+                        }
+                    }
+                }
+            }
+
+            // Secure Processing includes all the suggested settings
+            if (hasSecureProcessing) {
+                return;
+            }
+
+            String simpleClassName = fullClassName.substring(fullClassName.lastIndexOf('/') + 1);
+
+            //Raise a bug
+            if (!hasFeatureDTD) {
+                bugReporter.reportBug(new BugInstance(this, XXE_DTD_TRANSFORM_FACTORY_TYPE, Priorities.NORMAL_PRIORITY) //
+                        .addClass(this).addMethod(this).addSourceLine(this)
+                        .addString(simpleClassName + "." + method + "(...)"));
+            }
+
+            if (!hasFeatureStylesheet) {
+                bugReporter.reportBug(new BugInstance(this, XXE_XSLT_TRANSFORM_FACTORY_TYPE, Priorities.NORMAL_PRIORITY) //
+                        .addClass(this).addMethod(this).addSourceLine(this)
+                        .addString(simpleClassName + "." + method + "(...)"));
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetector.java
@@ -102,13 +102,13 @@ public class TransformerFactoryDetector extends OpcodeStackDetector {
                         LDC loadConst = ByteCode.getPrevInstruction(location.getHandle(), LDC.class);
                         if (propertyConst != null && loadConst != null) {
                             if (PROPERTY_SUPPORT_DTD.equals(propertyConst.getValue(cpg))) {
-                                // Values "" and "all" disable external DTD processing. All other
-                                // values are considered vulnerable
-                                hasFeatureDTD = ("".equals(loadConst.getValue(cpg)) || "all".equals(loadConst.getValue(cpg)));
+                                // All values other than "all", "http" and "jar" will disable external DTD processing.
+                                // Since other vulnerable values could be added, we do not want to use a blacklist mechanism.
+                                hasFeatureDTD = ( "".equals(loadConst.getValue(cpg)) );
                             } else if (PROPERTY_SUPPORT_STYLESHEET.equals(propertyConst.getValue(cpg))){
-                                // Values "" and "all" disable external Stylesheet processing. All other
-                                // values are considered vulnerable
-                                hasFeatureStylesheet = ("".equals(loadConst.getValue(cpg)) || "all".equals(loadConst.getValue(cpg)));
+                                // All values other than "all", "http" and "jar" will disable external DTD processing.
+                                // Since other vulnerable values could be added, we do not want to use a blacklist mechanism.
+                                hasFeatureStylesheet = ( "".equals(loadConst.getValue(cpg)) );
                             }
                         }
                     } else if ("setFeature".equals(invoke.getMethodName(cpg))) {

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -34,6 +34,7 @@
     <Detector class="com.h3xstream.findsecbugs.file.FileUploadFilenameDetector" reports="FILE_UPLOAD_FILENAME"/>
     <Detector class="com.h3xstream.findsecbugs.ReDosDetector" reports="REDOS"/>
     <Detector class="com.h3xstream.findsecbugs.xml.XxeDetector" reports="XXE_SAXPARSER,XXE_XMLREADER,XXE_DOCUMENT"/>
+    <Detector class="com.h3xstream.findsecbugs.xml.TransformerFactoryDetector" reports="XXE_DTD_TRANSFORM_FACTORY,XXE_XSLT_TRANSFORM_FACTORY"/>
     <Detector class="com.h3xstream.findsecbugs.xml.XmlStreamReaderDetector" reports="XXE_XMLSTREAMREADER"/>
     <Detector class="com.h3xstream.findsecbugs.xpath.XPathInjectionDetector" reports="XPATH_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.endpoint.Struts1EndpointDetector" reports="STRUTS1_ENDPOINT"/>
@@ -161,6 +162,8 @@
     <BugPattern type="XXE_SAXPARSER" abbrev="SECXXESAX" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_XMLREADER" abbrev="SECXXEREAD" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_DOCUMENT" abbrev="SECXXEDOC" category="SECURITY" cweid="611"/>
+    <BugPattern type="XXE_DTD_TRANSFORM_FACTORY" abbrev="SECXXETFDTD" category="SECURITY" cweid="611"/>
+    <BugPattern type="XXE_XSLT_TRANSFORM_FACTORY" abbrev="SECXXETFXSLT" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_XMLSTREAMREADER" abbrev="SECXXESTR" category="SECURITY" cweid="611"/>
     <BugPattern type="XPATH_INJECTION" abbrev="SECXPI" category="SECURITY" cweid="643"/>
     <BugPattern type="STRUTS1_ENDPOINT" abbrev="SECSTR1" category="SECURITY"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1704,7 +1704,6 @@ transformer.transform(input, result);</pre>
 <p>
 The following snippets show two available solutions. You can set one feature or both.
 </p>
-
 <p><b>Solution using "Secure processing" mode:</b></p>
 <p>
 This setting will protect you against remote file access but not denial of service.

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1571,6 +1571,199 @@ Document doc = db.parse(input);</pre>
     <BugCode abbrev="SECXXEDOC">XXE Vulnerability using DocumentBuilder</BugCode>
 
     <!-- XPath Injection for Javax -->
+    <Detector class="com.h3xstream.findsecbugs.xml.TransformerFactoryDetector">
+        <Details>Identify TransformerFactory XML parser usage vulnerable to XXE</Details>
+    </Detector>
+
+    <BugPattern type="XXE_DTD_TRANSFORM_FACTORY">
+        <ShortDescription>XML parsing vulnerable to XXE (TransformerFactory)</ShortDescription>
+        <LongDescription>The use of {3} is vulnerable to XML External Entity attacks</LongDescription>
+        <Details>
+            <![CDATA[
+<!--XXE_GENERIC_START-->
+<h3>Attack</h3>
+<p>XML External Entity (XXE) attacks can occur when an XML parser supports XML entities while processing XML received
+from an untrusted source.</p>
+<p><b>Risk 1: Expose local file content (XXE: <u>X</u>ML e<u>X</u>ternal <u>E</u>ntity)</b></p>
+<p>
+<pre>
+&lt;?xml version=&quot;1.0&quot; encoding=&quot;ISO-8859-1&quot;?&gt;
+&lt;!DOCTYPE foo [
+   &lt;!ENTITY xxe SYSTEM &quot;file:///etc/passwd&quot; &gt; ]&gt;
+&lt;foo&gt;&amp;xxe;&lt;/foo&gt;</pre>
+</p>
+<b>Risk 2: Denial of service (XEE: <u>X</u>ml <u>E</u>ntity <u>E</u>xpansion)</b>
+<p>
+<pre>
+&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;!DOCTYPE lolz [
+ &lt;!ENTITY lol &quot;lol&quot;&gt;
+ &lt;!ELEMENT lolz (#PCDATA)&gt;
+ &lt;!ENTITY lol1 &quot;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&quot;&gt;
+ &lt;!ENTITY lol2 &quot;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&quot;&gt;
+ &lt;!ENTITY lol3 &quot;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&quot;&gt;
+[...]
+ &lt;!ENTITY lol9 &quot;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&quot;&gt;
+]&gt;
+&lt;lolz&gt;&amp;lol9;&lt;/lolz&gt;</pre>
+</p>
+
+<h3>Solution</h3>
+<p>
+In order to avoid exposing dangerous feature of the XML parser, you can do the following change to the code.
+</p>
+<!--XXE_GENERIC_END-->
+
+<p><b>Vulnerable Code:</b></p>
+<p>
+<pre>
+Transformer transformer = TransformerFactory.newInstance().newTransformer();
+transformer.transform(input, result);</pre>
+</p>
+<br/>
+<p>
+The following snippets show two available solutions. You can set one feature or both.
+</p>
+
+<p><b>Solution using "Secure processing" mode:</b></p>
+<p>
+This setting will protect you against remote file access but not denial of service.
+<pre>
+TransformerFactory factory = TransformerFactory.newInstance();
+factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
+
+Transformer transformer = factory.newTransformer();
+transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+transformer.transform(input, result);</pre>
+</p>
+
+<p><b>Solution disabling DTD:</b></p>
+<p>
+This setting will protect you against remote file access but not denial of service.
+<pre>
+TransformerFactory factory = TransformerFactory.newInstance();
+factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+Transformer transformer = factory.newTransformer();
+transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+transformer.transform(input, result);</pre>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<!--XXE_GENERIC_START-->
+<a href="http://cwe.mitre.org/data/definitions/611.html">CWE-611: Improper Restriction of XML External Entity Reference ('XXE')</a><br/>
+<a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=61702260">CERT: IDS10-J. Prevent XML external entity attacks</a><br/>
+<a href="https://www.owasp.org/index.php/XML_External_Entity_%28XXE%29_Processing">OWASP.org: XML External Entity (XXE) Processing</a><br/>
+<a href="http://www.ws-attacks.org/index.php/XML_Entity_Expansion">WS-Attacks.org: XML Entity Expansion</a><br/>
+<a href="http://www.ws-attacks.org/index.php/XML_External_Entity_DOS">WS-Attacks.org: XML External Entity DOS</a><br/>
+<a href="http://www.ws-attacks.org/index.php/XML_Entity_Reference_Attack">WS-Attacks.org: XML Entity Reference Attack</a><br/>
+<a href="http://blog.h3xstream.com/2014/06/identifying-xml-external-entity.html">Identifying Xml eXternal Entity vulnerability (XXE)</a><br/>
+<!--XXE_GENERIC_END-->
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECXXETFDTD">XXE Vulnerability using DocumentBuilder</BugCode>
+
+    <BugPattern type="XXE_XSLT_TRANSFORM_FACTORY">
+        <ShortDescription>XML parsing vulnerable to XXE (TransformerFactory)</ShortDescription>
+        <LongDescription>The use of {3} is vulnerable to XML External Entity attacks</LongDescription>
+        <Details>
+            <![CDATA[
+<!--XXE_GENERIC_START-->
+<h3>Attack</h3>
+<p>XML External Entity (XXE) attacks can occur when an XML parser supports XML entities while processing XML received
+from an untrusted source.</p>
+<p><b>Risk 1: Expose local file content (XXE: <u>X</u>ML e<u>X</u>ternal <u>E</u>ntity)</b></p>
+<p>
+<pre>
+&lt;?xml version=&quot;1.0&quot; encoding=&quot;ISO-8859-1&quot;?&gt;
+&lt;!DOCTYPE foo [
+   &lt;!ENTITY xxe SYSTEM &quot;file:///etc/passwd&quot; &gt; ]&gt;
+&lt;foo&gt;&amp;xxe;&lt;/foo&gt;</pre>
+</p>
+<b>Risk 2: Denial of service (XEE: <u>X</u>ml <u>E</u>ntity <u>E</u>xpansion)</b>
+<p>
+<pre>
+&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;!DOCTYPE lolz [
+ &lt;!ENTITY lol &quot;lol&quot;&gt;
+ &lt;!ELEMENT lolz (#PCDATA)&gt;
+ &lt;!ENTITY lol1 &quot;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&quot;&gt;
+ &lt;!ENTITY lol2 &quot;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&quot;&gt;
+ &lt;!ENTITY lol3 &quot;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&quot;&gt;
+[...]
+ &lt;!ENTITY lol9 &quot;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&quot;&gt;
+]&gt;
+&lt;lolz&gt;&amp;lol9;&lt;/lolz&gt;</pre>
+</p>
+
+<h3>Solution</h3>
+<p>
+In order to avoid exposing dangerous feature of the XML parser, you can do the following change to the code.
+</p>
+<!--XXE_GENERIC_END-->
+
+<p><b>Vulnerable Code:</b></p>
+<p>
+<pre>
+Transformer transformer = TransformerFactory.newInstance().newTransformer();
+transformer.transform(input, result);</pre>
+</p>
+<br/>
+<p>
+The following snippets show two available solutions. You can set one feature or both.
+</p>
+
+<p><b>Solution using "Secure processing" mode:</b></p>
+<p>
+This setting will protect you against remote file access but not denial of service.
+<pre>
+TransformerFactory factory = TransformerFactory.newInstance();
+factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
+
+Transformer transformer = factory.newTransformer();
+transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+transformer.transform(input, result);</pre>
+</p>
+
+<p><b>Solution disabling DTD:</b></p>
+<p>
+This setting will protect you against remote file access but not denial of service.
+<pre>
+TransformerFactory factory = TransformerFactory.newInstance();
+factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+Transformer transformer = factory.newTransformer();
+transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+transformer.transform(input, result);</pre>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<!--XXE_GENERIC_START-->
+<a href="http://cwe.mitre.org/data/definitions/611.html">CWE-611: Improper Restriction of XML External Entity Reference ('XXE')</a><br/>
+<a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=61702260">CERT: IDS10-J. Prevent XML external entity attacks</a><br/>
+<a href="https://www.owasp.org/index.php/XML_External_Entity_%28XXE%29_Processing">OWASP.org: XML External Entity (XXE) Processing</a><br/>
+<a href="http://www.ws-attacks.org/index.php/XML_Entity_Expansion">WS-Attacks.org: XML Entity Expansion</a><br/>
+<a href="http://www.ws-attacks.org/index.php/XML_External_Entity_DOS">WS-Attacks.org: XML External Entity DOS</a><br/>
+<a href="http://www.ws-attacks.org/index.php/XML_Entity_Reference_Attack">WS-Attacks.org: XML Entity Reference Attack</a><br/>
+<a href="http://blog.h3xstream.com/2014/06/identifying-xml-external-entity.html">Identifying Xml eXternal Entity vulnerability (XXE)</a><br/>
+<!--XXE_GENERIC_END-->
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECXXETFXSLT">XXE Vulnerability using DocumentBuilder</BugCode>
+
+    <!-- XPath Injection for Javax -->
     <Detector class="com.h3xstream.findsecbugs.xpath.XPathInjectionDetector">
         <Details>Find XPath queries using tainted inputs</Details>
     </Detector>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -1667,39 +1667,25 @@ transformer.transform(input, result);</pre>
 ]]>
         </Details>
     </BugPattern>
-    <BugCode abbrev="SECXXETFDTD">XXE Vulnerability using DocumentBuilder</BugCode>
+    <BugCode abbrev="SECXXETFDTD">XXE Vulnerability using TransformerFactory</BugCode>
 
     <BugPattern type="XXE_XSLT_TRANSFORM_FACTORY">
-        <ShortDescription>XML parsing vulnerable to XXE (TransformerFactory)</ShortDescription>
-        <LongDescription>The use of {3} is vulnerable to XML External Entity attacks</LongDescription>
+        <ShortDescription>XSLT parsing vulnerable to XXE (TransformerFactory)</ShortDescription>
+        <LongDescription>The use of {3} is vulnerable to XSLT External Entity attacks</LongDescription>
         <Details>
             <![CDATA[
 <!--XXE_GENERIC_START-->
 <h3>Attack</h3>
-<p>XML External Entity (XXE) attacks can occur when an XML parser supports XML entities while processing XML received
+<p>XSLT External Entity (XXE) attacks can occur when an XSLT parser supports external entities while processing XSLT received
 from an untrusted source.</p>
-<p><b>Risk 1: Expose local file content (XXE: <u>X</u>ML e<u>X</u>ternal <u>E</u>ntity)</b></p>
+<p><b>Risk: Expose local file content (XXE: <u>X</u>ML e<u>X</u>ternal <u>E</u>ntity)</b></p>
 <p>
 <pre>
-&lt;?xml version=&quot;1.0&quot; encoding=&quot;ISO-8859-1&quot;?&gt;
-&lt;!DOCTYPE foo [
-   &lt;!ENTITY xxe SYSTEM &quot;file:///etc/passwd&quot; &gt; ]&gt;
-&lt;foo&gt;&amp;xxe;&lt;/foo&gt;</pre>
-</p>
-<b>Risk 2: Denial of service (XEE: <u>X</u>ml <u>E</u>ntity <u>E</u>xpansion)</b>
-<p>
-<pre>
-&lt;?xml version=&quot;1.0&quot;?&gt;
-&lt;!DOCTYPE lolz [
- &lt;!ENTITY lol &quot;lol&quot;&gt;
- &lt;!ELEMENT lolz (#PCDATA)&gt;
- &lt;!ENTITY lol1 &quot;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&quot;&gt;
- &lt;!ENTITY lol2 &quot;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&amp;lol1;&quot;&gt;
- &lt;!ENTITY lol3 &quot;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&quot;&gt;
-[...]
- &lt;!ENTITY lol9 &quot;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&quot;&gt;
-]&gt;
-&lt;lolz&gt;&amp;lol9;&lt;/lolz&gt;</pre>
+&lt;xsl:stylesheet version=&quot;1.0&quot; xmlns:xsl=&quot;http://www.w3.org/1999/XSL/Transform&quot;&gt;
+   &lt;xsl:template match=&quot;/&quot;&gt;
+       &lt;xsl:value-of select=&quot;document(&apos;/etc/passwd&apos;)&quot;&gt;
+   &lt;/xsl:value-of&gt;&lt;/xsl:template&gt;
+&lt;/xsl:stylesheet&gt;</pre>
 </p>
 
 <h3>Solution</h3>
@@ -1761,7 +1747,7 @@ transformer.transform(input, result);</pre>
 ]]>
         </Details>
     </BugPattern>
-    <BugCode abbrev="SECXXETFXSLT">XXE Vulnerability using DocumentBuilder</BugCode>
+    <BugCode abbrev="SECXXETFXSLT">XXE Vulnerability using XSLT in TransformerFactory</BugCode>
 
     <!-- XPath Injection for Javax -->
     <Detector class="com.h3xstream.findsecbugs.xpath.XPathInjectionDetector">

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetectorTest.java
@@ -1,0 +1,100 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.xml;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class TransformerFactoryDetectorTest extends BaseDetectorTest {
+
+    @BeforeClass
+    public void traceCalls() {
+        //FindSecBugsGlobalConfig.getInstance().setDebugTaintState(true);
+        //FindSecBugsGlobalConfig.getInstance().setDebugPrintInvocationVisited(true);
+        //FindSecBugsGlobalConfig.getInstance().setDebugPrintInstructionVisited(true);
+    }
+
+    @Test
+    public void detectXxe() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/xxe/transformerfactory/TransformerFactoryVulnerable")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        List<String> vulnerableMethods = Arrays.asList("parseXMLdefaultValue", "parseXMLDoS", "parseXMLOneLiner",
+                "parseXMLWithXslt", "parseXMLWithMissingAttributeDtd", "parseXMLWithWrongFlag1", "parseXMLWithWrongFlag2");
+        List<String> vulnerableXsltMethods = Arrays.asList("parseXMLdefaultValue", "parseXMLDoS", "parseXMLOneLiner",
+                "parseXMLWithXslt", "parseXMLWithMissingAttributeStylesheet", "parseXMLWithWrongFlag1", "parseXMLWithWrongFlag2");
+
+        for (String method : vulnerableMethods) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("XXE_DTD_TRANSFORM_FACTORY")
+                            .inClass("TransformerFactoryVulnerable").inMethod(method)
+                            .build()
+            );
+        }
+
+        for (String method : vulnerableXsltMethods) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("XXE_XSLT_TRANSFORM_FACTORY")
+                            .inClass("TransformerFactoryVulnerable").inMethod(method)
+                            .build()
+            );
+        }
+    }
+
+    @Test
+    public void avoidFalsePositive() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/xxe/transformerfactory/TransformerFactorySafe")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_DTD_TRANSFORM_FACTORY")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_XSLT_TRANSFORM_FACTORY")
+                        .build()
+        );
+    }
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xml/TransformerFactoryDetectorTest.java
@@ -72,6 +72,23 @@ public class TransformerFactoryDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+
+        // We do not want to spam users with multiple report of the "same" vulnerability
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_SAXPARSER")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_XMLREADER")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_DOCUMENT")
+                        .build()
+        );
     }
 
     @Test
@@ -94,6 +111,23 @@ public class TransformerFactoryDetectorTest extends BaseDetectorTest {
         verify(reporter, never()).doReportBug(
                 bugDefinition()
                         .bugType("XXE_XSLT_TRANSFORM_FACTORY")
+                        .build()
+        );
+
+        // We do not want to spam users with multiple report of the "same" vulnerability
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_SAXPARSER")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_XMLREADER")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_DOCUMENT")
                         .build()
         );
     }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xml/XxeDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xml/XxeDetectorTest.java
@@ -55,6 +55,16 @@ public class XxeDetectorTest extends BaseDetectorTest {
                         .bugType("XXE_DOCUMENT")
                         .build()
         );
+        Mockito.verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_DTD_TRANSFORM_FACTORY")
+                        .build()
+        );
+        Mockito.verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_XSLT_TRANSFORM_FACTORY")
+                        .build()
+        );
     }
 
     @Test
@@ -85,6 +95,16 @@ public class XxeDetectorTest extends BaseDetectorTest {
                         .bugType("XXE_DOCUMENT")
                         .build()
         );
+        Mockito.verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_DTD_TRANSFORM_FACTORY")
+                        .build()
+        );
+        Mockito.verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_XSLT_TRANSFORM_FACTORY")
+                        .build()
+        );
     }
 
     @Test
@@ -113,6 +133,16 @@ public class XxeDetectorTest extends BaseDetectorTest {
         verify(reporter, never()).doReportBug(
                 bugDefinition()
                         .bugType("XXE_DOCUMENT")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_DTD_TRANSFORM_FACTORY")
+                        .build()
+        );
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_XSLT_TRANSFORM_FACTORY")
                         .build()
         );
     }

--- a/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactorySafe.java
+++ b/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactorySafe.java
@@ -50,24 +50,7 @@ public class TransformerFactorySafe {
         outWriter.toString();
     }
 
-    // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory
     public void parseXMLSafe2(Source input) throws XMLStreamException, TransformerException {
-
-        TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
-
-        Transformer transformer = factory.newTransformer();
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-
-        StringWriter outWriter = new StringWriter();
-        StreamResult result = new StreamResult(outWriter);
-
-        transformer.transform(input, result);
-        outWriter.toString();
-    }
-
-    public void parseXMLSafe3(Source input) throws XMLStreamException, TransformerException {
 
         TransformerFactory factory = TransformerFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
@@ -99,24 +82,7 @@ public class TransformerFactorySafe {
         outWriter.toString();
     }
 
-    // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory
     public void parseXSLTSafe2(Source input, Source xslt) throws XMLStreamException, TransformerException {
-
-        TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
-
-        Transformer transformer = factory.newTransformer(xslt);
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-
-        StringWriter outWriter = new StringWriter();
-        StreamResult result = new StreamResult(outWriter);
-
-        transformer.transform(input, result);
-        outWriter.toString();
-    }
-
-    public void parseXSLTSafe3(Source input, Source xslt) throws XMLStreamException, TransformerException {
 
         TransformerFactory factory = TransformerFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactorySafe.java
+++ b/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactorySafe.java
@@ -1,0 +1,133 @@
+package testcode.xxe.transformerfactory;
+
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.Source;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+public class TransformerFactorySafe {
+    public static void main(String[] args) throws Exception {
+        new TransformerFactorySafe().loadXml();
+    }
+
+    public void loadXml() throws XMLStreamException, TransformerException {
+        InputStream in = getClass().getResourceAsStream("/testcode/xxe/simple_xxe.xml");
+        InputStream xslt_in = getClass().getResourceAsStream("/testcode/xxe/simple_xxe.xslt");
+
+        if(in == null) System.out.println("Oups XML file not found.");
+        if(xslt_in == null) System.out.println("Oups XSLT file not found.");
+
+        Source source = new StreamSource(in);
+        Source xslt = new StreamSource(xslt_in);
+
+        parseXMLSafe1(source);
+        //parseXMLSafe2(source);
+        //parseXSLTSafe1(source, xslt);
+        //parseXSLTSafe2(source, xslt);
+    }
+
+    // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory
+    public void parseXMLSafe1(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory
+    public void parseXMLSafe2(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
+
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    public void parseXMLSafe3(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory
+    public void parseXSLTSafe1(Source input, Source xslt) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+
+        Transformer transformer = factory.newTransformer(xslt);
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory
+    public void parseXSLTSafe2(Source input, Source xslt) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
+
+        Transformer transformer = factory.newTransformer(xslt);
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    public void parseXSLTSafe3(Source input, Source xslt) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        Transformer transformer = factory.newTransformer(xslt);
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+}

--- a/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactorySafe.java
+++ b/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactorySafe.java
@@ -27,7 +27,7 @@ public class TransformerFactorySafe {
         Source source = new StreamSource(in);
         Source xslt = new StreamSource(xslt_in);
 
-        parseXMLSafe1(source);
+        //parseXMLSafe1(source);
         //parseXMLSafe2(source);
         //parseXSLTSafe1(source, xslt);
         //parseXSLTSafe2(source, xslt);

--- a/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactoryVulnerable.java
+++ b/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactoryVulnerable.java
@@ -121,8 +121,8 @@ public class TransformerFactoryVulnerable {
     public void parseXMLWithWrongFlag1(Source input) throws XMLStreamException, TransformerException {
 
         TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "http");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
 
         Transformer transformer = factory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactoryVulnerable.java
+++ b/plugin/src/test/java/testcode/xxe/transformerfactory/TransformerFactoryVulnerable.java
@@ -1,0 +1,151 @@
+package testcode.xxe.transformerfactory;
+
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.Source;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+public class TransformerFactoryVulnerable {
+
+
+    public static void main(String[] args) throws Exception {
+        new TransformerFactoryVulnerable().loadXml();
+    }
+
+    public void loadXml() throws XMLStreamException, TransformerException {
+        InputStream in = getClass().getResourceAsStream("/testcode/xxe/simple_xxe.xml");
+        InputStream dos_in = getClass().getResourceAsStream("/testcode/xxe/dos_xxe.xml");
+        InputStream xslt_in = getClass().getResourceAsStream("/testcode/xxe/simple_xxe.xslt");
+
+        if(in == null) System.out.println("Oups XML file not found.");
+        if(dos_in == null) System.out.println("Oups XML DoS file not found.");
+        if(xslt_in == null) System.out.println("Oups XSLT file not found.");
+
+        Source source = new StreamSource(in);
+        Source source_dos = new StreamSource(dos_in);
+        Source xslt = new StreamSource(xslt_in);
+
+        parseXMLdefaultValue(source);
+        //parseXMLDoS(source_dos);
+        //parseXMLOneLiner(source);
+        //parseXMLWithXslt(source, xslt);
+        //parseXMLWithMissingAttributeStylesheet(source, xslt);
+        //parseXMLWithMissingAttributeDtd(source, xslt);
+        //parseXMLWithWrongFlag1(source);
+        //parseXMLWithWrongFlag2(source);
+    }
+
+    public void parseXMLdefaultValue(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        Transformer transformer = factory.newTransformer();
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    public void parseXMLDoS(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        Transformer transformer = factory.newTransformer();
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    public void parseXMLOneLiner(Source input) throws XMLStreamException, TransformerException {
+
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    public void parseXMLWithXslt(Source input, Source xslt) throws XMLStreamException, TransformerException {
+
+        Transformer transformer = TransformerFactory.newInstance().newTransformer(xslt);
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        outWriter.toString();
+    }
+
+    public void parseXMLWithMissingAttributeStylesheet(Source input, Source xslt) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+
+        Transformer transformer = factory.newTransformer(xslt);
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        result.toString();
+    }
+
+    public void parseXMLWithMissingAttributeDtd(Source input, Source xslt) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+
+        Transformer transformer = factory.newTransformer(xslt);
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        result.toString();
+    }
+
+    public void parseXMLWithWrongFlag1(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "http");
+
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        result.toString();
+    }
+
+    public void parseXMLWithWrongFlag2(Source input) throws XMLStreamException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);
+
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter outWriter = new StringWriter();
+        StreamResult result = new StreamResult(outWriter);
+
+        transformer.transform(input, result);
+        result.toString();
+    }
+}

--- a/plugin/src/test/java/testcode/xxe/xmlinputfactory/XmlInputFactorySafe.java
+++ b/plugin/src/test/java/testcode/xxe/xmlinputfactory/XmlInputFactorySafe.java
@@ -12,12 +12,21 @@ public class XmlInputFactorySafe {
 
     public void loadXml() throws XMLStreamException {
         InputStream in = getClass().getResourceAsStream("/testcode/xxe/simple_xxe.xml");
+        InputStream dos_in = getClass().getResourceAsStream("/testcode/xxe/dos_xxe.xml");
 
-        if(in == null) System.out.println("Oups file not found.");
+        if(in == null) System.out.println("Oups XML file not found.");
+        if(dos_in == null) System.out.println("Oups XML DoS file not found.");
 
-//        parseXMLSafe1(in);
-        parseXMLSafe2(in);
-//        parseXMLSafe3(in);
+        //parseXMLSafe1(in);
+        //parseXMLSafe2(in);
+        //parseXMLSafe3(in);
+        //parseXMLSafe4(in);
+
+        // Testing for entity embedding (lol bomb)
+        //parseXMLSafe1(dos_in);
+        //parseXMLSafe2(dos_in);
+        //parseXMLSafe3(dos_in);
+        //parseXMLSafe4(dos_in);
     }
 
     public void parseXMLSafe1(InputStream input) throws XMLStreamException {

--- a/plugin/src/test/resources/testcode/xxe/dos_xxe.xml
+++ b/plugin/src/test/resources/testcode/xxe/dos_xxe.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+        <!ENTITY lol "lol">
+        <!ELEMENT lolz (#PCDATA)>
+        <!ENTITY lol1 "&lol;&lol;">
+        <!ENTITY lol2 "&lol1;&lol1;&lol1;">
+        <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;">
+        ]>
+<lolz>&lol3;</lolz>

--- a/plugin/src/test/resources/testcode/xxe/simple_xxe.xslt
+++ b/plugin/src/test/resources/testcode/xxe/simple_xxe.xslt
@@ -1,0 +1,5 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:template match="/">
+        <xsl:value-of select="document('http://csrf.me/findsecbugs')"></xsl:value-of>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
I have created a detector to add some XXE coverage (related to issue #138).

This detector detects the use of the TransformerFactory class without the `FEATURE_SECURE_PROCESSING`, `ACCESS_EXTERNAL_DTD` or `ACCESS_EXTERNAL_STYLESHEET` flags.

I have noted during my tests that even if these flags are set, the TransformerFactory class is still vulnerable to Denial of Service attacks (like LoL Bombs). However, I have not found a way to completely remove entity processing in the classic TransformerFactory.

I have also discovered during my tests that the `XmlInputFactorySafe.parseXMLSafe2` method could also be vulnerable to XXE Denial or Service attacks. Maybe this should not be considered "safe" but should instead flag a lower severity vulnerability.