### PR TITLE
Fix #432

### DIFF
--- a/findsecbugs-test-kotlin/src/test/kotlin/com/h3xstream/findsecbugs/injection/KotlinLogging.kt
+++ b/findsecbugs-test-kotlin/src/test/kotlin/com/h3xstream/findsecbugs/injection/KotlinLogging.kt
@@ -5,13 +5,13 @@ import java.util.ResourceBundle
 import java.util.function.Supplier
 import java.util.logging.*
 
-class Logging {
+class KotlinLogging {
 
 
     fun javaUtilLogging() {
         val tainted = req!!.getParameter("test")
         val safe = "safe"
-        val logger = Logger.getLogger(Logging::class.java.name)
+        val logger = Logger.getLogger(KotlinLogging::class.java.name)
         logger.level = Level.ALL
         val handler = ConsoleHandler()
         handler.level = Level.ALL

--- a/findsecbugs-test-kotlin/src/test/kotlin/com/h3xstream/findsecbugs/injection/KotlinSlf4jSample.kt
+++ b/findsecbugs-test-kotlin/src/test/kotlin/com/h3xstream/findsecbugs/injection/KotlinSlf4jSample.kt
@@ -2,7 +2,7 @@ package com.h3xstream.findsecbugs.injection
 
 import org.slf4j.Logger
 
-class Slf4jSample {
+class KotlinSlf4jSample {
 
     fun slf4j(log: Logger, tainted: DataClass, tainted2: String) {
         val safe = ""

--- a/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -378,9 +378,10 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
     @Override
     public void visitAASTORE(AASTORE obj) {
         try {
-            Taint valueTaint = getFrame().popValue();
-            getFrame().popValue(); // array index
-            Taint arrayTaint = getFrame().popValue();
+            Taint valueTaint = getFrame().popValue(); //Value
+            getFrame().popValue(); //Array index
+            Taint arrayTaint = getFrame().popValue(); //Array ref
+
             Taint merge = Taint.merge(valueTaint, arrayTaint);
             setLocalVariableTaint(merge, arrayTaint);
             Taint stackTop = null;
@@ -388,7 +389,7 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
                 stackTop = getFrame().getTopValue();
             }
             // varargs use duplicated values
-            if (stackTop == arrayTaint) {
+            if (arrayTaint.equals(stackTop)) {
                 getFrame().popValue();
                 getFrame().pushValue(new Taint(merge));
             }

--- a/plugin/src/test/java/com/h3xstream/findsecbugs/injection/crlf/CrlfLogInjectionDetectorTest.java
+++ b/plugin/src/test/java/com/h3xstream/findsecbugs/injection/crlf/CrlfLogInjectionDetectorTest.java
@@ -21,6 +21,8 @@ import com.h3xstream.findbugs.test.BaseDetectorTest;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
 import org.testng.annotations.Test;
 
 public class CrlfLogInjectionDetectorTest extends BaseDetectorTest {
@@ -44,10 +46,11 @@ public class CrlfLogInjectionDetectorTest extends BaseDetectorTest {
         verify(reporter, times(49 - 20)).doReportBug(bugDefinition().bugType("CRLF_INJECTION_LOGS").build());
     }
 
+
     @Test
     public void detectResponseSplittingKotlin() throws Exception {
         String[] files = {
-            getClassFilePath("com/h3xstream/findsecbugs/injection/Logging")
+            getClassFilePath("com/h3xstream/findsecbugs/injection/KotlinLogging")
         };
         SecurityReporter reporter = spy(new SecurityReporter());
         analyze(files, reporter);
@@ -56,36 +59,35 @@ public class CrlfLogInjectionDetectorTest extends BaseDetectorTest {
             verify(reporter).doReportBug(
                     bugDefinition()
                     .bugType("CRLF_INJECTION_LOGS")
-                    .inClass("Logging").inMethod("javaUtilLogging").atLine(line)
+                    .inClass("KotlinLogging").inMethod("javaUtilLogging").atLine(line)
                     .build()
             );
         }
         verify(reporter, times(49 - 20)).doReportBug(bugDefinition().bugType("CRLF_INJECTION_LOGS").build());
     }
 
+
+
     @Test
     public void detectSlf4jResponseSplittingKotlin() throws Exception {
+
+
         String[] files = {
-                getClassFilePath("com/h3xstream/findsecbugs/injection/Slf4jSample")
+                getClassFilePath("com/h3xstream/findsecbugs/injection/KotlinSlf4jSample")
         };
         SecurityReporter reporter = spy(new SecurityReporter());
         analyze(files, reporter);
 
         for (int line = 10; line <= 19; line++) {
 
-            // detector cannot recognise this line in Kotlin
-            if (line == 13) {
-                continue;
-            }
-
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("CRLF_INJECTION_LOGS")
-                            .inClass("Slf4jSample").inMethod("slf4j").atLine(line)
+                            .inClass("KotlinSlf4jSample").inMethod("slf4j").atLine(line)
                             .build()
             );
         }
-        verify(reporter, times(9)).doReportBug(bugDefinition().bugType("CRLF_INJECTION_LOGS").build());
+        verify(reporter, times(10)).doReportBug(bugDefinition().bugType("CRLF_INJECTION_LOGS").build());
     }
 
     @Test


### PR DESCRIPTION
Improve/fix bytecode analysis that made FSB confusion with bytecode generate from `arrayOf<Any>(...)`.

Rename Kotlin test class to avoid collision/confusion with the Java one.