### PR TITLE
Fix TravisCI for JDK version 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10
 
 matrix:
   allow_failures:
-    - jdk: oraclejdk10
+    - jdk: openjdk10
 
 # Activate container based infra https://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false


### PR DESCRIPTION
oraclejdk10 was changed to openjdk10 based on a recent error message on Travis-CI.

```
oraclejdk10 is deprecated. See https://www.oracle.com/technetwork/java/javase/eol-135779.html for more details. Consider using openjdk10 instead.
```