### PR TITLE
Improve and generalize the CLI unix launcher

### DIFF
--- a/cli/findsecbugs.sh
+++ b/cli/findsecbugs.sh
@@ -1,4 +1,20 @@
+#!/bin/bash
 
 SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+FINDBUGS_PLUGIN="$(find "$DIR"/lib/findsecbugs-plugin-* | sort --version-sort | tail -n1)"
 
-java -cp "$SOURCE/lib/\*:" edu.umd.cs.findbugs.LaunchAppropriateUI -quiet -pluginList lib/findsecbugs-plugin-1.8.0.jar -include include.xml $@
+for LIB in "$DIR"/lib/*.jar; do
+  if [[ -z "${LIBS// }" ]]; then
+    LIBS=$LIB
+  else
+    LIBS=$LIB:$LIBS
+  fi
+done
+
+java -cp "$LIBS" edu.umd.cs.findbugs.LaunchAppropriateUI -quiet -pluginList "$FINDBUGS_PLUGIN" -include "$DIR"/include.xml $@


### PR DESCRIPTION
- Decouple the launcher from the find-sec-bugs version
- Made it runnable from any directory
- Fix a bug with certain JDK classloaders not able to load wildcards
jars.

**This work has been sponsored by Doyensec LLC** [![Doyensec](https://www.doyensec.com/images/logo.svg)](https://doyensec.com/)