### PR TITLE
Fix sh script, so that cli can run on unix systems

### DIFF
--- a/cli/findsecbugs.sh
+++ b/cli/findsecbugs.sh
@@ -1,4 +1,5 @@
+#!/bin/bash
 
-SOURCE="${BASH_SOURCE[0]}"
+cd $(dirname $(readlink `[[ $OSTYPE == linux* ]] && echo "-f"` $0))
 
-java -cp "$SOURCE/lib/\*:" edu.umd.cs.findbugs.LaunchAppropriateUI -quiet -pluginList lib/findsecbugs-plugin-1.7.1.jar -include include.xml $@
+java -cp lib/\* edu.umd.cs.findbugs.LaunchAppropriateUI -quiet -pluginList lib/findsecbugs-plugin-1.8.0.jar -include include.xml $@


### PR DESCRIPTION
We've discovered that findsecbugs 1.8 doesn't run on unix using the cli. Seems to be an issue with the sh file.

As such, I've rewritten the script and updated it to use the correct version.


FYI the docs for CLI support are referencing the wrong version: 1.46 and 1.44 in different places.