### PR TITLE
local-variable-index-rewrite-bug

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -735,6 +735,11 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
             assert false : "Out of bounds local variable index in " + methodDescriptor;
             return; // ignore if assertions disabled
         }
+
+        if (valueTaint.hasValidVariableIndex() && valueTaint.getVariableIndex() != index) {
+            valueTaint = new Taint(valueTaint);
+        }
+
         valueTaint.setVariableIndex(index);
         getFrame().setValue(index, valueTaint);
     }


### PR DESCRIPTION
Hi @h3xstream,

I didn't add any test because we don't have any for taint analysis itself :(

I reproduced it when analyzing https://github.com/liferay/liferay-portal/blob/8362adb202e75dbf328b90abb4a9782b13457a21/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/DocumentConversionImpl.java#L81 with `com/liferay/document/library/document/conversion/internal/DocumentConversionImpl._validate(Ljava/lang/String;Ljava/lang/String;)V:0,1|+PATH_TRAVERSAL_SAFE#0,1` whitelist.

Then it failed here: 
https://github.com/find-sec-bugs/find-sec-bugs/blob/8b32373515e627cc42704b9e3edb5508c6ddb2bf/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java#L329