### PR TITLE
190430-taint-method-propagation-II

### DIFF
--- a/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/matcher/BugInstanceMatcher.java
+++ b/findbugs-test-util/src/test/java/com/h3xstream/findbugs/test/matcher/BugInstanceMatcher.java
@@ -152,7 +152,8 @@ public class BugInstanceMatcher extends BaseMatcher<BugInstance> {
                 boolean found = false;
                 for (StringAnnotation strAnn : srcAnn) {
                     //The key "Unknown source" can not be reference directly
-                    if (strAnn.getDescription().equals("Unknown source")) {
+                    String description = strAnn.getDescription();
+                    if (description.equals("Unknown source") || description.equals("Null source") || description.equals("Tainted source") || description.equals("Safe source")) {
                         if(unknownSources.contains(strAnn.getValue())) {
                             found = true;
                         }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/BCELUtil.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/BCELUtil.java
@@ -1,0 +1,134 @@
+package com.h3xstream.findsecbugs;
+
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.util.ClassName;
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.ConstantCP;
+import org.apache.bcel.classfile.ConstantPool;
+import org.apache.bcel.generic.FieldOrMethod;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InvokeInstruction;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class BCELUtil {
+    public static final String INVOKEDYNAMIC_GENERIC_CLASSNAME = Object.class.getName();
+
+    public static String getSlashedClassName(ConstantPoolGen cpg, FieldOrMethod obj) {
+        if (Const.INVOKEDYNAMIC == obj.getOpcode()) {
+            return INVOKEDYNAMIC_GENERIC_CLASSNAME;
+        }
+
+        ConstantPool cp = cpg.getConstantPool();
+        ConstantCP invokeConstant = (ConstantCP)cp.getConstant(obj.getIndex());
+        return cp.getConstantString(invokeConstant.getClassIndex(), Const.CONSTANT_Class);
+    }
+
+    public static String getSlashedClassName(JavaClass javaClass) {
+        ConstantPool cp = javaClass.getConstantPool();
+        int classNameIndex = javaClass.getClassNameIndex();
+        return cp.getConstantString(classNameIndex, Const.CONSTANT_Class);
+    }
+
+    public static Set<String> getParentClassNames(JavaClass javaClass) {
+        Set<String> classNames = superMap.get(javaClass.getClassName());
+
+        if (classNames == null) {
+            classNames = new HashSet<>();
+
+            Queue<JavaClass> queue = new LinkedList<>();
+            queue.offer(javaClass);
+            while (!queue.isEmpty()) {
+                JavaClass clazz = queue.poll();
+                if (clazz != javaClass) {
+                    classNames.add(BCELUtil.getSlashedClassName(clazz));
+                }
+
+                try {
+                    JavaClass superClass = clazz.getSuperClass();
+                    if (superClass != null) {
+                        queue.offer(superClass);
+                    }
+                } catch (ClassNotFoundException ex) {
+                    AnalysisContext.reportMissingClass(ex);
+
+                    classNames.add(ClassName.toSlashedClassName(clazz.getSuperclassName()));
+                }
+                try {
+                    for (JavaClass interfaceClass : clazz.getInterfaces()) {
+                        queue.offer(interfaceClass);
+                    }
+                } catch (ClassNotFoundException ex) {
+                    AnalysisContext.reportMissingClass(ex);
+
+                    for (String interfaceClassName : clazz.getInterfaceNames()) {
+                        classNames.add(ClassName.toSlashedClassName(interfaceClassName));
+                    }
+                }
+            }
+
+            superMap.put(javaClass.getClassName(), classNames);
+        }
+
+        return classNames;
+    }
+
+    private static Map<String, Set<String>> superMap = new WeakHashMap<>();
+
+    public static int getNumArgumentsIncludingObjectInstance(InvokeInstruction obj, ConstantPoolGen cpg) {
+        String signature = obj.getSignature(cpg);
+        int count = 1;
+
+        if ((obj.getOpcode() == Const.INVOKESTATIC) || (obj.getOpcode() == Const.INVOKEDYNAMIC)) {
+            count = 0;
+        }
+
+        for (int i = 0; i < signature.length(); i++) {
+            switch (signature.charAt(i)) {
+                case '(':
+                    break;
+
+                case ')':
+                    return count;
+
+                case 'B':
+                case 'C':
+                case 'D':
+                case 'F':
+                case 'I':
+                case 'J':
+                case 'S':
+                case 'Z':
+                    count++;
+                    break;
+
+                case 'L':
+                    int semi = signature.indexOf(';', i + 1);
+                    if (semi < 0) {
+                        throw new IllegalStateException("Invalid method signature: " + signature);
+                    }
+                    i = semi;
+                    count++;
+                    break;
+
+                case '[':
+                    break;
+
+                case 'V':
+                default:
+                    throw new IllegalStateException("Invalid method signature, unknown character " + signature.charAt(i) + " in " + signature);
+            }
+        }
+
+        return count;
+    }
+}

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/BCELUtil.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/BCELUtil.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs;
 
 import edu.umd.cs.findbugs.ba.AnalysisContext;

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractTaintDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractTaintDetector.java
@@ -72,6 +72,24 @@ public abstract class AbstractTaintDetector implements Detector {
             if (classContext.getMethodGen(method) == null) {
                 continue;
             }
+            if (!method.isStatic()) {
+                continue;
+            }
+            try {
+                analyzeMethod(classContext, method);
+            } catch (CheckedAnalysisException e) {
+                logException(classContext, method, e);
+            } catch (RuntimeException e) {
+                logException(classContext, method, e);
+            }
+        }
+        for (Method method : classContext.getMethodsInCallOrder()) {
+            if (classContext.getMethodGen(method) == null) {
+                continue;
+            }
+            if (method.isStatic()) {
+                continue;
+            }
             try {
                 analyzeMethod(classContext, method);
             } catch (CheckedAnalysisException e) {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractTaintDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractTaintDetector.java
@@ -90,7 +90,8 @@ public abstract class AbstractTaintDetector implements Detector {
             throws CheckedAnalysisException {
         TaintDataflow dataflow = getTaintDataFlow(classContext, method);
         ConstantPoolGen cpg = classContext.getConstantPoolGen();
-        String currentMethod = getFullMethodName(classContext.getMethodGen(method));
+        ClassMethodSignature classMethodSignature = new ClassMethodSignature(
+                com.h3xstream.findsecbugs.BCELUtil.getSlashedClassName(classContext.getJavaClass()), method.getName(), method.getSignature());
         for (Iterator<Location> i = getLocationIterator(classContext, method); i.hasNext();) {
             Location location = i.next();
             InstructionHandle handle = location.getHandle();
@@ -104,7 +105,7 @@ public abstract class AbstractTaintDetector implements Detector {
             if (!fact.isValid()) {
                 continue;
             }
-            analyzeLocation(classContext, method, handle, cpg, invoke, fact, currentMethod);
+            analyzeLocation(classContext, method, handle, cpg, invoke, fact, classMethodSignature);
         }
     }
     
@@ -122,12 +123,6 @@ public abstract class AbstractTaintDetector implements Detector {
         MethodDescriptor descriptor = BCELUtil.getMethodDescriptor(classContext.getJavaClass(), method);
         return Global.getAnalysisCache().getMethodAnalysis(TaintDataflow.class, descriptor);
     }
-
-    private static String getFullMethodName(MethodGen methodGen) {
-        String methodNameWithSignature = methodGen.getName() + methodGen.getSignature();
-        String slashedClassName = methodGen.getClassName().replace('.', '/');
-        return slashedClassName + "." + methodNameWithSignature;
-    }
     
     private void logException(ClassContext classContext, Method method, Exception ex) {
         bugReporter.logError("Exception while analyzing "
@@ -135,6 +130,6 @@ public abstract class AbstractTaintDetector implements Detector {
     }
     
     abstract protected void analyzeLocation(ClassContext classContext, Method method, InstructionHandle handle,
-            ConstantPoolGen cpg, InvokeInstruction invoke, TaintFrame fact, String currentMethod)
+            ConstantPoolGen cpg, InvokeInstruction invoke, TaintFrame fact, ClassMethodSignature classMethodSignature)
             throws DataflowAnalysisException;
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/ClassMethodSignature.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/ClassMethodSignature.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.injection;
 
 import java.util.Objects;

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/ClassMethodSignature.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/ClassMethodSignature.java
@@ -1,0 +1,68 @@
+package com.h3xstream.findsecbugs.injection;
+
+import java.util.Objects;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class ClassMethodSignature {
+    private String className;
+    private String methodName;
+    private String signature;
+
+    public ClassMethodSignature(String className, String methodName, String signature) {
+        this.className = className;
+        this.methodName = methodName;
+        this.signature = signature;
+    }
+
+    public static ClassMethodSignature from(String fullMethodName) {
+        int periodPos = fullMethodName.indexOf('.');
+        int parenthesisPos = fullMethodName.indexOf('(', periodPos);
+
+        String className = fullMethodName.substring(0, periodPos);
+        String methodName = fullMethodName.substring(periodPos + 1, parenthesisPos);
+        String signature = fullMethodName.substring(parenthesisPos);
+
+        return new ClassMethodSignature(className, methodName, signature);
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClassMethodSignature that = (ClassMethodSignature) o;
+        return Objects.equals(className, that.className) &&
+                Objects.equals(methodName, that.methodName) &&
+                Objects.equals(signature, that.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, methodName, signature);
+    }
+}

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/MethodAndSink.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/MethodAndSink.java
@@ -20,27 +20,24 @@ package com.h3xstream.findsecbugs.injection;
 import java.util.Objects;
 
 /**
- * String and InjectionSink tuple
+ * ClassMethodSignature and InjectionSink tuple
  * 
  * @author David Formanek (Y Soft Corporation, a.s.)
  */
 public class MethodAndSink {
     
-    private final String method;
+    private final ClassMethodSignature classMethodSignature;
     private final InjectionSink sink;
 
-    public MethodAndSink(String method, InjectionSink sink) {
-        Objects.requireNonNull(method, "method");
-        if (method.isEmpty()) {
-            throw new IllegalArgumentException("empty method name");
-        }
+    public MethodAndSink(ClassMethodSignature classMethodSignature, InjectionSink sink) {
+        Objects.requireNonNull(classMethodSignature, "classMethodSignature");
         Objects.requireNonNull(sink, "sink");
-        this.method = method;
+        this.classMethodSignature = classMethodSignature;
         this.sink = sink;
     }
 
-    public String getMethod() {
-        return method;
+    public ClassMethodSignature getClassMethodSignature() {
+        return classMethodSignature;
     }
 
     public InjectionSink getSink() {
@@ -48,25 +45,16 @@ public class MethodAndSink {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (!(obj instanceof MethodAndSink)) {
-            return false;
-        }
-        final MethodAndSink other = (MethodAndSink) obj;
-        return this.method.equals(other.method) && this.sink.equals(other.sink);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MethodAndSink that = (MethodAndSink) o;
+        return Objects.equals(classMethodSignature, that.classMethodSignature) &&
+                Objects.equals(sink, that.sink);
     }
-    
+
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 71 * hash + method.hashCode();
-        hash = 71 * hash + sink.hashCode();
-        return hash;
+        return Objects.hash(classMethodSignature, sink);
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/redirect/UnvalidatedRedirectDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/redirect/UnvalidatedRedirectDetector.java
@@ -19,7 +19,9 @@ package com.h3xstream.findsecbugs.injection.redirect;
 
 import com.h3xstream.findsecbugs.injection.InjectionSource;
 import com.h3xstream.findsecbugs.injection.LegacyInjectionDetector;
+import com.h3xstream.findsecbugs.taintanalysis.Taint;
 import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
 
 public class UnvalidatedRedirectDetector extends LegacyInjectionDetector {
 
@@ -31,4 +33,14 @@ public class UnvalidatedRedirectDetector extends LegacyInjectionDetector {
     public InjectionSource[] getInjectionSource() {
         return new InjectionSource[]{new RedirectionSource()};
     }
+
+    @Override
+    protected int getPriority(Taint taint) {
+        if (taint.hasTag(Taint.Tag.REDIRECT_SAFE)) {
+            return Priorities.IGNORE_PRIORITY;
+        } else {
+            return super.getPriority(taint);
+        }
+    }
+
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -181,6 +181,28 @@ public class Taint {
     }
 
     /**
+     * Checks if there is any valuable information derived by the taint analysis.
+     *
+     * @return true if the Taint contains any useful information, false otherwise
+     */
+    public boolean isInformative() {
+        if (!isUnknown()) {
+            return true;
+        }
+        if (hasParameters()) {
+            return true;
+        }
+        if (getRealInstanceClass() != null) {
+            return true;
+        }
+        if (hasTags() || isRemovingTags()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the taint state of this fact
      *
      * @return taint state

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -105,6 +105,7 @@ public class Taint {
         CUSTOM_INJECTION_SAFE,
         URL_ENCODED,
         PATH_TRAVERSAL_SAFE,
+        REDIRECT_SAFE,
 
         CREDIT_CARD_VARIABLE,
         PASSWORD_VARIABLE,

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/Taint.java
@@ -115,17 +115,18 @@ public class Taint {
     private State state;
     private static final int INVALID_INDEX = -1;
     private int variableIndex;
-    private final Set<TaintLocation> taintLocations;
-    private final Set<TaintLocation> unknownLocations;
-    private final Set<Integer> parameters;
+    private Set<TaintLocation> taintLocations;
+    private Set<TaintLocation> unknownLocations;
+    private Set<Integer> parameters;
     private State nonParametricState;
     private ObjectType realInstanceClass;
-    private final Set<Tag> tags;
-    private final Set<Tag> tagsToRemove;
+    private String realInstanceClassName;
+    private Set<Tag> tags;
+    private Set<Tag> tagsToRemove;
     private String constantValue;
     private String potentialValue;
     private String debugInfo = null;
-    private Set<UnknownSource> sources = new HashSet<>();
+    private Set<UnknownSource> sources;
 
     /**
      * Constructs a new empty instance of Taint with the specified state
@@ -141,13 +142,8 @@ public class Taint {
         }
         this.state = state;
         this.variableIndex = INVALID_INDEX;
-        this.unknownLocations = new HashSet<TaintLocation>();
-        this.taintLocations = new HashSet<TaintLocation>();
-        this.parameters = new HashSet<Integer>();
         this.nonParametricState = State.INVALID;
         this.realInstanceClass = null;
-        this.tags = EnumSet.noneOf(Tag.class);
-        this.tagsToRemove = EnumSet.noneOf(Tag.class);
         this.constantValue = null;
         if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             this.debugInfo = "?";
@@ -165,19 +161,31 @@ public class Taint {
         assert taint.state != null;
         this.state = taint.state;
         this.variableIndex = taint.variableIndex;
-        this.taintLocations = new HashSet<TaintLocation>(taint.taintLocations);
-        this.unknownLocations = new HashSet<TaintLocation>(taint.unknownLocations);
-        this.parameters = new HashSet<Integer>(taint.getParameters());
+        if (taint.taintLocations != null) {
+            this.taintLocations = new HashSet<>(taint.taintLocations);
+        }
+        if (taint.unknownLocations != null) {
+            this.unknownLocations = new HashSet<>(taint.unknownLocations);
+        }
+        if (taint.parameters != null) {
+            this.parameters = new HashSet<>(taint.parameters);
+        }
         this.nonParametricState = taint.nonParametricState;
         this.realInstanceClass = taint.realInstanceClass;
-        this.tags = EnumSet.copyOf(taint.tags);
-        this.tagsToRemove = EnumSet.copyOf(taint.tagsToRemove);
+        if (taint.hasTags()) {
+            this.tags = EnumSet.copyOf(taint.tags);
+        }
+        if (taint.isRemovingTags()) {
+            this.tagsToRemove = EnumSet.copyOf(taint.tagsToRemove);
+        }
         this.constantValue = taint.constantValue;
         this.potentialValue = taint.potentialValue;
         if (FindSecBugsGlobalConfig.getInstance().isDebugTaintState()) {
             this.debugInfo = taint.debugInfo;
         }
-        this.sources.addAll(taint.sources);
+        if (taint.sources != null) {
+            this.sources = new HashSet<>(taint.sources);
+        }
     }
 
     /**
@@ -262,8 +270,15 @@ public class Taint {
     public void addLocation(TaintLocation location, boolean isKnownTaintSource) {
         Objects.requireNonNull(location, "location is null");
         if (isKnownTaintSource) {
+            if (taintLocations == null) {
+                taintLocations = new HashSet<>();
+            }
+
             taintLocations.add(location);
         } else {
+            if (unknownLocations == null) {
+                unknownLocations = new HashSet<>();
+            }
             unknownLocations.add(location);
         }
     }
@@ -276,6 +291,10 @@ public class Taint {
      * @return unmodifiable set of locations
      */
     public Set<TaintLocation> getTaintedLocations() {
+        if (taintLocations == null) {
+            return Collections.emptySet();
+        }
+
         return Collections.unmodifiableSet(taintLocations);
     }
 
@@ -283,6 +302,10 @@ public class Taint {
      * @return All the location of tainted and unknown locations.
      */
     public Collection<TaintLocation> getUnknownLocations() {
+        if (unknownLocations == null) {
+            return Collections.emptySet();
+        }
+
         return Collections.unmodifiableSet(unknownLocations);
     }
 
@@ -290,10 +313,18 @@ public class Taint {
      * @return All the location of tainted and unknown locations.
      */
     public Collection<TaintLocation> getAllLocations() {
-        List<TaintLocation> allLocations = new ArrayList<>();
-        allLocations.addAll(unknownLocations);
-        allLocations.addAll(taintLocations);
-        return allLocations;
+        if (unknownLocations != null && taintLocations != null) {
+            List<TaintLocation> allLocations = new ArrayList<>(unknownLocations.size() + taintLocations.size());
+            allLocations.addAll(unknownLocations);
+            allLocations.addAll(taintLocations);
+            return allLocations;
+        }
+        else if (unknownLocations != null) {
+            return getUnknownLocations();
+        }
+        else {
+            return getTaintedLocations();
+        }
     }
 
     /**
@@ -327,6 +358,9 @@ public class Taint {
         if (parameterIndex < 0) {
             throw new IllegalArgumentException("index cannot be negative");
         }
+        if (parameters == null) {
+            parameters = new HashSet<>();
+        }
         parameters.add(parameterIndex);
     }
 
@@ -336,7 +370,7 @@ public class Taint {
      * @return true if there is an influence, false otherwise
      */
     public boolean hasParameters() {
-        return !parameters.isEmpty();
+        return parameters != null && !parameters.isEmpty();
     }
 
     /**
@@ -345,6 +379,10 @@ public class Taint {
      * @return unmodifiable set of parameter indices
      */
     public Set<Integer> getParameters() {
+        if (parameters == null) {
+            return Collections.emptySet();
+        }
+
         return Collections.unmodifiableSet(parameters);
     }
 
@@ -389,7 +427,11 @@ public class Taint {
         if (realInstanceClass == null) {
             return null;
         }
-        return ClassName.toSlashedClassName(realInstanceClass.getClassName());
+        if (realInstanceClassName == null) {
+            realInstanceClassName = ClassName.toSlashedClassName(realInstanceClass.getClassName());
+        }
+
+        return realInstanceClassName;
     }
 
     /**
@@ -400,6 +442,10 @@ public class Taint {
      * @return true if this tag was not present before, false otherwise
      */
     public boolean addTag(Tag tag) {
+        if (tags == null) {
+            tags = EnumSet.noneOf(Tag.class);
+        }
+
         return tags.add(tag);
     }
     
@@ -410,7 +456,7 @@ public class Taint {
      * @return true if it is present, false otherwise
      */
     public boolean hasTag(Tag tag) {
-        return tags.contains(tag);
+        return tags != null && tags.contains(tag);
     }
 
     /**
@@ -420,6 +466,10 @@ public class Taint {
      * @return true if at least one is present, false otherwise
      */
     public boolean hasOneTag(Tag... tags) {
+        if (this.tags == null) {
+            return false;
+        }
+
         for(Tag t : tags) {
             if (this.tags.contains(t)) return true;
         }
@@ -432,7 +482,7 @@ public class Taint {
      * @return true if number of tags is &gt; 0, false otherwise
      */
     public boolean hasTags() {
-        return !tags.isEmpty();
+        return tags != null && !tags.isEmpty();
     }
     
     /**
@@ -441,6 +491,10 @@ public class Taint {
      * @return unmodifiable set of all present taint tags
      */
     public Set<Tag> getTags() {
+        if (tags == null) {
+            return Collections.emptySet();
+        }
+
         return Collections.unmodifiableSet(tags);
     }
     
@@ -452,8 +506,12 @@ public class Taint {
      * @return true if the tag was present, false otherwise
      */
     public boolean removeTag(Tag tag) {
+        if (tagsToRemove == null) {
+            tagsToRemove = EnumSet.noneOf(Tag.class);
+        }
         tagsToRemove.add(tag);
-        return tags.remove(tag);
+
+        return tags != null && tags.remove(tag);
     }
     
     /**
@@ -463,7 +521,7 @@ public class Taint {
      * @return true if there are some, false otherwise
      */
     public boolean isRemovingTags() {
-        return !tagsToRemove.isEmpty();
+        return tagsToRemove != null && !tagsToRemove.isEmpty();
     }
     
     /**
@@ -472,6 +530,10 @@ public class Taint {
      * @return unmodifiable set of tags
      */
     public Set<Tag> getTagsToRemove() {
+        if (tagsToRemove == null) {
+            return Collections.emptySet();
+        }
+
         return Collections.unmodifiableSet(tagsToRemove);
     }
     
@@ -554,10 +616,30 @@ public class Taint {
         if (a.variableIndex == b.variableIndex) {
             result.variableIndex = a.variableIndex;
         }
-        result.taintLocations.addAll(a.taintLocations);
-        result.taintLocations.addAll(b.taintLocations);
-        result.unknownLocations.addAll(a.unknownLocations);
-        result.unknownLocations.addAll(b.unknownLocations);
+        int taintLocationsSize =
+                (a.taintLocations != null ? a.taintLocations.size() : 0) +
+                    (b.taintLocations != null ? b.taintLocations.size() : 0);
+        if (taintLocationsSize > 0) {
+            result.taintLocations = new HashSet<>(taintLocationsSize);
+        }
+        if (a.taintLocations != null) {
+            result.taintLocations.addAll(a.taintLocations);
+        }
+        if (b.taintLocations != null) {
+            result.taintLocations.addAll(b.taintLocations);
+        }
+        int unknownLocationsSize =
+                (a.unknownLocations != null ? a.unknownLocations.size() : 0) +
+                    (b.unknownLocations != null ? b.unknownLocations.size() : 0);
+        if (unknownLocationsSize > 0) {
+            result.unknownLocations = new HashSet<>(unknownLocationsSize);
+        }
+        if (a.unknownLocations != null) {
+            result.unknownLocations.addAll(a.unknownLocations);
+        }
+        if (b.unknownLocations != null) {
+            result.unknownLocations.addAll(b.unknownLocations);
+        }
         if (!result.isTainted()) {
            mergeParameters(a, b, result); 
         }
@@ -576,14 +658,40 @@ public class Taint {
         else if(b.potentialValue != null) {
             result.potentialValue = b.potentialValue;
         }
-        result.addAllSources(a.sources);
-        result.addAllSources(b.sources);
+
+        int sourcesSize =
+                (a.sources != null ? a.sources.size() : 0) +
+                        (b.sources != null ? b.sources.size() : 0);
+        if (sourcesSize > 0) {
+            result.sources = new HashSet<>(sourcesSize);
+        }
+        if (a.sources != null) {
+            result.sources.addAll(a.sources);
+        }
+        if (b.sources != null) {
+            result.sources.addAll(b.sources);
+        }
+
         return result;
     }
 
     private static void mergeParameters(Taint a, Taint b, Taint result) {
-        result.parameters.addAll(a.parameters);
-        result.parameters.addAll(b.parameters);
+        int parametersSize =
+                (a.parameters != null ? a.parameters.size() : 0) +
+                        (b.parameters != null ? b.parameters.size() : 0);
+
+        if (parametersSize == 0) {
+            return;
+        }
+
+        result.parameters = new HashSet<>(parametersSize);
+        if (a.parameters != null) {
+            result.parameters.addAll(a.parameters);
+        }
+        if (b.parameters != null) {
+            result.parameters.addAll(b.parameters);
+        }
+
         if (a.hasParameters()) {
             if (b.hasParameters()) {
                 result.nonParametricState = State.merge(a.nonParametricState, b.nonParametricState);
@@ -613,16 +721,39 @@ public class Taint {
     }
     
     private static void mergeTags(Taint a, Taint b, Taint result) {
-        if (a.isSafe()) {
+        if (a.isSafe() && b.hasTags()) {
+            if (result.tags == null) {
+                result.tags = EnumSet.noneOf(Tag.class);
+            }
             result.tags.addAll(b.tags);
-        } else if (b.isSafe()) {
+        } else if (b.isSafe() && a.hasTags()) {
+            if (result.tags == null) {
+                result.tags = EnumSet.noneOf(Tag.class);
+            }
             result.tags.addAll(a.tags);
         } else {
-            result.tags.addAll(a.tags);
-            result.tags.retainAll(b.tags);
+            if (a.hasTags() && b.hasTags()) {
+                if (result.tags == null) {
+                    result.tags = EnumSet.noneOf(Tag.class);
+                }
+
+                result.tags.addAll(a.tags);
+                result.tags.retainAll(b.tags);
+            }
         }
-        result.tagsToRemove.addAll(a.tagsToRemove);
-        result.tagsToRemove.addAll(b.tagsToRemove);
+
+        if (a.isRemovingTags()) {
+            if (result.tagsToRemove == null) {
+                result.tagsToRemove = EnumSet.noneOf(Tag.class);
+            }
+            result.tagsToRemove.addAll(a.tagsToRemove);
+        }
+        if (b.isRemovingTags()) {
+            if (result.tagsToRemove == null) {
+                result.tagsToRemove = EnumSet.noneOf(Tag.class);
+            }
+            result.tagsToRemove.addAll(b.tagsToRemove);
+        }
     }
 
     @Override
@@ -639,9 +770,9 @@ public class Taint {
         Taint other = (Taint) obj;
         return this.state == other.state
                 && this.variableIndex == other.variableIndex
-                && this.taintLocations.equals(other.taintLocations)
-                && this.unknownLocations.equals(other.unknownLocations)
-                && this.parameters.equals(other.parameters)
+                && Objects.equals(this.taintLocations, other.taintLocations)
+                && Objects.equals(this.unknownLocations, other.unknownLocations)
+                && Objects.equals(this.parameters, other.parameters)
                 && this.nonParametricState == other.nonParametricState
                 && Objects.equals(this.realInstanceClass, other.realInstanceClass)
                 //&& this.tags.equals(other.tags)
@@ -676,14 +807,30 @@ public class Taint {
     }
 
     public Set<UnknownSource> getSources() {
+        if (sources == null) {
+            return Collections.emptySet();
+        }
+
         return sources;
     }
 
     public void addSource(UnknownSource source) {
+        if (this.sources == null) {
+            this.sources = new HashSet<>();
+        }
+
         this.sources.add(source);
     }
 
     protected void addAllSources(Set<UnknownSource> sources) {
+        if (sources == null) {
+            return;
+        }
+
+        if (this.sources == null) {
+            this.sources = new HashSet<>();
+        }
+
         this.sources.addAll(sources);
     }
 
@@ -694,7 +841,7 @@ public class Taint {
         if (hasValidVariableIndex()) {
             sb.append(variableIndex);
         }
-        if (!parameters.isEmpty()) {
+        if (parameters != null && !parameters.isEmpty()) {
             sb.append(parameters);
         }
         assert nonParametricState != null;
@@ -724,7 +871,7 @@ public class Taint {
         if (potentialValue != null) {
             sb.append(" potential=").append(potentialValue);
         }
-        if (tags.size() > 0) {
+        if (tags != null && tags.size() > 0) {
             sb.append(" tags=").append(Arrays.toString(tags.toArray()));
         }
         return sb.toString();

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
@@ -103,6 +103,7 @@ public class TaintAnalysis extends FrameDataflowAnalysis<Taint, TaintFrame> {
     public void initEntryFact(TaintFrame fact) {
         fact.setValid();
         fact.clearStack();
+        String methodFullSignature = methodDescriptor.getSlashedClassName() + "." + methodDescriptor.getName() + methodDescriptor.getSignature();
         boolean inMainMethod = isInMainMethod();
         int numSlots = fact.getNumSlots();
         int numLocals = fact.getNumLocals();
@@ -124,7 +125,7 @@ public class TaintAnalysis extends FrameDataflowAnalysis<Taint, TaintFrame> {
                     } else {
                         value.addParameter(stackOffset);
                     }
-                    value.addSource(new UnknownSource(UnknownSourceType.PARAMETER,value.getState()).setParameterIndex(stackOffset));
+                    value.addSource(new UnknownSource(UnknownSourceType.PARAMETER,value.getState()).setSignatureMethod(methodFullSignature).setParameterIndex(stackOffset));
                 }
                 value.setVariableIndex(i);
             }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintClassConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintClassConfig.java
@@ -33,6 +33,7 @@ public class TaintClassConfig implements TaintTypeConfig {
     private static final String IMMUTABLE = "#IMMUTABLE";
     private Taint.State taintState = DEFAULT_TAINT_STATE;
     private boolean immutable;
+    private String typeSignature;
     private static final Pattern typePattern;
     private static final Pattern taintConfigPattern;
 
@@ -96,17 +97,16 @@ public class TaintClassConfig implements TaintTypeConfig {
         if (taintConfig.isEmpty()) {
             throw new IOException("No taint class config specified");
         }
-        TaintClassConfig taintClassConfig = new TaintClassConfig();
         if (taintConfig.endsWith(IMMUTABLE)) {
-            taintClassConfig.immutable = true;
+            immutable = true;
             taintConfig = taintConfig.substring(0, taintConfig.length() - IMMUTABLE.length());
         }
 
         if (!taintConfig.isEmpty()) {
-            taintClassConfig.taintState = Taint.State.valueOf(taintConfig);
+            taintState = Taint.State.valueOf(taintConfig);
         }
 
-        return taintClassConfig;
+        return this;
     }
 
     public Taint.State getTaintState() {
@@ -123,5 +123,23 @@ public class TaintClassConfig implements TaintTypeConfig {
         }
 
         return taintState;
+    }
+
+    /**
+     * Set full class and method signature for the analyzed method
+     *
+     * @param typeSignature method signature
+     */
+    public void setTypeSignature(String typeSignature) {
+        this.typeSignature = typeSignature;
+    }
+
+    /**
+     * Returns the analyzed method full signature
+     *
+     * @return signature of the method
+     */
+    public String getTypeSignature() {
+        return typeSignature;
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintConfig.java
@@ -93,6 +93,7 @@ public class TaintConfig extends HashMap<String, TaintMethodConfig> {
                         throw new IllegalStateException("Config for " + typeSignature + " already loaded");
                     }
                     TaintClassConfig taintClassConfig = new TaintClassConfig().load(config);
+                    taintClassConfig.setTypeSignature(typeSignature);
                     taintClassConfigMap.put(typeSignature, taintClassConfig);
                     return;
                 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintConfig.java
@@ -49,12 +49,14 @@ import java.util.TreeSet;
  * @author David Formanek (Y Soft Corporation, a.s.)
  */
 public class TaintConfig extends HashMap<String, TaintMethodConfig> {
-    
+
     private static final long serialVersionUID = 1L;
     private final Map<String, TaintClassConfig> taintClassConfigMap = new HashMap<String, TaintClassConfig>();
     private final Map<String, TaintFieldConfig> taintFieldConfigMap = new HashMap<String, TaintFieldConfig>();
     private final Map<String, TaintMethodConfigWithArgumentsAndLocation> taintMethodConfigWithArgumentsAndLocationMap =
             new HashMap<String, TaintMethodConfigWithArgumentsAndLocation>();
+
+    private final Map<String, Taint> staticFieldsTaint = new HashMap<String, Taint>();
 
     /**
      * Dumps all the summaries for debugging
@@ -290,4 +292,22 @@ public class TaintConfig extends HashMap<String, TaintMethodConfig> {
         String key = methodDefinition + "@" + methodDescriptor.getSlashedClassName();
         return taintMethodConfigWithArgumentsAndLocationMap.get(key);
     }
+
+    public Taint getStaticFieldTaint(String fieldSignature, Taint defaultValue) {
+        if (!isFieldType(fieldSignature)) {
+            return defaultValue;
+        }
+
+        return staticFieldsTaint.getOrDefault(fieldSignature, defaultValue);
+    }
+
+    public void putStaticFieldTaint(String fieldSignature, Taint t) {
+        if (!isFieldType(fieldSignature)) {
+            return;
+        }
+
+        staticFieldsTaint.put(fieldSignature, t);
+    }
+
+
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -186,10 +186,11 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
         flow.execute();
         analysis.finishAnalysis();
         if (CONFIG.isDebugOutputTaintConfigs() && writer != null) {
-            TaintMethodConfig derivedConfig = taintConfig.get(getSlashedMethodName(methodGen));
+            String slashedMethodName = getSlashedMethodName(methodGen);
+            TaintMethodConfig derivedConfig = taintConfig.get(slashedMethodName);
             if (derivedConfig != null) {
                 try {
-                    writer.append(getSlashedMethodName(methodGen));
+                    writer.append(slashedMethodName);
 
                     Taint outputTaint = derivedConfig.getOutputTaint();
                     if (outputTaint != null) {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -40,8 +40,10 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.apache.bcel.generic.MethodGen;
 
@@ -187,7 +189,25 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
             TaintMethodConfig derivedConfig = taintConfig.get(getSlashedMethodName(methodGen));
             if (derivedConfig != null) {
                 try {
-                    writer.append(derivedConfig + "\n");
+                    writer.append(getSlashedMethodName(methodGen));
+
+                    Taint outputTaint = derivedConfig.getOutputTaint();
+                    if (outputTaint != null) {
+                        writer.append(':');
+                        writeTaint(outputTaint);
+                    }
+
+                    Map<Integer, Taint> parametersOutputTaints = derivedConfig.getParametersOutputTaints();
+                    if (!parametersOutputTaints.isEmpty()) {
+                        for (Map.Entry<Integer, Taint> parameterTaint : parametersOutputTaints.entrySet()) {
+                            writer.append('^');
+                            writer.append(Integer.toString(parameterTaint.getKey()));
+                            writer.append(':');
+                            writeTaint(parameterTaint.getValue());
+                        }
+                    }
+
+                    writer.append('\n');
                     writer.flush();
                 } catch (IOException ex) {
                     AnalysisContext.logError("Cannot write derived configs", ex);
@@ -195,6 +215,30 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
             }
         }
         return flow;
+    }
+
+    private void writeTaint(Taint taint) throws IOException {
+        if (taint.isUnknown() && taint.hasParameters()) {
+            writer.append(taint.getParameters().stream().map(String::valueOf).collect(Collectors.joining(",")));
+
+            Taint.State nonParametricState = taint.getNonParametricState();
+            if (nonParametricState != Taint.State.INVALID) {
+                writer.append(',');
+                writer.append(nonParametricState.name());
+            }
+        }
+        else {
+            writer.append(taint.getState().name());
+        }
+
+        if (taint.hasTags()) {
+            writer.append('|');
+            writer.append(taint.getTags().stream().map(Taint.Tag::name).collect(Collectors.joining(",", "+", "")));
+        }
+        if (taint.isRemovingTags()) {
+            writer.append('|');
+            writer.append(taint.getTagsToRemove().stream().map(Taint.Tag::name).collect(Collectors.joining(",", "-", "")));
+        }
     }
 
     private static String getSlashedMethodName(MethodGen methodGen) {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -187,7 +187,7 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
             TaintMethodConfig derivedConfig = taintConfig.get(getSlashedMethodName(methodGen));
             if (derivedConfig != null) {
                 try {
-                    writer.append(getSlashedMethodName(methodGen) + ":" + derivedConfig + "\n");
+                    writer.append(derivedConfig + "\n");
                     writer.flush();
                 } catch (IOException ex) {
                     AnalysisContext.logError("Cannot write derived configs", ex);

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFieldConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFieldConfig.java
@@ -1,0 +1,135 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Summary of information about a class field related to taint analysis,
+ * allows to configure default behavior for class fields.
+ *
+ * Default configuration is mutable class with null taint state.
+ *
+ * @author Tomas Polesovsky (Liferay, Inc.)
+ */
+public class TaintFieldConfig implements TaintTypeConfig {
+    public static final Taint.State DEFAULT_TAINT_STATE = Taint.State.NULL;
+    private Taint.State taintState = DEFAULT_TAINT_STATE;
+    private String typeSignature;
+    private static final Pattern typePattern;
+    private static final Pattern taintConfigPattern;
+
+    static {
+        String javaIdentifierRegex = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
+        String classWithPackageRegex = javaIdentifierRegex+"(\\/"+javaIdentifierRegex+")*";
+        String typeRegex = classWithPackageRegex + "\\." + javaIdentifierRegex;
+        typePattern = Pattern.compile(typeRegex);
+
+        String taintConfigRegex = "([A-Z_]+)";
+        taintConfigPattern = Pattern.compile(taintConfigRegex);
+    }
+
+    public static boolean accepts(String typeSignature, String taintConfig) {
+        return typePattern.matcher(typeSignature).matches() && taintConfigPattern.matcher(taintConfig).matches();
+    }
+
+    /**
+     * Loads class field summary from String<br/>
+     * <br/>
+     * The summary should have the following syntax:<br />
+     * <code>defaultTaintState #IMMUTABLE</code>, where <ol>
+     *     <li><code>defaultTaintState</code> means the Taint state for type casting and return types. Usually <code>SAFE</code> is used to specify classes that cannot contain injection escape characters</li>
+     *     <li><code>#IMMUTABLE</code> flags is used for classes that cannot be subject to taint state mutation during taint analysis</li>
+     *     <li>at least one of two above are required</li>
+     * </ol>
+     *
+     * Example: <br/>
+     * <code>Ljava/lang/Boolean;:SAFE#IMMUTABLE</code><br />
+     * <ul>
+     *     <li>Here the summary is: <code>SAFE#IMMUTABLE</code></li>
+     *     <li>When a object is casted to Boolean or Boolean is a method result type, the taint state will be always SAFE</li>
+     *     <li>When applying taint mutation to method arguments, Boolean arguments cannot change taint state</li>
+     *     <li>Practically, Booleans cannot transfer characters that could cause injections and thus are SAFE as return types and casts</li>
+     * </ul>
+     *
+     * Example: <br/>
+     * <code>Ljava/lang/String;:#IMMUTABLE</code><br />
+     * <ul>
+     *     <li>String is immutable class and therefore String method arguments cannot change taint state</li>
+     *     <li>Practically, String can carry injection sensitive characters but is always immutable</li>
+     * </ul>
+     *
+     * Example: <br/>
+     * <code>Ljava/util/concurrent/atomic/AtomicBoolean;:SAFE</code><br />
+     * <ul>
+     *     <li>AtomicBoolean value can be changed but cannot carry injection sensitive value</li>
+     * </ul>
+     *
+     * @param taintConfig <code>state#IMMUTABLE</code>, where state is one of Taint.STATE or empty
+     * @return initialized object with taint class summary
+     * @throws IOException for bad format of parameter
+     * @throws NullPointerException if argument is null
+     */
+    @Override
+    public TaintFieldConfig load(String taintConfig) throws IOException {
+        if (taintConfig == null) {
+            throw new NullPointerException("Taint config is null");
+        }
+        taintConfig = taintConfig.trim();
+        if (taintConfig.isEmpty()) {
+            throw new IOException("No taint class config specified");
+        }
+
+        if (!taintConfig.isEmpty()) {
+            taintState = Taint.State.valueOf(taintConfig);
+        }
+
+        return this;
+    }
+
+    public Taint.State getTaintState() {
+        return taintState;
+    }
+
+    public Taint.State getTaintState(Taint.State defaultState) {
+        if (taintState.equals(DEFAULT_TAINT_STATE)) {
+            return defaultState;
+        }
+
+        return taintState;
+    }
+
+    /**
+     * Set full class and method signature for the analyzed method
+     *
+     * @param typeSignature method signature
+     */
+    public void setTypeSignature(String typeSignature) {
+        this.typeSignature = typeSignature;
+    }
+
+    /**
+     * Returns the analyzed method full signature
+     *
+     * @return signature of the method
+     */
+    public String getTypeSignature() {
+        return typeSignature;
+    }
+}

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -191,9 +191,15 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
                 getFrame().pushValue(new Taint(Taint.State.NULL));
             }
         } else {
-            //super.visitGETSTATIC(obj);
             String fieldSig = BCELUtil.getSlashedClassName(cpg, obj)+"."+obj.getName(cpg);
-            Taint.State state = taintConfig.getClassTaintState(fieldSig, Taint.State.UNKNOWN);
+            Taint.State state = taintConfig.getFieldTaintState(fieldSig, Taint.State.INVALID);
+            if (state == Taint.State.INVALID) {
+                state = taintConfig.getClassTaintState(obj.getSignature(cpg), Taint.State.INVALID);
+            }
+            if (state == Taint.State.INVALID) {
+                state = Taint.State.UNKNOWN;
+            }
+
             Taint taint = new Taint(state);
 
             if (!state.equals(Taint.State.SAFE)){
@@ -230,7 +236,14 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
     @Override
     public void visitGETFIELD(GETFIELD obj) {
         String fieldSig = BCELUtil.getSlashedClassName(cpg, obj)+"."+obj.getName(cpg);
-        Taint.State state = taintConfig.getClassTaintState(fieldSig, Taint.State.UNKNOWN);
+        Taint.State state = taintConfig.getFieldTaintState(fieldSig, Taint.State.INVALID);
+        if (state == Taint.State.INVALID) {
+            state = taintConfig.getClassTaintState(obj.getSignature(cpg), Taint.State.INVALID);
+        }
+        if (state == Taint.State.INVALID) {
+            state = Taint.State.UNKNOWN;
+        }
+
         Taint taint = new Taint(state);
 
         if (!state.equals(Taint.State.SAFE)){

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -825,15 +825,23 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
     private Taint mergeTransferParameters(Collection<Integer> transferParameters) {
         assert transferParameters != null && !transferParameters.isEmpty();
         Taint taint = null;
+        Taint safeTaint = null;
         for (Integer transferParameter : transferParameters) {
             try {
                 Taint value = getFrame().getStackValue(transferParameter);
-                taint = Taint.merge(taint, value);
+                if (value.isSafe()) {
+                    safeTaint = Taint.merge(safeTaint, value);;
+                } else {
+                    taint = Taint.merge(taint, value);
+                }
             } catch (DataflowAnalysisException ex) {
                 throw new RuntimeException("Bad transfer parameter specification", ex);
             }
         }
-        assert taint != null;
+        assert taint != null || safeTaint != null;
+        if (taint == null) {
+            return safeTaint;
+        }
         return taint;
     }
 

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfig.java
@@ -75,6 +75,8 @@ public class TaintMethodConfig implements TaintTypeConfig {
         configPattern = Pattern.compile(configRegex);
     }
 
+    private boolean parametersOutputTaintsProcessed;
+
     /**
      * Constructs an empty summary
      *
@@ -193,10 +195,8 @@ public class TaintMethodConfig implements TaintTypeConfig {
         if (outputTaint != null && outputTaint.isInformative()) {
             return true;
         }
-        for (Taint taint : parametersOutputTaints.values()) {
-            if (taint.isInformative()) {
-                return true;
-            }
+        if (parametersOutputTaintsProcessed) {
+            return true;
         }
 
         return false;
@@ -494,5 +494,13 @@ public class TaintMethodConfig implements TaintTypeConfig {
      */
     public Map<Integer, Taint> getParametersOutputTaints() {
         return Collections.unmodifiableMap(parametersOutputTaints);
+    }
+
+    public void setParametersOutputTaintsProcessed(boolean parametersOutputTaintsProcessed) {
+        this.parametersOutputTaintsProcessed = parametersOutputTaintsProcessed;
+    }
+
+    public boolean isParametersOutputTaintsProcessed() {
+        return parametersOutputTaintsProcessed;
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintMethodConfig.java
@@ -74,7 +74,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
 
     /**
      * Constructs an empty summary
-     * 
+     *
      * @param isConfigured true for configured summaries, false for derived
      */
     public TaintMethodConfig(boolean isConfigured) {
@@ -84,18 +84,19 @@ public class TaintMethodConfig implements TaintTypeConfig {
     }
 
     /**
-     * Creates a copy of the summary (output taint not copied)
-     * 
+     * Creates a copy of the summary (output taint and output parameters taint not copied)
+     *
      * @param config Original taint config to copy
      */
     public TaintMethodConfig(TaintMethodConfig config) {
         this.mutableStackIndices = config.mutableStackIndices;
         this.isConfigured = config.isConfigured;
+        this.typeSignature = config.typeSignature;
     }
-    
+
     /**
      * Returns all stack indices modified by method if there are any
-     * 
+     *
      * @return unmodifiable collection of indices
      * @throws IllegalStateException if there are not indices set
      */
@@ -108,7 +109,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
 
     /**
      * Checks if there are any indices modified by method
-     * 
+     *
      * @return true if some index is set, false otherwise
      */
     public boolean hasMutableStackIndices() {
@@ -118,7 +119,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
 
     /**
      * Adds a stack index modified by method
-     * 
+     *
      * @param mutableStackIndex index to add
      * @throws IllegalArgumentException if index is negative
      */
@@ -131,7 +132,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
 
     /**
      * Returns the output taint of the method describing the taint transfer
-     * 
+     *
      * @return a copy of the output taint or null if not set
      */
     public Taint getOutputTaint() {
@@ -144,7 +145,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
     /**
      * Sets the output taint of the method describing the taint transfer,
      * copy of the parameter is made and variable index is invalidated
-     * 
+     *
      * @param taint output taint to set
      */
     public void setOuputTaint(Taint taint) {
@@ -160,7 +161,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
     /**
      * Constructs a default constructor summary
      * (modifies 2 stack items with UNKNOWN taint state)
-     * 
+     *
      * @param stackSize size of the parameter stack (including instance)
      * @return new instance of default summary
      * @throws IllegalArgumentException for stackSize &lt; 1
@@ -178,7 +179,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
 
     /**
      * Checks if the summary needs to be saved or has no information value
-     * 
+     *
      * @return true if summary should be saved, false otherwise
      */
     public boolean isInformative() {
@@ -206,13 +207,13 @@ public class TaintMethodConfig implements TaintTypeConfig {
 
     /**
      * Checks if the summary is configured or derived
-     * 
+     *
      * @return true if configured, false if derived
      */
     public boolean isConfigured() {
         return isConfigured;
     }
-    
+
     @Override
     public String toString() {
         if (outputTaint == null) {
@@ -380,7 +381,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
         }
         return str;
     }
-    
+
     private void loadStatesAndParameters(String str) throws IOException {
         if (str.isEmpty()) {
             throw new IOException("No taint information set");
@@ -432,7 +433,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
             }
         }
     }
-    
+
     private boolean isTaintTagValue(String value) {
         assert value != null && !value.isEmpty();
         for (Taint.Tag tag : Taint.Tag.values()) {
@@ -442,7 +443,7 @@ public class TaintMethodConfig implements TaintTypeConfig {
         }
         return false;
     }
-    
+
     private boolean isTaintStateValue(String value) {
         assert value != null && !value.isEmpty();
         Taint.State[] states = Taint.State.values();
@@ -454,7 +455,21 @@ public class TaintMethodConfig implements TaintTypeConfig {
         return false;
     }
 
+    /**
+     * Set full class and method signature for the analyzed method
+     *
+     * @param typeSignature method signature
+     */
     public void setTypeSignature(String typeSignature) {
         this.typeSignature = typeSignature;
+    }
+
+    /**
+     * Returns the analyzed method full signature
+     *
+     * @return signature of the method
+     */
+    public String getTypeSignature() {
+        return typeSignature;
     }
 }

--- a/findsecbugs-plugin/src/main/resources/taint-config/collections.txt
+++ b/findsecbugs-plugin/src/main/resources/taint-config/collections.txt
@@ -1,7 +1,7 @@
 java/util/Collection.add(Ljava/lang/Object;)Z:0,1#1
 java/util/Collection.addAll(Ljava/util/Collection;)Z:0,1#1
-java/util/Collection.contains(Ljava/util/Object;)Z:UNKNOWN
-java/util/Collection.containsAll(Ljava/util/Collection;)Z:UNKNOWN
+java/util/Collection.contains(Ljava/lang/Object;)Z:0#0
+java/util/Collection.containsAll(Ljava/util/Collection;)Z:0#0
 java/util/Collection.clear()V:SAFE#0
 java/util/Collection.remove(Ljava/lang/Object;)Z:1
 java/util/Collection.removeAll(Ljava/util/Collection;)Z:1

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/ParameterTaintBackPropagationTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/ParameterTaintBackPropagationTest.java
@@ -1,0 +1,75 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+public class ParameterTaintBackPropagationTest extends BaseDetectorTest {
+
+    @Test
+    public void testBackPropagation() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/taint/ParameterTaintBackPropagation")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+
+        String customConfigFile = FindSecBugsGlobalConfig.getInstance().getCustomConfigFile();
+        String path = this.getClass().getResource("/com/h3xstream/findsecbugs/taintanalysis/CustomConfig.txt").getPath();
+        FindSecBugsGlobalConfig.getInstance().setCustomConfigFile(path);
+        try {
+            analyze(files, reporter);
+        }
+        finally {
+            FindSecBugsGlobalConfig.getInstance().setCustomConfigFile(customConfigFile == null ? "" : customConfigFile);
+        }
+
+        verify(reporter, times(2)).doReportBug(
+                bugDefinition().bugType("SERVLET_PARAMETER").build());
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_HIBERNATE")
+                        .inClass("ParameterTaintBackPropagation").inMethod("taintedUsingPropagatedParameter")
+                        .withPriority("High") //High because of taint parameter
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_HIBERNATE")
+                        .inClass("ParameterTaintBackPropagation").inMethod("safeByParameterBackPropagation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_HIBERNATE")
+                        .inClass("ParameterTaintBackPropagation").inMethod("safeByTagBackPropagation")
+                        .build());
+    }
+}

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/StaticContextTaintPropagationTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/StaticContextTaintPropagationTest.java
@@ -1,0 +1,59 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import org.testng.annotations.Test;
+import testcode.taint.StaticContextTaintPropagation;
+
+import static org.mockito.Mockito.*;
+
+public class StaticContextTaintPropagationTest extends BaseDetectorTest {
+
+    @Test
+    public void testBackPropagation() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/taint/StaticContextTaintPropagation")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+
+        verify(reporter, never()).doReportBug(
+            bugDefinition().bugType("SQL_INJECTION_HIBERNATE")
+                .inClass("StaticContextTaintPropagation").inMethod("falsePositive")
+                .build());
+
+        verify(reporter, times(1)).doReportBug(
+            bugDefinition().bugType("SQL_INJECTION_HIBERNATE")
+                .inClass("StaticContextTaintPropagation").inMethod("taintedValue")
+                .withPriority("High") // tainted value
+                .build());
+
+        verify(reporter, times(1)).doReportBug(
+            bugDefinition().bugType("SQL_INJECTION_HIBERNATE")
+                .inClass("StaticContextTaintPropagation").inMethod("staticContextTaintPropagationAfter")
+                .withPriority("High") // tainted value
+                .build());
+    }
+}

--- a/findsecbugs-plugin/src/test/resources/com/h3xstream/findsecbugs/taintanalysis/CustomConfig.txt
+++ b/findsecbugs-plugin/src/test/resources/com/h3xstream/findsecbugs/taintanalysis/CustomConfig.txt
@@ -1,0 +1,1 @@
+java/lang/Long.parseLong(Ljava/lang/String;)J:0|+SQL_INJECTION_SAFE#0

--- a/findsecbugs-samples-java/src/test/java/testcode/taint/ParameterTaintBackPropagation.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/taint/ParameterTaintBackPropagation.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package testcode.taint;
 
 import org.hibernate.SessionFactory;

--- a/findsecbugs-samples-java/src/test/java/testcode/taint/ParameterTaintBackPropagation.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/taint/ParameterTaintBackPropagation.java
@@ -1,0 +1,67 @@
+package testcode.taint;
+
+import org.hibernate.SessionFactory;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class ParameterTaintBackPropagation {
+    private HttpServletRequest request;
+    private SessionFactory sessionFactory;
+
+    public void taintedUsingPropagatedParameter(){
+        StringBuffer sb = new StringBuffer();
+
+        appendRequestParameter1(0, sb, 0, "param", 0);
+
+        sessionFactory.openSession().createQuery("FROM comment WHERE userId="+sb.toString());
+    }
+
+    public void safeByParameterBackPropagation(){
+        StringBuffer sb = new StringBuffer();
+
+        appendString(sb, "param");
+
+        sessionFactory.openSession().createQuery("FROM comment WHERE userId="+sb.toString());
+    }
+
+    public void safeByTagBackPropagation(){
+        String tainted = request.getParameter("tainted");
+
+        checkIsNum(tainted);
+
+        sessionFactory.openSession().createQuery("FROM comment WHERE userId=" + tainted);
+    }
+
+    private boolean appendRequestParameter1(long l1, StringBuffer sb, long l2, String name, long l3) {
+        return appendRequestParameter(l1, sb, l2, name, l3);
+    }
+
+    private boolean appendRequestParameter(long l1, StringBuffer sb, long l2, String name, long l3) {
+        String parameter = request.getParameter(name);
+
+        if (parameter != null) {
+            sb.append(parameter);
+
+            return true;
+        }
+        else {
+            sb.append(l1 + l2 + l3);
+
+            return false;
+        }
+    }
+
+    private boolean appendString(StringBuffer sb, String str) {
+        sb.append(str);
+
+        return true;
+    }
+
+    private void checkIsNum(String value) {
+        Long.parseLong(value);
+    }
+
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/taint/StaticContextTaintPropagation.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/taint/StaticContextTaintPropagation.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package testcode.taint;
 
 import org.hibernate.SessionFactory;

--- a/findsecbugs-samples-java/src/test/java/testcode/taint/StaticContextTaintPropagation.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/taint/StaticContextTaintPropagation.java
@@ -1,0 +1,48 @@
+package testcode.taint;
+
+import org.hibernate.SessionFactory;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class StaticContextTaintPropagation {
+    private HttpServletRequest request;
+    private SessionFactory sessionFactory;
+
+    private static String simpleStaticVar = "Test";
+    private static String computedStaticVar = "(" + surround(simpleStaticVar, "%") + ")";
+
+    private static String propagatingStaticVar = "";
+
+    private static String surround(String a, String b) {
+        if (a == null) {
+            return b + b;
+        }
+
+        return b + a + b;
+    }
+
+    public void falsePositive() {
+        sessionFactory.openSession().createQuery("FROM comment WHERE userId like " + computedStaticVar);
+    }
+
+    public void taintedValue() {
+        simpleStaticVar = request.getParameter("test");
+
+        sessionFactory.openSession().createQuery("FROM comment WHERE userId like " + simpleStaticVar);
+    }
+
+    public void staticContextTaintPropagation() {
+        propagatingStaticVar = request.getParameter("test");
+
+        staticContextTaintPropagationAfter();
+    }
+
+    public void staticContextTaintPropagationAfter() {
+        sessionFactory.openSession().createQuery("FROM comment WHERE userId like " + propagatingStaticVar);
+    }
+
+
+}


### PR DESCRIPTION
Hi @h3xstream,

these are some improvements I made in April when analyzed the Liferay portal. I didn't get to make it prettier and don't want to block it on my side anymore.

I'd like to ask you to go together through the changes, discuss them, improve them and hopefully merge them.

I tested the code when working with the plugin but it's possible I introduced some inconsistencies/bugs so I'd be glad for a review.

Thank you.

The important things:
1, Automatic back-propagation of taints from method calls. 
2, Improved static fields and static blocks analysis
3, GC improvements

**Automatic back-propagation of taints from method calls**
I realized there is lot of unknown in the interprocedural analysis. When we call a safe method `safe(Map a)` and the method doesn't change the parameter we are unable to return this information back to the caller.  So now when we call `Map m = new HashMap(); safe(m)` then the variable `m` keeps now the SAFE taint.

This includes also when we change the taint/tags of the parameter the analysis should back-propagate the changed taint into the caller variable. I.e. having:  
```java
public void taint(HttpServletRequest req, StringBuilder output) {
  output.append(req.getParameter("aa"));
}
```

and calling `StringBuilder sb = new StringBuilder; taint(request, output);` then sb variable in now tainted and not unknown as previously.

**Improved static code analysis**
This looks like a long term requested feature so I did some small improvement. 

I maintain a global context of static variables taints throughout the whole analysis (in a static `TaintConfig#staticFieldsTaint` Map) and when we read/write static field I merge the taint with the global state set by other methods.

This is good enough for things like `static String a = new StringBundler().append("a").append("b").toString();` but cannot infer the taint for methods writing/reading  fields in unpredictable thread-like world like this example:
```java
class A {
  static String someStorage;
  public static void writeTainted(HttpServletRequest r) {
    someStorage = r.getParameter("taintedValue");
  }
  public static void writeSafe() {
    someStorage = "safe value";
  }
  public static String readStorage() {
    return someStorage;
  }
}
```
Now when another class calls `A.readStorage` we cannot be sure if the output is safe or tainted.

**GC improvements**
With the back-propagation I need to store much more info in the memory and I realized some hot spots. Now it should be back to normal / better then before. The code is now a bit more complex to read, especially `Taint` class, but now it doesn't necessarily create empty objects on heap that are never used.