### PR TITLE
Add  permissive CORS detector for CorsRegistration in Springboot

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
@@ -1,0 +1,124 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.spring;
+
+import android.util.Log;
+import com.h3xstream.findsecbugs.common.StackUtils;
+import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
+import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
+import com.h3xstream.findsecbugs.injection.InjectionPoint;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
+import com.h3xstream.findsecbugs.taintanalysis.Taint.State;
+import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Const;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
+
+import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
+
+//public class CorsRegistryCORSDetector extends BasicInjectionDetector {
+//
+//    private static final String PERMISSIVE_CORS = "PERMISSIVE_CORS";
+//    private static final String CORS_REGISTRY_CLASS = "org.springframework.web.servlet.config.annotation.CorsRegistration";
+//
+//    // javap  -cp C:\Users\x5651\.m2\repository\org\springframework\spring-webmvc\5.1.6.RELEASE\spring-webmvc-5.1.6.RELEASE.jar -s or g.springframework.web.servlet.config.annotation.CorsRegistration
+//    private static final InvokeMatcherBuilder CORS_REGISTRY_ALLOWED_ORIGINS_METHOD = invokeInstruction()
+//            .atClass(CORS_REGISTRY_CLASS).atMethod("allowedOrigins")
+//            .withArgs("([Ljava/lang/String;)Lorg/springframework/web/servlet/config/annotation/CorsRegistration;");
+//
+//
+//    public CorsRegistryCORSDetector(BugReporter bugReporter) {
+//        super(bugReporter);
+//    }
+//
+//    /**
+//     * 每次调用时都会用该函数判断是否存在漏洞
+//     * invoke：表示一次调用
+//     */
+//    @Override
+//    protected InjectionPoint getInjectionPoint(InvokeInstruction invoke, ConstantPoolGen cpg,
+//            InstructionHandle handle) {
+//        assert invoke != null && cpg != null;
+//        // 可以通过一下方法获取InvokeMatcherBuilder的class、method、Signature
+//        // System.out.println(invoke.getClassName(cpg));
+//        // System.out.println(invoke.getMethodName(cpg));
+//        // System.out.println(invoke.getSignature(cpg));
+//
+//        if (CORS_REGISTRY_ALLOWED_ORIGINS_METHOD.matches(invoke, cpg)) {
+//            return new InjectionPoint(new int[] { 0 }, PERMISSIVE_CORS);
+//        }
+//        return InjectionPoint.NONE;
+//    }
+//
+//    /**
+//     * 返回危险等级
+//     */
+//    @Override
+//    protected int getPriorityFromTaintFrame(TaintFrame fact, int offset) throws DataflowAnalysisException {
+//        // Get the value of the Access-Control-Allow-Origin parameter (Second argument from setHeader(2nd,1rst))
+//        System.out.println(fact.toString());
+//        System.out.println(fact.allSlots());
+//        System.out.println(fact.getValue(1));
+//        Taint  originsTaint= fact.getStackValue(1);
+//        System.out.println(originsTaint.getConstantOrPotentialValue());
+//
+//        return Priorities.HIGH_PRIORITY;
+////        if (originsTaint.getConstantOrPotentialValue().contains("*")) { //Ignore unknown/dynamic header name
+////            return Priorities.HIGH_PRIORITY;
+////        } else {
+////            return Priorities.IGNORE_PRIORITY;
+////        }
+//    }
+//}
+public class CorsRegistryCORSDetector extends OpcodeStackDetector {
+
+    private static final String PERMISSIVE_CORS = "PERMISSIVE_CORS";
+    private BugReporter bugReporter;
+
+    public CorsRegistryCORSDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        //printOpCode(seen);
+        if (seen == Const.INVOKEVIRTUAL && getNameConstantOperand().equals("allowedOrigins")) {
+            OpcodeStack.Item item = stack.getStackItem(0); //First item on the stack is the last
+            OpcodeStack.Item item2 = stack.getStackItem(1); //First item on the stack is the last
+            System.out.println(stack.toString());
+            System.out.println();
+            System.out.println(item.getXField());
+            System.out.println(item.getConstant());
+            System.out.println(item2);
+//            if(StackUtils.isConstantInteger(item)) {
+//                Integer value = (Integer) item.getConstant();
+//                if(value == null || value != 0) {
+//                    bugReporter.reportBug(new BugInstance(this, ANDROID_WORLD_WRITABLE_TYPE, Priorities.NORMAL_PRIORITY) //
+//                            .addClass(this).addMethod(this).addSourceLine(this));
+//                }
+//            }
+        }
+    }
+}

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
@@ -35,6 +35,10 @@ import org.apache.bcel.Const;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
+import sun.management.BaseOperatingSystemImpl;
+import sun.reflect.ConstantPool;
+
+import java.io.*;
 
 import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
 
