### PR TITLE
Make Java 9 build mandatory for Travis-CI

### DIFF
--- a/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/BaseConfigValidation.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/BaseConfigValidation.java
@@ -28,7 +28,9 @@ public class BaseConfigValidation {
 
     TaintConfigLoader loader = new TaintConfigLoader();
 
-    private List<String> java8classes = Arrays.asList("java.time.ZonedId");
+    private List<String> classesDeprecatedInJava8 = Arrays.asList("java.time.ZonedId");
+    private List<String> classesDeprecatedInJava9 = Arrays.asList("javax.activation.FileDataSource",
+            "javax.xml.bind.DatatypeConverter");
 
     /**
      * Validate if the class name exists.
@@ -38,7 +40,8 @@ public class BaseConfigValidation {
      * @param origfileName
      */
     public void validateClass(String className, String origfileName) {
-        if(java8classes.contains(className)) return;
+        if(classesDeprecatedInJava8.contains(className)) return;
+        if(classesDeprecatedInJava9.contains(className)) return;
 
         if(className.endsWith("$")) return; //Skipping Scala class
         if(className.startsWith("play.")) return; //Temporary skip Play

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <build>
         <plugins>
-            <!-- Force the use the compatibility to Java 6 -->
+            <!-- Force the use the compatibility to Java 8 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>


### PR DESCRIPTION
At some point oracle JDK was simply not available on Travis-CI.
Now, I realise that it is running but some test are failing because of class removed/deprecated in Java 9.

