### PR TITLE
FileItem.getName() as a new source for XSS_SERVLET

### DIFF
--- a/plugin/src/main/resources/taint-config/java-ee.txt
+++ b/plugin/src/main/resources/taint-config/java-ee.txt
@@ -128,3 +128,5 @@ javax/servlet/jsp/JspWriter.print([C)V:UNKNOWN
 javax/servlet/jsp/JspWriter.print(Ljava/lang/Object;)V:UNKNOWN
 javax/servlet/jsp/JspWriter.println([C)V:UNKNOWN
 javax/servlet/jsp/JspWriter.println(Ljava/lang/Object;)V:UNKNOWN
+
+org/apache/commons/fileupload/FileItem.getName()Ljava/lang/String;:TAINTED

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
@@ -187,4 +187,25 @@ public class XssServletDetectorTest extends BaseDetectorTest {
         verify(reporter, never()).doReportBug(bugDefinition().bugType("XSS_SERVLET").inClass("XssServlet6")
                 .inMethod("doPost").withPriority("Low").build());
     }
+
+    @Test
+    public void detectXssServlet7() throws Exception {
+        // Locate test code
+        String[] files = { getClassFilePath("testcode/xss/servlets/XssServlet7") };
+
+        // Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(bugDefinition().bugType("XSS_SERVLET").inClass("XssServlet7")
+                .inMethod("doPost").atLine(32).withPriority("High").build());
+
+        verify(reporter).doReportBug(bugDefinition().bugType("XSS_SERVLET").inClass("XssServlet7")
+                .inMethod("doPost").atLine(34).withPriority("Low").build());
+
+        verify(reporter).doReportBug(bugDefinition().bugType("XSS_SERVLET").inClass("XssServlet7")
+                .inMethod("doPost").atLine(35).withPriority("Low").build());
+
+        verify(reporter, times(3)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
+    }
 }

--- a/plugin/src/test/java/testcode/xss/servlets/XssServlet7.java
+++ b/plugin/src/test/java/testcode/xss/servlets/XssServlet7.java
@@ -1,0 +1,40 @@
+package testcode.xss.servlets;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+
+import org.owasp.esapi.ESAPI;
+
+import org.apache.commons.lang.StringEscapeUtils;
+
+public class XssServlet7 extends HttpServlet {
+    @Override
+    public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/html");
+
+        ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
+
+        try {
+            List<FileItem> fileItems = upload.parseRequest(req);
+            Iterator<FileItem> i = fileItems.iterator();
+            String filename = i.next().getName();
+
+            resp.getWriter().write(filename);
+
+            resp.getWriter().write(ESAPI.encoder().encodeForHTML(filename));
+            resp.getWriter().write(StringEscapeUtils.escapeHtml(filename));
+        } catch(Exception ex) {
+            System.out.println(ex);
+        }
+    }
+}


### PR DESCRIPTION
As @h3xstream suggested on the issue #358, I added a source in the java-ee.txt file and create test cases.
Could you review the pull request?

Thank you

## Changes  
### Add source for 'XSS via file name' and test cases

- Add source FileItem.getName() on the java-ee.txt
- Create test code class named XssServlet7.java
- Add corressponding test driver detectXssServlet7() on the XssServletDetectorTest.java