@@ -106,12 +110,13 @@ public class CorsRegistryCORSDetector extends OpcodeStackDetector {
         //printOpCode(seen);
         if (seen == Const.INVOKEVIRTUAL && getNameConstantOperand().equals("allowedOrigins")) {
             OpcodeStack.Item item = stack.getStackItem(0); //First item on the stack is the last
-            OpcodeStack.Item item2 = stack.getStackItem(1); //First item on the stack is the last
-            System.out.println(stack.toString());
-            System.out.println();
-            System.out.println(item.getXField());
-            System.out.println(item.getConstant());
-            System.out.println(item2);
+            int idx=getNextCodeByte(-5);
+            System.out.println(getNextCodeByte(-6)+":"+getNextCodeByte(-5)+":"+getNextCodeByte(4));
+            System.out.println(item.getPC());
+
+            System.out.println(getString(8));
+            System.out.println(getString(9));
+            System.out.println(getString(11));
 //            if(StackUtils.isConstantInteger(item)) {
 //                Integer value = (Integer) item.getConstant();
 //                if(value == null || value != 0) {
@@ -121,4 +126,14 @@ public class CorsRegistryCORSDetector extends OpcodeStackDetector {
 //            }
         }
     }
+     public String getString(int idx) {
+         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         DataOutputStream outputStream=new DataOutputStream(baos);
+         try {
+             getConstantPool().getConstant(idx).dump(outputStream);
+         } catch (IOException e) {
+             e.printStackTrace();
+         }
+         return baos.toString();
+     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
@@ -17,88 +17,19 @@
  */
 package com.h3xstream.findsecbugs.spring;
 
-import android.util.Log;
-import com.h3xstream.findsecbugs.common.StackUtils;
-import com.h3xstream.findsecbugs.common.matcher.InvokeMatcherBuilder;
-import com.h3xstream.findsecbugs.injection.BasicInjectionDetector;
-import com.h3xstream.findsecbugs.injection.InjectionPoint;
-import com.h3xstream.findsecbugs.taintanalysis.Taint;
-import com.h3xstream.findsecbugs.taintanalysis.Taint.State;
-import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.OpcodeStack;
-import edu.umd.cs.findbugs.Priorities;
-import edu.umd.cs.findbugs.ba.DataflowAnalysisException;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import org.apache.bcel.Const;
-import org.apache.bcel.generic.ConstantPoolGen;
-import org.apache.bcel.generic.InstructionHandle;
-import org.apache.bcel.generic.InvokeInstruction;
-import sun.management.BaseOperatingSystemImpl;
-import sun.reflect.ConstantPool;
+import org.apache.bcel.classfile.Constant;
+import org.apache.bcel.classfile.ConstantString;
 
 import java.io.*;
+import java.util.Arrays;
 
-import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInstruction;
-
-//public class CorsRegistryCORSDetector extends BasicInjectionDetector {
-//
-//    private static final String PERMISSIVE_CORS = "PERMISSIVE_CORS";
-//    private static final String CORS_REGISTRY_CLASS = "org.springframework.web.servlet.config.annotation.CorsRegistration";
-//
-//    // javap  -cp C:\Users\x5651\.m2\repository\org\springframework\spring-webmvc\5.1.6.RELEASE\spring-webmvc-5.1.6.RELEASE.jar -s or g.springframework.web.servlet.config.annotation.CorsRegistration
-//    private static final InvokeMatcherBuilder CORS_REGISTRY_ALLOWED_ORIGINS_METHOD = invokeInstruction()
-//            .atClass(CORS_REGISTRY_CLASS).atMethod("allowedOrigins")
-//            .withArgs("([Ljava/lang/String;)Lorg/springframework/web/servlet/config/annotation/CorsRegistration;");
-//
-//
-//    public CorsRegistryCORSDetector(BugReporter bugReporter) {
-//        super(bugReporter);
-//    }
-//
-//    /**
-//     * 每次调用时都会用该函数判断是否存在漏洞
-//     * invoke：表示一次调用
-//     */
-//    @Override
-//    protected InjectionPoint getInjectionPoint(InvokeInstruction invoke, ConstantPoolGen cpg,
-//            InstructionHandle handle) {
-//        assert invoke != null && cpg != null;
-//        // 可以通过一下方法获取InvokeMatcherBuilder的class、method、Signature
-//        // System.out.println(invoke.getClassName(cpg));
-//        // System.out.println(invoke.getMethodName(cpg));
-//        // System.out.println(invoke.getSignature(cpg));
-//
-//        if (CORS_REGISTRY_ALLOWED_ORIGINS_METHOD.matches(invoke, cpg)) {
-//            return new InjectionPoint(new int[] { 0 }, PERMISSIVE_CORS);
-//        }
-//        return InjectionPoint.NONE;
-//    }
-//
-//    /**
-//     * 返回危险等级
-//     */
-//    @Override
-//    protected int getPriorityFromTaintFrame(TaintFrame fact, int offset) throws DataflowAnalysisException {
-//        // Get the value of the Access-Control-Allow-Origin parameter (Second argument from setHeader(2nd,1rst))
-//        System.out.println(fact.toString());
-//        System.out.println(fact.allSlots());
-//        System.out.println(fact.getValue(1));
-//        Taint  originsTaint= fact.getStackValue(1);
-//        System.out.println(originsTaint.getConstantOrPotentialValue());
-//
-//        return Priorities.HIGH_PRIORITY;
-////        if (originsTaint.getConstantOrPotentialValue().contains("*")) { //Ignore unknown/dynamic header name
-////            return Priorities.HIGH_PRIORITY;
-////        } else {
-////            return Priorities.IGNORE_PRIORITY;
-////        }
-//    }
-//}
 public class CorsRegistryCORSDetector extends OpcodeStackDetector {
 
-    private static final String PERMISSIVE_CORS = "PERMISSIVE_CORS";
     private BugReporter bugReporter;
 
     public CorsRegistryCORSDetector(BugReporter bugReporter) {
@@ -107,33 +38,54 @@ public class CorsRegistryCORSDetector extends OpcodeStackDetector {
 
     @Override
     public void sawOpcode(int seen) {
+
         //printOpCode(seen);
         if (seen == Const.INVOKEVIRTUAL && getNameConstantOperand().equals("allowedOrigins")) {
-            OpcodeStack.Item item = stack.getStackItem(0); //First item on the stack is the last
-            int idx=getNextCodeByte(-5);
-            System.out.println(getNextCodeByte(-6)+":"+getNextCodeByte(-5)+":"+getNextCodeByte(4));
-            System.out.println(item.getPC());
-
-            System.out.println(getString(8));
-            System.out.println(getString(9));
-            System.out.println(getString(11));
-//            if(StackUtils.isConstantInteger(item)) {
-//                Integer value = (Integer) item.getConstant();
-//                if(value == null || value != 0) {
-//                    bugReporter.reportBug(new BugInstance(this, ANDROID_WORLD_WRITABLE_TYPE, Priorities.NORMAL_PRIORITY) //
-//                            .addClass(this).addMethod(this).addSourceLine(this));
-//                }
-//            }
+            if ("org/springframework/web/servlet/config/annotation/CorsRegistration".equals(getClassConstantOperand())) {
+                OpcodeStack.Item item = stack.getStackItem(0); //First item on the stack is the last
+                if(item.isArray()) {
+                    String[] strings=getArray(item);
+                    String pattern="*";
+                    for (String s: strings) {
+                        if (s.equals(pattern)) {
+                             bugReporter.reportBug(new BugInstance(this, "PERMISSIVE_CORS", HIGH_PRIORITY)
+                        .addClassAndMethod(this).addSourceLine(this));
+                             break;
+                        }
+                    }
+                }
+            }
         }
     }
-     public String getString(int idx) {
-         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-         DataOutputStream outputStream=new DataOutputStream(baos);
-         try {
-             getConstantPool().getConstant(idx).dump(outputStream);
-         } catch (IOException e) {
-             e.printStackTrace();
-         }
-         return baos.toString();
-     }
+    public String[] getArray(OpcodeStack.Item item){
+        Integer argumentsNum = (Integer) item.getConstant();
+        String[] strings = new String[argumentsNum];
+        for (int i=0; i<argumentsNum; i++) {
+            int idx=-5-5*i;
+            int stringIdx=getNextCodeByte(idx);
+            System.out.println(stringIdx);
+            String s=getStringFromIdx(stringIdx);
+            System.out.println(Arrays.toString(s.toCharArray()));
+            strings[i]=s;
+        }
+        return strings;
+    }
+    public String getStringFromIdx(int idx) {
+        Constant constant= getConstantPool().getConstant(idx);
+        int s = ((ConstantString) constant).getStringIndex();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream outputStream=new DataOutputStream(baos);
+        try {
+            Constant string = getConstantPool().getConstant(s);
+            if (string!=null) {
+                string.dump(outputStream);
+            } else {
+                return null;
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return baos.toString().substring(3);
+    }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetector.java
@@ -44,7 +44,7 @@ public class CorsRegistryCORSDetector extends OpcodeStackDetector {
             if ("org/springframework/web/servlet/config/annotation/CorsRegistration".equals(getClassConstantOperand())) {
                 OpcodeStack.Item item = stack.getStackItem(0); //First item on the stack is the last
                 if(item.isArray()) {
-                    String[] strings=getArray(item);
+                    String[] strings=getStringArray(item);
                     String pattern="*";
                     for (String s: strings) {
                         if (s.equals(pattern)) {
@@ -57,15 +57,15 @@ public class CorsRegistryCORSDetector extends OpcodeStackDetector {
             }
         }
     }
-    public String[] getArray(OpcodeStack.Item item){
+    public String[] getStringArray(OpcodeStack.Item item){
         Integer argumentsNum = (Integer) item.getConstant();
         String[] strings = new String[argumentsNum];
         for (int i=0; i<argumentsNum; i++) {
             int idx=-5-5*i;
             int stringIdx=getNextCodeByte(idx);
-            System.out.println(stringIdx);
+//            System.out.println(stringIdx);
             String s=getStringFromIdx(stringIdx);
-            System.out.println(Arrays.toString(s.toCharArray()));
+//            System.out.println(Arrays.toString(s.toCharArray()));
             strings[i]=s;
         }
         return strings;

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -120,6 +120,7 @@
     <Detector class="com.h3xstream.findsecbugs.injection.smtp.SmtpHeaderInjectionDetector" reports="SMTP_HEADER_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.spring.SpringUnvalidatedRedirectDetector" reports="SPRING_UNVALIDATED_REDIRECT"/>
     <Detector class="com.h3xstream.findsecbugs.spring.SpringEntityLeakDetector" reports="SPRING_ENTITY_LEAK"/>
+    <Detector class="com.h3xstream.findsecbugs.spring.CorsRegistryCORSDetector" reports="PERMISSIVE_CORS"/>
     <Detector class="com.h3xstream.findsecbugs.taintanalysis.extra.PotentialValueTracker" reports="HARD_CODE_PASSWORD,DES_USAGE,WEAK_MESSAGE_DIGEST_MD5,WEAK_MESSAGE_DIGEST_SHA1"/> <!-- This detector is not reporting any issue -->
     <Detector class="com.h3xstream.findsecbugs.taintanalysis.extra.JstlExpressionWhiteLister" reports="XSS_JSP_PRINT"/> <!-- This detector is not reporting any issue -->
     <Detector class="com.h3xstream.findsecbugs.crypto.ErrorMessageExposureDetector" reports="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -5347,6 +5347,11 @@ Avoid using * as the value of the Access-Control-Allow-Origin header, which indi
     </BugPattern>
     <BugCode abbrev="SECCORS">Overly permissive CORS policy</BugCode>
 
+    <!-- Overly permissive CORS policy -->
+    <Detector class="com.h3xstream.findsecbugs.spring.CorsRegistryCORSDetector">
+        <Details>Detect overly CorsRegistry CORS policy. </Details>
+    </Detector>
+
     <!-- LDAP anonymous bind detector -->
     <Detector class="com.h3xstream.findsecbugs.ldap.AnonymousLdapDetector">
         <Details>Identify use of anonymous LDAP bind</Details>

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
@@ -29,7 +29,7 @@ public class PermissiveCORSDetectorTest extends BaseDetectorTest {
     public void detectPermissiveCORS() throws Exception {
         //Locate test code
         String[] files = {
-                getClassFilePath("testcode/PermissiveCORS")
+                getClassFilePath("testcode/cors/PermissiveCORS")
         };
 
         //Run the analysis

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/CorsRegistryCORSDetectorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.spring;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class CorsRegistryCORSDetectorTest  extends BaseDetectorTest {
+
+    @Test
+    public void detectPermissiveCORS() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cors/SpringPermissiveCORSInsecure")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+
+        //
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("SpringPermissiveCORSInsecure").inMethod("addCorsMappings").atLine(11)
+                        .build()
+        );
+    }
+
+    @Test
+    public void detectPermissiveCORSavoidFP() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cors/SpringPermissiveCORSSecure")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //
+        verify(reporter,never()).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("SpringPermissiveCORSSecure")
+                        .build()
+        );
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistration.java
+++ b/findsecbugs-samples-deps/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistration.java
@@ -1,0 +1,10 @@
+package org.springframework.web.servlet.config.annotation;
+
+public class CorsRegistration {
+    public CorsRegistration allowCredentials(boolean allowCredentials) {return this;}
+    public CorsRegistration allowedHeaders(String... headers) {return this;}
+    public CorsRegistration allowedMethods(String... methods) {return this;}
+    public CorsRegistration allowedOrigins(String... origins) {return this;}
+    public CorsRegistration exposedHeaders(String... headers) {return this;}
+    public CorsRegistration	maxAge(long maxAge) {return this;};
+}

--- a/findsecbugs-samples-deps/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistry.java
+++ b/findsecbugs-samples-deps/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistry.java
@@ -1,0 +1,8 @@
+package org.springframework.web.servlet.config.annotation;
+
+public class CorsRegistry {
+
+    public CorsRegistration	addMapping(String pathPattern) {
+        return null;
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.java
+++ b/findsecbugs-samples-deps/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.java
@@ -1,0 +1,6 @@
+package org.springframework.web.servlet.config.annotation;
+
+public interface WebMvcConfigurer {
+
+    void addCorsMappings(CorsRegistry registry);
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cors/PermissiveCORS.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cors/PermissiveCORS.java
@@ -1,4 +1,4 @@
-package testcode;
+package testcode.cors;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;

--- a/findsecbugs-samples-java/src/test/java/testcode/cors/SpringPermissiveCORSInsecure.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cors/SpringPermissiveCORSInsecure.java
@@ -1,0 +1,15 @@
+package testcode.cors;
+
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class SpringPermissiveCORSInsecure implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*") //vulnerable
+                .allowedMethods("GET","POST","PUT", "DELETE")
+                .allowCredentials(true).maxAge(3600);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cors/SpringPermissiveCORSSecure.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cors/SpringPermissiveCORSSecure.java
@@ -1,0 +1,4 @@
+package testcode.cors;
+
+public class SpringPermissiveCORSSecure {
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cors/SpringPermissiveCORSSecure.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cors/SpringPermissiveCORSSecure.java
@@ -1,4 +1,15 @@
 package testcode.cors;
 
-public class SpringPermissiveCORSSecure {
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class SpringPermissiveCORSSecure implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("safe.com") //specific domain
+                .allowedMethods("GET","POST","PUT", "DELETE")
+                .allowCredentials(true).maxAge(3600);
+    }
 }


### PR DESCRIPTION
Springboot developer may use CorsRegistration to set access-control-allow-origin to `*`, which is permissive. The vulnerable code may like this:
```java
import org.springframework.context.annotation.Configuration;
import org.springframework.web.servlet.config.annotation.CorsRegistry;
import org.springframework.web.servlet.config.annotation.EnableWebMvc;
import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

@Configuration
@EnableWebMvc
public class WebConfig implements WebMvcConfigurer {

   @Override
    public void addCorsMappings(CorsRegistry registry) {
        registry.addMapping("/**")
            .allowedOrigins("*") //vulnerable
            .allowedMethods("GET","POST","PUT", "DELETE")
            .allowCredentials(true).maxAge(3600);
    }
}
```
This detector can find this pattern.