### PR TITLE
Optional API and improvement to crypto detector

### DIFF
--- a/plugin-deps/src/main/java/com/google/common/base/Optional.java
+++ b/plugin-deps/src/main/java/com/google/common/base/Optional.java
@@ -1,0 +1,7 @@
+package com.google.common.base;
+
+import java.io.Serializable;
+
+public abstract class Optional<T> implements Serializable {
+    public abstract T or(T defaultValue);
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/PotentialValueDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/PotentialValueDetector.java
@@ -1,0 +1,77 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrameAdditionalVisitor;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.LoadInstruction;
+import org.apache.bcel.generic.MethodGen;
+
+import java.util.List;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+public class PotentialValueDetector extends BasicInjectionDetector implements TaintFrameAdditionalVisitor {
+
+    private static final InvokeMatcherBuilder PROPERTIES_GET_WITH_DEFAULT = invokeInstruction()
+            .atClass("java/util/Properties")
+            .atMethod("getProperty")
+            .withArgs("(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+
+    private static final InvokeMatcherBuilder OPTIONAL_OR = invokeInstruction()
+            .atClass("com/google/common/base/Optional")
+            .atMethod("or")
+            .withArgs("(Ljava/lang/Object;)Ljava/lang/Object;");
+
+    private static final InvokeMatcherBuilder HASHMAP_GET_WITH_DEFAULT = invokeInstruction()
+            .atClass("java/util/HashMap")
+            .atMethod("getOrDefault")
+            .withArgs("(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+    public PotentialValueDetector(BugReporter bugReporter) {
+        super(bugReporter);
+        registerVisitor(this);
+    }
+
+
+    @Override
+    public void visitInvoke(InvokeInstruction invoke, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, List<Taint> parameters) throws DataflowAnalysisException{
+
+        if(PROPERTIES_GET_WITH_DEFAULT.matches(invoke,cpg) || OPTIONAL_OR.matches(invoke,cpg) || HASHMAP_GET_WITH_DEFAULT.matches(invoke,cpg)) {
+            Taint defaultVal = parameters.get(0); //Top of the stack last arguments
+            if(defaultVal.getConstantValue() != null) {
+                Taint value = frameType.getTopValue();
+                value.setPotentialValue(defaultVal.getConstantValue());
+            }
+        }
+
+        //ByteCode.printOpCode(invoke,cpg);
+    }
+
+    @Override
+    public void visitLoad(LoadInstruction load, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, int numProduced) {
+
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/common/TaintUtil.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/common/TaintUtil.java
@@ -1,0 +1,32 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.common;
+
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+
+public class TaintUtil {
+
+    public static boolean isConstantValueAndNotEmpty(Taint value) {
+        return (value.getConstantValue() != null && !value.getConstantValue().isEmpty())
+                || (value.getPotentialValue() != null && !value.getPotentialValue().isEmpty());
+    }
+
+    public static boolean isConstantValue(Taint value) {
+        return value.getConstantValue() != null || value.getPotentialValue() != null;
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsecureSmtpSslDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsecureSmtpSslDetector.java
@@ -71,7 +71,6 @@ public class InsecureSmtpSslDetector implements Detector {
 
         HashMap<Location, String> sslConnMap = new HashMap<Location, String>();
         HashSet<String> sslCertVerSet = new HashSet<String>();
-        Location locationWeakness = null;
         String hostName = null;
 
         ConstantPoolGen cpg = classContext.getConstantPoolGen();

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsufficientKeySizeRsaDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsufficientKeySizeRsaDetector.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
  */
 public class InsufficientKeySizeRsaDetector implements Detector {
 
-    private static final boolean DEBUG = false;
     private static final String RSA_KEY_SIZE_TYPE = "RSA_KEY_SIZE";
 
     private BugReporter bugReporter;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsufficientKeySizeRsaDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/InsufficientKeySizeRsaDetector.java
@@ -121,7 +121,7 @@ public class InsufficientKeySizeRsaDetector implements Detector {
                     }
                 }
             }
-        }       
+        }
     }
 
     private void addToReport(Method m, ClassContext classContext, Location locationWeakness, Number n){

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/OldDesUsageDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/OldDesUsageDetector.java
@@ -41,14 +41,15 @@ import org.apache.bcel.Constants;
  *
  * Ref: <a href="http://docs.oracle.com/javase/7/docs/api/javax/crypto/Cipher.html">Partial list of ciphers</a>
  */
-public class DesUsageDetector extends OpcodeStackDetector {
+@Deprecated
+public class OldDesUsageDetector extends OpcodeStackDetector {
 
     private static final boolean DEBUG = false;
     private static final String DES_USAGE_TYPE = "DES_USAGE";
 
     private BugReporter bugReporter;
 
-    public DesUsageDetector(BugReporter bugReporter) {
+    public OldDesUsageDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/OldRsaNoPaddingDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/OldRsaNoPaddingDetector.java
@@ -28,13 +28,14 @@ import org.apache.bcel.Constants;
 /**
  * Ref: http://cwe.mitre.org/data/definitions/780.html
  */
-public class RsaNoPaddingDetector extends OpcodeStackDetector {
+@Deprecated
+public class OldRsaNoPaddingDetector extends OpcodeStackDetector {
 
     private static final String RSA_NO_PADDING_TYPE = "RSA_NO_PADDING";
 
     private final BugReporter bugReporter;
 
-    public RsaNoPaddingDetector(BugReporter bugReporter) {
+    public OldRsaNoPaddingDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/CipherDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/CipherDetector.java
@@ -1,0 +1,108 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.crypto.cipher;
+
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.injection.InjectionPoint;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+public abstract class CipherDetector extends BasicInjectionDetector {
+
+
+    private static final String DES_USAGE_TYPE = "DES_USAGE";
+
+    private static final InvokeMatcherBuilder CIPHER_GET_INSTANCE = invokeInstruction()
+            .atClass("javax/crypto/Cipher")
+            .atMethod("getInstance")
+            .withArgs("(Ljava/lang/String;)Ljavax/crypto/Cipher;");
+    private static final InvokeMatcherBuilder CIPHER_GET_INSTANCE_PROVIDER = invokeInstruction()
+            .atClass("javax/crypto/Cipher")
+            .atMethod("getInstance")
+            .withArgs("(Ljava/lang/String;Ljava/lang/String;)Ljavax/crypto/Cipher;",
+                    "(Ljava/lang/String;Ljava/security/Provider;)Ljavax/crypto/Cipher;");
+
+    private static final InvokeMatcherBuilder KEYGENERATOR_GET_INSTANCE = invokeInstruction()
+            .atClass("javax/crypto/KeyGenerator")
+            .atMethod("getInstance")
+            .withArgs("(Ljava/lang/String;)Ljavax/crypto/KeyGenerator;");
+    private static final InvokeMatcherBuilder KEYGENERATOR_GET_INSTANCE_PROVIDER = invokeInstruction()
+            .atClass("javax/crypto/KeyGenerator")
+            .atMethod("getInstance")
+            .withArgs("(Ljava/lang/String;Ljava/lang/String;)Ljavax/crypto/KeyGenerator;",
+                    "(Ljava/lang/String;Ljava/security/Provider;)Ljavax/crypto/KeyGenerator;");
+
+
+    public CipherDetector(BugReporter bugReporter) {
+        super(bugReporter);
+    }
+
+    /**
+     * Hook Cipher.getInstance(), KeyGenerator.getInstance()
+     * @param invoke
+     * @param cpg
+     * @param handle
+     * @return
+     */
+    @Override
+    protected InjectionPoint getInjectionPoint(InvokeInstruction invoke, ConstantPoolGen cpg,
+                                               InstructionHandle handle) {
+        assert invoke != null && cpg != null;
+
+        //ByteCode.printOpCode(invoke,cpg);
+
+        if(CIPHER_GET_INSTANCE.matches(invoke,cpg)) {
+            return new InjectionPoint(new int[]{0}, getBugPattern());
+        }
+        else if(CIPHER_GET_INSTANCE_PROVIDER.matches(invoke,cpg)) {
+            return new InjectionPoint(new int[]{1}, getBugPattern());
+        }
+        else if(KEYGENERATOR_GET_INSTANCE.matches(invoke,cpg)) {
+            return new InjectionPoint(new int[]{0}, getBugPattern());
+        }
+        else if(KEYGENERATOR_GET_INSTANCE_PROVIDER.matches(invoke,cpg)) {
+            return new InjectionPoint(new int[]{1}, getBugPattern());
+        }
+        return InjectionPoint.NONE;
+    }
+
+    @Override
+    protected int getPriorityFromTaintFrame(TaintFrame fact, int offset)
+            throws DataflowAnalysisException {
+
+        Taint valueTaint = fact.getStackValue(offset);
+
+        String cipherValue = valueTaint.getConstantOrPotentialValue();
+        if(cipherValue == null) {
+            return Priorities.IGNORE_PRIORITY;
+        }
+        return getCipherPriority(cipherValue);
+    }
+
+    abstract int    getCipherPriority(String cipherValue);
+    abstract String getBugPattern();
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/DesUsageDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/DesUsageDetector.java
@@ -1,0 +1,67 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.crypto.cipher;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.injection.InjectionPoint;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+/**
+ * <b>Cipher identify</b>
+ *
+ * <ul>
+ * <li>DES/CBC/NoPadding (56 bit)</li>
+ * <li>DES/CBC/PKCS5Padding (56 bit)</li>
+ * <li>DES/ECB/NoPadding (56 bit)</li>
+ * <li>DES/ECB/PKCS5Padding (56 bit)</li>
+ * </ul>
+ *
+ * Ref: <a href="http://docs.oracle.com/javase/7/docs/api/javax/crypto/Cipher.html">Partial list of ciphers</a>
+ */
+public class DesUsageDetector extends CipherDetector {
+
+
+    public DesUsageDetector(BugReporter bugReporter) {
+        super(bugReporter);
+    }
+
+    @Override
+    int getCipherPriority(String cipherValue) {
+        cipherValue = cipherValue.toLowerCase();
+        if (cipherValue.equals("des") || cipherValue.startsWith("des/")) {
+            return Priorities.NORMAL_PRIORITY;
+        }
+        return Priorities.IGNORE_PRIORITY;
+    }
+
+    @Override
+    String getBugPattern() {
+        return "DES_USAGE";
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/RsaNoPaddingDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/RsaNoPaddingDetector.java
@@ -1,4 +1,43 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.crypto.cipher;
 
-public class RsaNoPaddingDetector {
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+
+public class RsaNoPaddingDetector extends CipherDetector {
+
+    public RsaNoPaddingDetector(BugReporter bugReporter) {
+        super(bugReporter);
+    }
+
+    @Override
+    int getCipherPriority(String cipherValue) {
+        //cipherValue = cipherValue.toLowerCase();
+
+        if (cipherValue.startsWith("RSA/") && cipherValue.endsWith("/NoPadding")) {
+            return Priorities.NORMAL_PRIORITY;
+        }
+        return Priorities.IGNORE_PRIORITY;
+    }
+
+    @Override
+    String getBugPattern() {
+        return "RSA_NO_PADDING";
+    }
 }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/RsaNoPaddingDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/RsaNoPaddingDetector.java
@@ -1,0 +1,4 @@
+package com.h3xstream.findsecbugs.crypto.cipher;
+
+public class RsaNoPaddingDetector {
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/TDesUsageDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/crypto/cipher/TDesUsageDetector.java
@@ -1,0 +1,55 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.crypto.cipher;
+
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+
+/**
+ * <b>Cipher identify</b>
+ *
+ * <ul>
+ * <li>DESede/CBC/NoPadding (168 bit)</li>
+ * <li>DESede/CBC/PKCS5Padding (168 bit)</li>
+ * <li>DESede/ECB/NoPadding (168 bit)</li>
+ * <li>DESede/ECB/PKCS5Padding (168 bit)</li>
+ * </ul>
+ *
+ * Ref: <a href="http://docs.oracle.com/javase/7/docs/api/javax/crypto/Cipher.html">Partial list of ciphers</a>
+ */
+public class TDesUsageDetector extends CipherDetector {
+
+
+    public TDesUsageDetector(BugReporter bugReporter) {
+        super(bugReporter);
+    }
+
+    @Override
+    int getCipherPriority(String cipherValue) {
+        cipherValue = cipherValue.toLowerCase();
+        if (cipherValue.equals("desede") || cipherValue.startsWith("desede/")) {
+            return Priorities.LOW_PRIORITY;
+        }
+        return Priorities.IGNORE_PRIORITY;
+    }
+
+    @Override
+    String getBugPattern() {
+        return "TDES_USAGE";
+    }
+}

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/injection/InjectionSink.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/injection/InjectionSink.java
@@ -142,10 +142,8 @@ public class InjectionSink {
 
         for(TaintLocation source : unknownSources) {
             addMessage(bug, "Unknown source", source.getTaintSource());
-            //md.getSlashedClassName() + "." + md.getName() + md.getSignature());
         }
 
-        addMessage(bug, "Sink method", sinkMethod);
         if (sinkPriority != UNKNOWN_SINK_PRIORITY) {
             // higher priority is represented by lower integer
             if (sinkPriority < originalPriority) {

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/password/HardcodedPasswordEqualsDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/password/HardcodedPasswordEqualsDetector.java
@@ -18,6 +18,7 @@
 package com.h3xstream.findsecbugs.password;
 
 import com.h3xstream.findsecbugs.common.StackUtils;
+import com.h3xstream.findsecbugs.common.TaintUtil;
 import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
 import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
 import com.h3xstream.findsecbugs.injection.InjectionPoint;
@@ -33,6 +34,8 @@ import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.LoadInstruction;
 import org.apache.bcel.generic.LocalVariableGen;
 import org.apache.bcel.generic.MethodGen;
+
+import java.util.List;
 
 import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
 
@@ -71,8 +74,8 @@ public class HardcodedPasswordEqualsDetector extends BasicInjectionDetector impl
 
         //If a constant value is compare with the variable
         //Empty constant are ignored.. it is most likely a validation to make sure it is not empty
-        boolean valueHardcodedLeft = leftValue.getConstantValue() != null && !leftValue.getConstantValue().isEmpty();
-        boolean valueHardcodedRight = rightValue.getConstantValue() != null && !rightValue.getConstantValue().isEmpty();
+        boolean valueHardcodedLeft = TaintUtil.isConstantValueAndNotEmpty(leftValue);
+        boolean valueHardcodedRight = TaintUtil.isConstantValueAndNotEmpty(rightValue);
 
         //Is a constant value that was tag because the value was place in a variable name "password" at some point.
         if ((passwordVariableLeft && valueHardcodedRight) ||
@@ -82,6 +85,7 @@ public class HardcodedPasswordEqualsDetector extends BasicInjectionDetector impl
             return Priorities.IGNORE_PRIORITY;
         }
     }
+
 
     @Override
     protected InjectionPoint getInjectionPoint(InvokeInstruction invoke, ConstantPoolGen cpg,
@@ -93,7 +97,7 @@ public class HardcodedPasswordEqualsDetector extends BasicInjectionDetector impl
     }
 
     @Override
-    public void visitInvoke(InvokeInstruction instruction, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType) {
+    public void visitInvoke(InvokeInstruction instruction, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, List<Taint> parameters) {
         //ByteCode.printOpCode(instruction, cpg);
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/password/HashUnsafeEqualsDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/password/HashUnsafeEqualsDetector.java
@@ -103,7 +103,7 @@ public class HashUnsafeEqualsDetector extends BasicInjectionDetector implements 
     }
 
     @Override
-    public void visitInvoke(InvokeInstruction invoke, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType) {
+    public void visitInvoke(InvokeInstruction invoke, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, List<Taint> parameters) {
 
     }
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/password/IntuitiveHardcodePasswordDetector.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/password/IntuitiveHardcodePasswordDetector.java
@@ -17,6 +17,7 @@
  */
 package com.h3xstream.findsecbugs.password;
 
+import com.h3xstream.findsecbugs.common.TaintUtil;
 import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
 import com.h3xstream.findsecbugs.injection.InjectionPoint;
 import com.h3xstream.findsecbugs.taintanalysis.Taint;
@@ -78,7 +79,7 @@ public class IntuitiveHardcodePasswordDetector extends BasicInjectionDetector {
             throws DataflowAnalysisException {
         Taint stringValue = fact.getStackValue(offset);
 
-        if (stringValue.isSafe() && stringValue.getConstantValue() != null) { //Is a constant value
+        if (TaintUtil.isConstantValue(stringValue)) { //Is a constant value
             return Priorities.NORMAL_PRIORITY;
         } else {
             return Priorities.IGNORE_PRIORITY;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -203,9 +203,8 @@ public class Taint {
      * @throws IllegalStateException if index is uknown
      */
     public int getVariableIndex() {
-        if (variableIndex == INVALID_INDEX) {
-            throw new IllegalStateException("index not set or has been invalidated");
-        }
+        if (variableIndex == INVALID_INDEX) throw new IllegalStateException("index not set or has been invalidated");
+
         assert variableIndex >= 0;
         return variableIndex;
     }
@@ -220,9 +219,7 @@ public class Taint {
     }
 
     void setVariableIndex(int index) {
-        if (index < 0) {
-            throw new IllegalArgumentException("negative index");
-        }
+        if (index < 0) throw new IllegalArgumentException("negative index");
         variableIndex = index;
     }
 
@@ -675,7 +672,7 @@ public class Taint {
             sb.append(" potential=").append(potentialValue);
         }
         if (tags.size() > 0) {
-            sb.append(" tags: ").append(Arrays.toString(tags.toArray()));
+            sb.append(" tags=").append(Arrays.toString(tags.toArray()));
         }
         return sb.toString();
     }

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -122,6 +122,7 @@ public class Taint {
     private final Set<Tag> tags;
     private final Set<Tag> tagsToRemove;
     private String constantValue;
+    private String potentialValue;
     private String debugInfo = null;
 
     /**
@@ -170,6 +171,7 @@ public class Taint {
         this.tags = EnumSet.copyOf(taint.tags);
         this.tagsToRemove = EnumSet.copyOf(taint.tagsToRemove);
         this.constantValue = taint.constantValue;
+        this.potentialValue = taint.potentialValue;
         if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             this.debugInfo = taint.debugInfo;
         }
@@ -460,10 +462,27 @@ public class Taint {
         return constantValue;
     }
     
-    void setConstantValue(String value) {
+    public void setConstantValue(String value) {
         this.constantValue = value;
     }
-    
+
+    /**
+     * Returns the constant value that will be set under a specific condition
+     *
+     * @return constant value or null if unknown
+     */
+    public String getPotentialValue() {
+        return potentialValue;
+    }
+
+    public void setPotentialValue(String value) {
+        this.potentialValue = value;
+    }
+
+    public String getConstantOrPotentialValue() {
+        return constantValue != null ? constantValue : potentialValue;
+    }
+
     /**
      * Constructs a new instance of taint from the specified state name
      * 
@@ -529,6 +548,12 @@ public class Taint {
             result.setDebugInfo("[" + a.getDebugInfo() + "]+[" + b.getDebugInfo() + "]");
         }
         assert !result.hasParameters() || result.isUnknown();
+        if(a.potentialValue != null) {
+            result.potentialValue = a.potentialValue;
+        }
+        else if(b.potentialValue != null) {
+            result.potentialValue = b.potentialValue;
+        }
         return result;
     }
 
@@ -642,6 +667,12 @@ public class Taint {
         }
         if (debugInfo != null) {
             sb.append(" {").append(debugInfo).append('}');
+        }
+        if (constantValue != null) {
+            sb.append(" constant=").append(constantValue);
+        }
+        if (potentialValue != null) {
+            sb.append(" potential=").append(potentialValue);
         }
         if (tags.size() > 0) {
             sb.append(" tags: ").append(Arrays.toString(tags.toArray()));

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -68,9 +68,7 @@ public class Taint {
          */
         public static State merge(State a, State b) {
             if (a == null || b == null) {
-                throw new NullPointerException(
-                        "use Taint.State." + INVALID.name() + " instead of null"
-                );
+                throw new NullPointerException("use Taint.State." + INVALID.name() + " instead of null");
             }
             if (a == TAINTED || b == TAINTED) {
                 return TAINTED;

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -75,7 +75,7 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
         "other.txt"
     };
     private final TaintConfig taintConfig = new TaintConfig();
-    private static Writer writer = null;
+    protected static Writer writer = null;
     private static List<TaintFrameAdditionalVisitor> visitors = new ArrayList<TaintFrameAdditionalVisitor>();
 
 

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -61,6 +61,7 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
         "java-lang.txt",
         "java-ee.txt",
         "collections.txt",
+        "guava.txt",
         "java-net.txt",
         "scala.txt",
         "logging.txt",

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameAdditionalVisitor.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameAdditionalVisitor.java
@@ -22,15 +22,18 @@ import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.LoadInstruction;
 import org.apache.bcel.generic.MethodGen;
 
+import java.util.List;
+
 public interface TaintFrameAdditionalVisitor {
 
     /**
-     *  @param invoke
+     * @param invoke
      * @param cpg
-     * @param methodGen
-     * @param frameType
+     * @param methodGen Method
+     * @param frameType Frame representation after the invoke (results)
+     * @param parameters Stack representation just before the invoke
      */
-    void visitInvoke(InvokeInstruction invoke, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType);
+    void visitInvoke(InvokeInstruction invoke, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, List<Taint> parameters) throws Exception;
 
     /**
      * @param load
@@ -39,6 +42,6 @@ public interface TaintFrameAdditionalVisitor {
      * @param frameType
      * @param numProduced
      */
-    void visitLoad(LoadInstruction load, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, int numProduced);
+    void visitLoad(LoadInstruction load, ConstantPoolGen cpg, MethodGen methodGen, TaintFrame frameType, int numProduced) throws Exception;
 
 }

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -51,7 +51,8 @@
     <Detector class="com.h3xstream.findsecbugs.crypto.NullCipherDetector" reports="NULL_CIPHER"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedSocketDetector" reports="UNENCRYPTED_SOCKET"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedServerSocketDetector" reports="UNENCRYPTED_SERVER_SOCKET"/>
-    <Detector class="com.h3xstream.findsecbugs.crypto.DesUsageDetector" reports="DES_USAGE"/>
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.DesUsageDetector" reports="DES_USAGE"/>
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.TDesUsageDetector" reports="TDES_USAGE"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector" reports="RSA_NO_PADDING"/>
     <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector" reports="HARD_CODE_PASSWORD,HARD_CODE_KEY"/>
     <Detector class="com.h3xstream.findsecbugs.password.GoogleApiKeyDetector" reports="HARD_CODE_PASSWORD"/>
@@ -114,6 +115,7 @@
     <Detector class="com.h3xstream.findsecbugs.injection.formatter.FormatStringManipulationDetector" reports="FORMAT_STRING_MANIPULATION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.http.HttpParameterPollutionDetector" reports="HTTP_PARAMETER_POLLUTION"/>
     <Detector class="com.h3xstream.findsecbugs.spring.SpringUnvalidatedRedirectDetector" reports="SPRING_UNVALIDATED_REDIRECT"/>
+    <Detector class="com.h3xstream.findsecbugs.PotentialValueDetector" reports="HARD_CODE_PASSWORD,DES_USAGE,WEAK_MESSAGE_DIGEST_MD5,WEAK_MESSAGE_DIGEST_SHA1"/>
 
     <BugPattern type="HTTP_PARAMETER_POLLUTION" abbrev="SECHPP" category="SECURITY"/>
     <BugPattern type="FORMAT_STRING_MANIPULATION" abbrev="SECFSM" category="SECURITY"/>
@@ -187,7 +189,8 @@
     <BugPattern type="NULL_CIPHER" abbrev="SECNC" category="SECURITY" cweid="327"/>
     <BugPattern type="UNENCRYPTED_SOCKET" abbrev="SECUS" category="SECURITY" cweid="319"/>
     <BugPattern type="UNENCRYPTED_SERVER_SOCKET" abbrev="SECUSS" category="SECURITY" cweid="319"/>
-    <BugPattern type="DES_USAGE" abbrev="SECDU" category="SECURITY" cweid="326"/>
+    <BugPattern type="DES_USAGE" abbrev="SECDU" category="SECURITY" cweid="327"/>
+    <BugPattern type="TDES_USAGE" abbrev="SECTDU" category="SECURITY" cweid="326"/>
     <BugPattern type="RSA_NO_PADDING" abbrev="SECRNP" category="SECURITY" cweid="780"/>
     <BugPattern type="HARD_CODE_PASSWORD" abbrev="SECHCP" category="SECURITY" cweid="259"/>
     <BugPattern type="UNSAFE_HASH_EQUALS" abbrev="SECUHE" category="SECURITY" cweid="203"/>
@@ -209,7 +212,7 @@
     <BugPattern type="XML_DECODER" abbrev="XMLDEC" category="SECURITY"/>
     <BugPattern type="STATIC_IV" abbrev="STAIV" category="SECURITY" cweid="329"/>
     <BugPattern type="ECB_MODE" abbrev="SECECB" category="SECURITY" cweid="327"/>
-    <BugPattern type="PADDING_ORACLE" abbrev="PADORA" category="SECURITY"/>
+    <BugPattern type="PADDING_ORACLE" abbrev="PADORA" category="SECURITY" cweid="326"/>
     <BugPattern type="CIPHER_INTEGRITY" abbrev="CIPINT" category="SECURITY" cweid="353"/>
     <BugPattern type="ESAPI_ENCRYPTOR" abbrev="ESAPIENC" category="SECURITY"/>
     <BugPattern type="SCRIPT_ENGINE_INJECTION" abbrev="SCRIPTE" category="SECURITY" cweid="94"/>

--- a/plugin/src/main/resources/metadata/findbugs.xml
+++ b/plugin/src/main/resources/metadata/findbugs.xml
@@ -54,7 +54,7 @@
     <Detector class="com.h3xstream.findsecbugs.crypto.UnencryptedServerSocketDetector" reports="UNENCRYPTED_SERVER_SOCKET"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.cipher.DesUsageDetector" reports="DES_USAGE"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.cipher.TDesUsageDetector" reports="TDES_USAGE"/>
-    <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector" reports="RSA_NO_PADDING"/>
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.RsaNoPaddingDetector" reports="RSA_NO_PADDING"/>
     <Detector class="com.h3xstream.findsecbugs.password.ConstantPasswordDetector" reports="HARD_CODE_PASSWORD,HARD_CODE_KEY"/>
     <Detector class="com.h3xstream.findsecbugs.password.GoogleApiKeyDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.password.HardcodePasswordInMapDetector" reports="HARD_CODE_PASSWORD"/>

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -3104,7 +3104,7 @@ byte[] cipherText = c.doFinal(plainText);</pre>
     <BugCode abbrev="SECTDU">DESede</BugCode>
 
     <!-- RSA NoPadding -->
-    <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector">
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.RsaNoPaddingDetector">
         <Details>RSA cipher without proper padding</Details>
     </Detector>
     <BugPattern type="RSA_NO_PADDING">

--- a/plugin/src/main/resources/metadata/messages.xml
+++ b/plugin/src/main/resources/metadata/messages.xml
@@ -2854,17 +2854,53 @@ to do this correctly.
     <BugCode abbrev="SECUSS">Unencrypted Server Socket</BugCode>
 
     <!-- DES usage -->
-    <Detector class="com.h3xstream.findsecbugs.crypto.DesUsageDetector">
-        <Details>DES / DESede should be replace by AES</Details>
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.DesUsageDetector">
+        <Details>DES should be replace by AES</Details>
     </Detector>
     <BugPattern type="DES_USAGE">
-        <ShortDescription>DES/DESede is insecure</ShortDescription>
-        <LongDescription>DES/DESede should be replaced with AES</LongDescription>
+        <ShortDescription>DES is insecure</ShortDescription>
+        <LongDescription>DES should be replaced with AES</LongDescription>
         <Details>
             <![CDATA[
 <p>
-DES and DESede (3DES) are not considered strong ciphers for modern applications. Currently, NIST recommends the 
-usage of AES block ciphers instead of DES/3DES.
+DES is considered strong ciphers for modern applications. Currently, NIST recommends the
+usage of AES block ciphers instead of DES.
+</p>
+<p>
+    <b>Example weak code:</b>
+<pre>Cipher c = Cipher.getInstance("DES/ECB/PKCS5Padding");
+c.init(Cipher.ENCRYPT_MODE, k, iv);
+byte[] cipherText = c.doFinal(plainText);</pre>
+</p>
+<p>
+    <b>Example solution:</b>
+    <pre>Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
+c.init(Cipher.ENCRYPT_MODE, k, iv);
+byte[] cipherText = c.doFinal(plainText);</pre>
+</p>
+<br/>
+<p>
+<b>References</b><br/>
+<a href="http://www.nist.gov/itl/fips/060205_des.cfm">NIST Withdraws Outdated Data Encryption Standard</a><br/>
+<a href="http://cwe.mitre.org/data/definitions/326.html">CWE-326: Inadequate Encryption Strength</a>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECDU">DES</BugCode>
+
+    <!-- TDES usage -->
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.TDesUsageDetector">
+        <Details>DESede should be replace by AES</Details>
+    </Detector>
+    <BugPattern type="TDES_USAGE">
+        <ShortDescription>DESede is insecure</ShortDescription>
+        <LongDescription>DESede should be replaced with AES</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Triple DES (also known as 3DES or DESede) is considered strong ciphers for modern applications. Currently, NIST recommends the
+usage of AES block ciphers instead of 3DES.
 </p>
 <p>
     <b>Example weak code:</b>
@@ -2887,8 +2923,7 @@ byte[] cipherText = c.doFinal(plainText);</pre>
 ]]>
         </Details>
     </BugPattern>
-    <BugCode abbrev="SECDU">DES / DESede</BugCode>
-
+    <BugCode abbrev="SECTDU">DESede</BugCode>
 
     <!-- RSA NoPadding -->
     <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector">
@@ -5450,5 +5485,10 @@ Sanitize user input before using it in HTTP parameters.
         </Details>
     </BugPattern>
     <BugCode abbrev="SECHPP">HTTP Parameter Pollution</BugCode>
+
+
+    <Detector class="com.h3xstream.findsecbugs.PotentialValueDetector">
+        <Details>Help other detector at finding hardcoded value used if a dynamic parameter is null.</Details>
+    </Detector>
 
 </MessageCollection>

--- a/plugin/src/main/resources/metadata/messages_ja.xml
+++ b/plugin/src/main/resources/metadata/messages_ja.xml
@@ -2846,7 +2846,7 @@ byte[] cipherText = c.doFinal(plainText);</pre>
 
 
     <!-- RSA NoPadding -->
-    <Detector class="com.h3xstream.findsecbugs.crypto.RsaNoPaddingDetector">
+    <Detector class="com.h3xstream.findsecbugs.crypto.cipher.RsaNoPaddingDetector">
         <Details>適切なパディングなしの RSA 暗号です。</Details>
     </Detector>
     <BugPattern type="RSA_NO_PADDING">

--- a/plugin/src/main/resources/taint-config/guava.txt
+++ b/plugin/src/main/resources/taint-config/guava.txt
@@ -1,0 +1,3 @@
+
+--Avoid tainting argument
+com/google/common/base/Optional.or(Ljava/lang/Object;)Ljava/lang/Object;:0,1#2

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/PotentialValueDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/PotentialValueDetectorTest.java
@@ -1,0 +1,98 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class PotentialValueDetectorTest extends BaseDetectorTest {
+
+
+    @Test
+    public void detectHardcodePassword1() throws Exception {
+//        FindSecBugsGlobalConfig.getInstance().setDebugPrintInstructionVisited(true);
+//        FindSecBugsGlobalConfig.getInstance().setDebugTaintState(true);
+
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/potential/PotentialHardcodePassword")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for(Integer line : Arrays.asList(16, 29, 30, /*31,*/ 32)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("HARD_CODE_PASSWORD")
+                            .inClass("PotentialHardcodePassword").atLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter,times(4)).doReportBug(
+                bugDefinition()
+                        .bugType("HARD_CODE_PASSWORD")
+                        .inClass("PotentialHardcodePassword")
+                        .build()
+        );
+
+    }
+
+
+
+    @Test
+    public void detectDes1() throws Exception {
+        //FindSecBugsGlobalConfig.getInstance().setDebugPrintInstructionVisited(true);
+        //FindSecBugsGlobalConfig.getInstance().setDebugTaintState(true);
+
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/potential/PotentialAlgorithm")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for(Integer line : Arrays.asList(10)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("DES_USAGE")
+                            .inClass("PotentialAlgorithm").atLine(line)
+                            .build()
+            );
+        }
+
+        verify(reporter,times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("DES_USAGE")
+                        .inClass("PotentialAlgorithm")
+                        .build()
+        );
+
+    }
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/DesUsageDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/DesUsageDetectorTest.java
@@ -41,7 +41,7 @@ public class DesUsageDetectorTest extends BaseDetectorTest {
         analyze(files, reporter);
 
         //Assertions
-        for (Integer line : Arrays.asList(20, 21, 22, 23, 24, 25, 26, 27, 33, 34)) {
+        for (Integer line : Arrays.asList(20, 21, 22, 23, 33, 34)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("DES_USAGE")
@@ -51,11 +51,28 @@ public class DesUsageDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+        for (Integer line : Arrays.asList(24, 25, 26, 27)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("TDES_USAGE")
+                            .inClass("BlockCipherList")
+                            .inMethod("main")
+                            .atLine(line)
+                            .build()
+            );
+        }
+
 
         //Nothing more than the previous 10
-        verify(reporter, times(10)).doReportBug(
+        verify(reporter, times(6)).doReportBug(
                 bugDefinition()
                         .bugType("DES_USAGE")
+                        .inClass("BlockCipherList")
+                        .build()
+        );
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition()
+                        .bugType("TDES_USAGE")
                         .inClass("BlockCipherList")
                         .build()
         );
@@ -73,7 +90,7 @@ public class DesUsageDetectorTest extends BaseDetectorTest {
         analyze(files, reporter);
 
         //Assertions
-        for (Integer line : Arrays.asList(11,12,13,14,15,16,17,18,19,20)) {
+        for (Integer line : Arrays.asList(11,12,13,14,15,16)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("DES_USAGE")
@@ -83,11 +100,27 @@ public class DesUsageDetectorTest extends BaseDetectorTest {
                             .build()
             );
         }
+        for (Integer line : Arrays.asList(17,18,19,20)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("TDES_USAGE")
+                            .inClass("DesKeyGeneration")
+                            .inMethod("weakDesKeyGenerator")
+                            .atLine(line)
+                            .build()
+            );
+        }
 
-        //Nothing more than the previous 4
-        verify(reporter, times(10)).doReportBug(
+        //Nothing more than the previous
+        verify(reporter, times(6)).doReportBug(
                 bugDefinition()
                         .bugType("DES_USAGE")
+                        .inClass("DesKeyGeneration")
+                        .build()
+        );
+        verify(reporter, times(4)).doReportBug(
+                bugDefinition()
+                        .bugType("TDES_USAGE")
                         .inClass("DesKeyGeneration")
                         .build()
         );

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/RsaNoPaddingDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/crypto/RsaNoPaddingDetectorTest.java
@@ -19,10 +19,9 @@ package com.h3xstream.findsecbugs.crypto;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
 
 public class RsaNoPaddingDetectorTest extends BaseDetectorTest {
 
@@ -61,6 +60,14 @@ public class RsaNoPaddingDetectorTest extends BaseDetectorTest {
                 .inClass("RsaNoPadding")
                 .inMethod("rsaCipherOk")
                 .build()
+        );
+
+        verify(reporter,times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("RSA_NO_PADDING")
+                        .inClass("RsaNoPadding")
+                        .inMethod("dataflowCipherWeak")
+                        .build()
         );
     }
 

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngineTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngineTest.java
@@ -1,0 +1,53 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import org.testng.annotations.Test;
+
+import java.io.Writer;
+
+import static org.mockito.Mockito.*;
+
+public class TaintDataflowEngineTest extends BaseDetectorTest {
+
+    @Test
+    public void testDerivedConfiguration() throws Exception {
+
+        FindSecBugsGlobalConfig.getInstance().setDebugOutputTaintConfigs(true);
+
+        TaintDataflowEngine.writer = mock(Writer.class);
+
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/command/CommandInjection"),
+                getClassFilePath("testcode/command/MoreMethods"),
+                getClassFilePath("testcode/command/SubClass")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new BaseDetectorTest.SecurityReporter());
+        analyze(files, reporter);
+
+        verify(TaintDataflowEngine.writer,atLeast(2)).append(anyString());
+
+        FindSecBugsGlobalConfig.getInstance().setDebugOutputTaintConfigs(false);
+    }
+}

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameTest.java
@@ -99,5 +99,31 @@ public class TaintFrameTest {
         }
     }
 
+    @Test
+    public void validateSimpleTaintFrameWithOptionalAndConstant() {
+        Taint unknown = new Taint(Taint.State.UNKNOWN);
+        unknown.setPotentialValue("12345678");
+        unknown.addTag(Taint.Tag.PASSWORD_VARIABLE);
+
+        Taint constant = new Taint(Taint.State.SAFE);
+        constant.setConstantValue("H@rdC0deStr1ng");
+
+        TaintFrame frame = new TaintFrame(0);
+        frame.pushValue(new Taint(Taint.State.TAINTED));
+        frame.pushValue(unknown);
+        frame.pushValue(new Taint(Taint.State.NULL));
+        frame.pushValue(constant);
+
+        String debugOutput = frame.toString();
+        System.out.println(debugOutput);
+        assertTrue(debugOutput.contains("0. SAFE {S"));
+        assertTrue(debugOutput.contains("1. NULL {N}"));
+        assertTrue(debugOutput.contains("2. UNKNOWN {U"));
+        assertTrue(debugOutput.contains("3. TAINTED {T}"));
+        assertTrue(debugOutput.contains("12345678"));
+        assertTrue(debugOutput.contains("PASSWORD_VARIABLE"));
+        assertTrue(debugOutput.contains("H@rdC0deStr1ng"));
+    }
+
 
 }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfigTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfigTest.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.taintanalysis;
 
 import org.testng.annotations.Test;

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfigTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfigTest.java
@@ -1,0 +1,44 @@
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertTrue;
+
+public class TaintMethodConfigTest {
+    @Test
+    public void validateSimpleTaintMethodConfig() throws IOException {
+        String sig = "android/database/DatabaseUtils.concatenateWhere(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;";
+        TaintMethodConfig config = new TaintMethodConfig(true).load("1#2");
+        config.setTypeSignature(sig);
+        String output = config.toString();
+        System.out.println(output);
+
+        assertTrue(output.contains("DatabaseUtils"));
+
+        ////////
+
+        String sig1    = "java/net/URLEncoder.encode(Ljava/lang/String;)Ljava/lang/String;";
+        String config1 = "0|+URL_ENCODED,+XSS_SAFE";
+        String sig2    = "java/net/URLDecoder.decode(Ljava/lang/String;)Ljava/lang/String;";
+        String config2 = "0|-URL_ENCODED,-XSS_SAFE";
+
+        TaintMethodConfig tmconfig1 = new TaintMethodConfig(true).load(config1);
+        tmconfig1.setTypeSignature(sig1);
+        TaintMethodConfig tmconfig2 = new TaintMethodConfig(true).load(config2);
+        tmconfig2.setTypeSignature(sig2);
+
+        output = tmconfig1.toString();
+        System.out.println(output);
+        assertTrue(output.contains("URLEncoder.encode"));
+        assertTrue(output.contains("+URL_ENCODED")); //The order of the tags is subject to change
+        assertTrue(output.contains("+XSS_SAFE"));
+        output = tmconfig2.toString();
+        System.out.println(output);
+        assertTrue(output.contains("URLDecoder.decode"));
+        assertTrue(output.contains("-URL_ENCODED"));
+        assertTrue(output.contains("-XSS_SAFE"));
+
+    }
+}

--- a/plugin/src/test/java/testcode/crypto/DesKeyGeneration.java
+++ b/plugin/src/test/java/testcode/crypto/DesKeyGeneration.java
@@ -10,13 +10,13 @@ public class DesKeyGeneration {
     public static void weakDesKeyGenerator() throws NoSuchAlgorithmException, NoSuchProviderException {
         KeyGenerator.getInstance("DES");
         KeyGenerator.getInstance("des");
-        KeyGenerator.getInstance("DESede");
-        KeyGenerator.getInstance("DESEDE");
         KeyGenerator.getInstance("DES",new DummyProvider());
         KeyGenerator.getInstance("des",new DummyProvider());
-        KeyGenerator.getInstance("DESede",new DummyProvider());
         KeyGenerator.getInstance("DES", "SUN");
         KeyGenerator.getInstance("des", "SUN");
+        KeyGenerator.getInstance("DESede");
+        KeyGenerator.getInstance("DESEDE");
+        KeyGenerator.getInstance("DESede",new DummyProvider());
         KeyGenerator.getInstance("DESede", "SUN");
         KeyGenerator.getInstance("AES"); //OK!
         KeyGenerator.getInstance("RSA"); //OK!

--- a/plugin/src/test/java/testcode/crypto/RsaNoPadding.java
+++ b/plugin/src/test/java/testcode/crypto/RsaNoPadding.java
@@ -17,4 +17,13 @@ public class RsaNoPadding {
         Cipher.getInstance("RSA/NONE/NoPadding");
         Cipher.getInstance("RSA/NONE/NoPadding", "BC");
     }
+
+    public void dataflowCipherWeak() throws Exception {
+        String cipher1 = null;
+        Cipher.getInstance(cipher1);
+        String cipher2 = "RSA/NONE/NoPadding";
+        Cipher.getInstance(cipher2);
+        String cipher3 = null;
+        Cipher.getInstance(cipher3);
+    }
 }

--- a/plugin/src/test/java/testcode/potential/PotentialAlgorithm.java
+++ b/plugin/src/test/java/testcode/potential/PotentialAlgorithm.java
@@ -1,0 +1,12 @@
+package testcode.potential;
+
+import javax.crypto.Cipher;
+import java.util.Properties;
+
+public class PotentialAlgorithm {
+
+    public void testDesAlgo(Properties config) throws Exception {
+        String algorithmWithBadDefault = config.getProperty("algorithm", "DES");
+        Cipher.getInstance(algorithmWithBadDefault);
+    }
+}

--- a/plugin/src/test/java/testcode/potential/PotentialHardcodePassword.java
+++ b/plugin/src/test/java/testcode/potential/PotentialHardcodePassword.java
@@ -1,0 +1,35 @@
+package testcode.potential;
+
+import com.google.common.base.Optional;
+import testcode.password.customapi.Vault;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+public class PotentialHardcodePassword {
+
+    public void badInitHardcodePassword(Properties p){
+
+        String riskyVal = p.getProperty("password","ThisIsNotASecret");
+
+        Vault v = new Vault();
+        v.setPassword(riskyVal); //BAD
+    }
+
+    public void goodInitHardcodePassword(Properties p){
+
+        String riskyVal = p.getProperty("password");
+
+        Vault v = new Vault();
+        v.setPassword(riskyVal); //GOOD
+    }
+
+    public void badVariousSignature(Vault v, Properties p, Optional<String> o, HashMap<String,String> m) {
+        //All the following are BAD
+        v.setPassword(p.getProperty("password","1111111"));
+        v.setPassword(o.or("2222222"));
+        //JDK8//v.setPassword(m.getOrDefault("password", "3333333")); //Uncomment when the project will be Java8+
+        v.setPassword(System.getProperty("password","4444444"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
                         <exclude>**/java/com/fasterxml/jackson/**/**.java</exclude>
                         <exclude>**/java/ognl/**/**.java</exclude>
                         <exclude>**/com/opensymphony/**/**.java</exclude>
+                        <exclude>**/com/google/**/**.java</exclude>
                     </excludes>
                     <properties>
                         <project>Find Security Bugs</project>


### PR DESCRIPTION
Support to track constant values place in default value of Optional API.
Migrate a couple of detectors to reuse dataflow analysis.

```java
    public void badVariousSignature(Vault v, Properties p, Optional<String> o, HashMap<String,String> m) {
        //All the following are BAD
        v.setPassword(p.getProperty("password","1111111"));
        v.setPassword(o.or("2222222"));
        v.setPassword(m.getOrDefault("password", "3333333"));
        v.setPassword(System.getProperty("password","4444444"));
    }
```

Detectors affected:
 - Hardcode password
 - Weak crypto algorithm (DES and Triple DES)
 - RSA No Padding

This may impact the scan time for these detectors but the coverage for this type of bugs will be greatly improved.