### PR TITLE
Unable to detect injections on older versions of Hibernate

### DIFF
--- a/findsecbugs-plugin/src/main/resources/injection-sinks/sql-hibernate.txt
+++ b/findsecbugs-plugin/src/main/resources/injection-sinks/sql-hibernate.txt
@@ -3,4 +3,5 @@ org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;Ljava/lang
 org/hibernate/criterion/Restrictions.sqlRestriction(Ljava/lang/String;[Ljava/lang/Object;[Lorg/hibernate/type/Type;)Lorg/hibernate/criterion/Criterion;:2
 
 org/hibernate/Session.createQuery(Ljava/lang/String;)Lorg/hibernate/Query;:0
+org/hibernate/Session.createQuery(Ljava/lang/String;)Lorg/hibernate/query/Query;:0
 org/hibernate/Session.createSQLQuery(Ljava/lang/String;)Lorg/hibernate/SQLQuery;:0


### PR DESCRIPTION
Added a sink signature for the deprecated hibernate createQuery, which returns org.hibernate.query.Query.