### PR TITLE
Improvement to information leakage and mass assignment detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
+  - openjdk9
   - openjdk10
+  - openjdk11
+  - openjdk-ea
 
 matrix:
   allow_failures:
-    - jdk: openjdk10
+    - jdk: openjdk-ea
 
 # Activate container based infra https://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
@@ -1,3 +1,20 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
 package com.h3xstream.findsecbugs.spring;
 
 import org.apache.bcel.Repository;
@@ -13,7 +30,6 @@ import java.util.regex.Pattern;
  *
  * It support the extraction of type in format such as:
  *  - java/util/List&lt;java/lang/String&gt; => java.util.List & java.lang.String
- *
  */
 public class SignatureParserWithGeneric {
 

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
@@ -1,0 +1,63 @@
+package com.h3xstream.findsecbugs.spring;
+
+import org.apache.bcel.Repository;
+import org.apache.bcel.classfile.JavaClass;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SignatureParserWithGeneric {
+
+    private String[] argumentsTypes;
+    private String returnType;
+
+    public SignatureParserWithGeneric(String signature) {
+        String sigOnlyArgs = signature.substring(signature.indexOf("(")+1);
+        String[] paramAndReturn = sigOnlyArgs.split("\\)");
+        argumentsTypes = paramAndReturn[0].split(",");
+
+        returnType = paramAndReturn[1];
+    }
+
+    public List<JavaClass[]> getArgumentsClasses() {
+        List<JavaClass[]> types = new ArrayList<>();
+
+        for(String argumentType : argumentsTypes) {
+            if(argumentType.equals("")) continue;
+            types.add(typeToJavaClass(argumentType));
+        }
+        return types;
+    }
+
+    public JavaClass[] getReturnClasses() {
+        return typeToJavaClass(returnType);
+    }
+
+    private JavaClass[] typeToJavaClass(String type) {
+        Matcher m = Pattern.compile("([^<]+)(<([^>]+)>)?").matcher(type);
+
+        List<JavaClass> types = new ArrayList<>();
+        if(m.find()) {
+            try {
+                types.add(Repository.lookupClass(cleanClassName(m.group(1))));
+            } catch (ClassNotFoundException e) {
+                System.out.println(e.getMessage());
+            }
+            if(m.groupCount() == 3 && m.group(3) != null) {
+                try {
+                    types.add(Repository.lookupClass(cleanClassName(m.group(3))));
+                } catch (ClassNotFoundException e) {
+                    System.out.println(e.getMessage());
+                }
+            }
+
+        }
+        return types.toArray(new JavaClass[types.size()]);
+    }
+
+    private String cleanClassName(String classname) {
+        return classname.replaceAll("^L", "").replaceAll(";$","").replaceAll("/",".");
+    }
+}

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
@@ -8,6 +8,13 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Similar to <code>edu.umd.cs.findbugs.ba.SignatureParser</code>
+ *
+ * It support the extraction of type in format such as:
+ *  - java/util/List&lt;java/lang/String&gt; => java.util.List & java.lang.String
+ *
+ */
 public class SignatureParserWithGeneric {
 
     private String[] argumentsTypes;
@@ -43,13 +50,13 @@ public class SignatureParserWithGeneric {
             try {
                 types.add(Repository.lookupClass(cleanClassName(m.group(1))));
             } catch (ClassNotFoundException e) {
-                System.out.println(e.getMessage());
+                //System.out.println(e.getMessage());
             }
             if(m.groupCount() == 3 && m.group(3) != null) {
                 try {
                     types.add(Repository.lookupClass(cleanClassName(m.group(3))));
                 } catch (ClassNotFoundException e) {
-                    System.out.println(e.getMessage());
+                    //System.out.println(e.getMessage());
                 }
             }
 

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetector.java
@@ -22,7 +22,6 @@ import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Detector;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.ba.ClassContext;
-import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
@@ -38,7 +37,9 @@ import java.util.List;
  * @author Karan Bansal (Github:karanb192)
  */
 public class SpringEntityLeakDetector implements Detector {
-	private static final String SPRING_ENTITY_LEAK_TYPE = "SPRING_ENTITY_LEAK";
+	private static final String ENTITY_LEAK_TYPE = "ENTITY_LEAK";
+    private static final String ENTITY_MASS_ASSIGNMENT_TYPE = "ENTITY_MASS_ASSIGNMENT";
+
 	private static final List<String> REQUEST_MAPPING_ANNOTATION_TYPES = Arrays.asList(
 			"Lorg/springframework/web/bind/annotation/RequestMapping;",
 			"Lorg/springframework/web/bind/annotation/GetMapping;",
@@ -62,26 +63,23 @@ public class SpringEntityLeakDetector implements Detector {
 	public void visitClassContext(ClassContext classContext) {
 		JavaClass clazz = classContext.getJavaClass();
 
-		if (hasRequestMapping(clazz)) {
-			Method[] methods = clazz.getMethods();
-			for (Method m: methods) {
-				analyzeMethod(m, classContext);
-			}
-		}
+        Method[] methods = clazz.getMethods();
+        for (Method m: methods) {
+            if (hasRequestMapping(m)) { //We only need to analyse method with the annotation @RequestMapping
+                analyzeMethod(m, classContext);
+            }
+        }
 	}
 
-	private boolean hasRequestMapping(JavaClass clazz) {
-		Method[] methods = clazz.getMethods();
-		for (Method m: methods) {
-			AnnotationEntry[] annotations = m.getAnnotationEntries();
-			m.getReturnType();
+	private boolean hasRequestMapping(Method m) {
+        AnnotationEntry[] annotations = m.getAnnotationEntries();
+        m.getReturnType();
 
-			for (AnnotationEntry ae: annotations) {
-				if (REQUEST_MAPPING_ANNOTATION_TYPES.contains(ae.getAnnotationType())) {
-					return true;
-				}
-			}
-		}
+        for (AnnotationEntry ae: annotations) {
+            if (REQUEST_MAPPING_ANNOTATION_TYPES.contains(ae.getAnnotationType())) {
+                return true;
+            }
+        }
 		return false;
 	}
 
@@ -99,36 +97,40 @@ public class SpringEntityLeakDetector implements Detector {
 
 		return annotations;
 	}
+
 	private void analyzeMethod(Method m, ClassContext classContext) {
 		JavaClass clazz = classContext.getJavaClass();
 		MethodGen methodGen = classContext.getMethodGen(m);
 
-		List<String> annotations = new ArrayList<>();
-		List<String> classesToInspect = new ArrayList<>(Arrays.asList(methodGen.getReturnType().toString()));
-		for (Type type: methodGen.getArgumentTypes())
-			classesToInspect.add(type.toString());
+        String signature = m.getGenericSignature() == null ? m.getSignature() : m.getGenericSignature();
+        SignatureParserWithGeneric sig = new SignatureParserWithGeneric(signature);
+
+        //Look for potential mass assignment
+        for(JavaClass[] argument : sig.getArgumentsClasses()) {
+            testClassesForEntityAnnotation(argument, ENTITY_MASS_ASSIGNMENT_TYPE, clazz, m);
+        }
+        //Look for potential leak
+        testClassesForEntityAnnotation(sig.getReturnClasses(), ENTITY_LEAK_TYPE, clazz,m);
 
 
-		for (String classToInspect : classesToInspect) {
-			try {
-				JavaClass javaClass = Repository.lookupClass(classToInspect);
-				annotations.addAll(getAnnotationList(javaClass));
-			} catch (Exception e) {
-			}
-		}
-
-		for (String annotation: annotations) {
-			if (ENTITY_ANNOTATION_TYPES.contains(annotation)) {
-				BugInstance bug = new BugInstance(this, SPRING_ENTITY_LEAK_TYPE, Priorities.NORMAL_PRIORITY);
-				bug.addClassAndMethod(clazz, m);
-				reporter.reportBug(bug);
-				break;
-			}
-		}
 	}
 
 	@Override
 	public void report() {
 
 	}
+
+	private void testClassesForEntityAnnotation(JavaClass[] javaClasses,String bugType, JavaClass reportedClass, Method reportedMethod) {
+	    for(JavaClass j : javaClasses) {
+
+            for (String annotation : getAnnotationList(j)) {
+                if (ENTITY_ANNOTATION_TYPES.contains(annotation)) {
+                    BugInstance bug = new BugInstance(this, bugType, Priorities.NORMAL_PRIORITY);
+                    bug.addClassAndMethod(reportedClass, reportedMethod);
+                    reporter.reportBug(bug);
+                    break;
+                }
+            }
+        }
+    }
 }

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -119,7 +119,7 @@
     <Detector class="com.h3xstream.findsecbugs.injection.http.HttpParameterPollutionDetector" reports="HTTP_PARAMETER_POLLUTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.smtp.SmtpHeaderInjectionDetector" reports="SMTP_HEADER_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.spring.SpringUnvalidatedRedirectDetector" reports="SPRING_UNVALIDATED_REDIRECT"/>
-    <Detector class="com.h3xstream.findsecbugs.spring.SpringEntityLeakDetector" reports="SPRING_ENTITY_LEAK"/>
+    <Detector class="com.h3xstream.findsecbugs.spring.SpringEntityLeakDetector" reports="ENTITY_LEAK,ENTITY_MASS_ASSIGNMENT"/>
     <Detector class="com.h3xstream.findsecbugs.spring.CorsRegistryCORSDetector" reports="PERMISSIVE_CORS"/>
     <Detector class="com.h3xstream.findsecbugs.taintanalysis.extra.PotentialValueTracker" reports="HARD_CODE_PASSWORD,DES_USAGE,WEAK_MESSAGE_DIGEST_MD5,WEAK_MESSAGE_DIGEST_SHA1"/> <!-- This detector is not reporting any issue -->
     <Detector class="com.h3xstream.findsecbugs.taintanalysis.extra.JstlExpressionWhiteLister" reports="XSS_JSP_PRINT"/> <!-- This detector is not reporting any issue -->
@@ -217,7 +217,8 @@
     <BugPattern type="UNVALIDATED_REDIRECT" abbrev="SECUR" category="SECURITY" cweid="601"/>
     <BugPattern type="PLAY_UNVALIDATED_REDIRECT" abbrev="SECPUR" category="SECURITY" cweid="601"/>
     <BugPattern type="SPRING_UNVALIDATED_REDIRECT" abbrev="SECSUR" category="SECURITY" cweid="601"/>
-    <BugPattern type="SPRING_ENTITY_LEAK" abbrev="SECSEL" category="SECURITY"/>
+    <BugPattern type="ENTITY_LEAK" abbrev="SECELEAK" category="SECURITY"/>
+    <BugPattern type="ENTITY_MASS_ASSIGNMENT" abbrev="SECEMA" category="SECURITY"/>
     <BugPattern type="XSS_JSP_PRINT" abbrev="SECXSS1" category="SECURITY" cweid="79"/>
     <BugPattern type="JSP_INCLUDE" abbrev="SECJSPINC" category="SECURITY" cweid="98"/>
     <BugPattern type="JSP_SPRING_EVAL" abbrev="SECJSPSPRING" category="SECURITY" cweid="917"/>

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -217,8 +217,8 @@
     <BugPattern type="UNVALIDATED_REDIRECT" abbrev="SECUR" category="SECURITY" cweid="601"/>
     <BugPattern type="PLAY_UNVALIDATED_REDIRECT" abbrev="SECPUR" category="SECURITY" cweid="601"/>
     <BugPattern type="SPRING_UNVALIDATED_REDIRECT" abbrev="SECSUR" category="SECURITY" cweid="601"/>
-    <BugPattern type="ENTITY_LEAK" abbrev="SECELEAK" category="SECURITY"/>
-    <BugPattern type="ENTITY_MASS_ASSIGNMENT" abbrev="SECEMA" category="SECURITY"/>
+    <BugPattern type="ENTITY_LEAK" abbrev="SECELEAK" category="SECURITY" cweid="212"/>
+    <BugPattern type="ENTITY_MASS_ASSIGNMENT" abbrev="SECEMA" category="SECURITY" cweid="915"/>
     <BugPattern type="XSS_JSP_PRINT" abbrev="SECXSS1" category="SECURITY" cweid="79"/>
     <BugPattern type="JSP_INCLUDE" abbrev="SECJSPINC" category="SECURITY" cweid="98"/>
     <BugPattern type="JSP_SPRING_EVAL" abbrev="SECJSPSPRING" category="SECURITY" cweid="917"/>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -3700,7 +3700,7 @@ public String redirect(@RequestParam("url") String url) {
     </Detector>
 
     <BugPattern type="ENTITY_LEAK">
-        <ShortDescription>Unexpected property leak</ShortDescription>
+        <ShortDescription>Unexpected Property Leak</ShortDescription>
         <LongDescription>Unexpected property could be leaked because a persistence class is directly exposed to the client</LongDescription>
         <Details>
             <![CDATA[
@@ -3724,12 +3724,16 @@ class UserEntity {
 }
 
 [...]
+@Controller
+class UserController {
 
     @GetMapping("/user/{id}")
     public UserEntity getUser(@PathVariable("id") String id) {
 
         return userService.findById(id).get(); //Return the user entity with ALL fields.
     }
+
+}
 </pre>
 </p>
 <p>
@@ -3740,7 +3744,34 @@ class UserEntity {
         <li>Data should be persisted in database only after proper sanitisation checks.</li>
     </ul>
 </p>
-<br/>
+<p>
+    <b>Spring MVC Solution:</b><br/>
+    In Spring specifically, you can apply the following solution to allow or disallow specific fields.
+
+        <pre>
+@Controller
+class UserController {
+
+   @InitBinder
+   public void initBinder(WebDataBinder binder, WebRequest request)
+   {
+      binder.setAllowedFields(["username","firstname","lastname"]);
+   }
+
+}
+    </pre>
+</p>
+
+<p>
+<b>References</b><br/>
+<a href="https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure">OWASP Top 10-2017 A3: Sensitive Data Exposure</a><br/>
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html#spring-mvc">OWASP Cheat Sheet: Mass Assignment</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/212.html">CWE-212: Improper Cross-boundary Removal of Sensitive Data</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/213.html">CWE-213: Intentional Information Exposure</a><br/>
+
+
+</p>
+
             ]]>
         </Details>
     </BugPattern>
@@ -3748,7 +3779,7 @@ class UserEntity {
 
 
     <BugPattern type="ENTITY_MASS_ASSIGNMENT">
-        <ShortDescription>Mass assignment</ShortDescription>
+        <ShortDescription>Mass Assignment</ShortDescription>
         <LongDescription>The persistent objects could be exploited by attacker to read sensitive information.</LongDescription>
         <Details>
             <![CDATA[
@@ -3774,30 +3805,65 @@ class UserEntity {
 }
 
 [...]
+@Controller
+class UserController {
 
-    @UpdateMapping("/user/")
-    public Response update(UserEntity user) {
+    @PutMapping("/user/")
+    @ResponseStatus(value = HttpStatus.OK)
+    public void update(UserEntity user) {
 
-        return userService.save(user); //ALL fields from the user can be altered
-
+        userService.save(user); //ALL fields from the user can be altered
     }
-</pre>
-<br>
-<pre>@GetMapping("/sampletwo/api")
-public void update(SampleEntityClass updateEntity) {
-  ...
+
 }
 </pre>
 </p>
 <p>
-    <b>Solution/Countermeasures:</b><br/>
+    <b>General Guidelines:</b><br/>
     <ul>
         <li>Data transfer objects should be used instead including only the parameters needed as input/response to/from the API.</li>
         <li>Sensitive parameters should be removed properly before transferring to UI.</li>
         <li>Data should be persisted in database only after proper sanitisation checks.</li>
     </ul>
 </p>
+<p>
+    <b>Spring MVC Solution:</b><br/>
+    In Spring specifically, you can apply the following solution to allow or disallow specific fields.<br/>
 <br/>
+With whitelist:<br/>
+        <pre>
+@Controller
+class UserController {
+
+   @InitBinder
+   public void initBinder(WebDataBinder binder, WebRequest request)
+   {
+      binder.setAllowedFields(["username","password"]);
+   }
+
+}
+    </pre>
+<br/>
+With a blacklist:<br/>
+    <pre>
+@Controller
+class UserController {
+
+   @InitBinder
+   public void initBinder(WebDataBinder binder, WebRequest request)
+   {
+      binder.setDisallowedFields(["role"]);
+   }
+
+}
+    </pre>
+</p>
+
+<p>
+<b>References</b><br/>
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html#spring-mvc">OWASP Cheat Sheet: Mass Assignment</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/915.html">CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes</a><br/>
+</p>
             ]]>
         </Details>
     </BugPattern>
@@ -5928,8 +5994,8 @@ The sensitive information may be valuable information on its own (such as a pass
 </p>
 <p>
 <b>References</b><br/>
-
-<a href="https://cwe.mitre.org/data/definitions/209.html">CWE-209: Information Exposure Through an Error Message</a>
+<a href="https://cwe.mitre.org/data/definitions/209.html">CWE-209: Information Exposure Through an Error Message</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/211.html">CWE-211: Information Exposure Through Externally-Generated Error Message</a><br/>
 </p>
             ]]>
         </Details>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -3696,33 +3696,92 @@ public String redirect(@RequestParam("url") String url) {
 
     <!--Spring entity leak detector and bug pattern-->
     <Detector class="com.h3xstream.findsecbugs.spring.SpringEntityLeakDetector">
-        <Details>Identify persistent Objects leakage and mass updation in Spring</Details>
+        <Details>Identify persistent Objects leakage in Spring REST endpoint</Details>
     </Detector>
 
-    <BugPattern type="SPRING_ENTITY_LEAK">
-        <ShortDescription>Spring Entity Leak</ShortDescription>
-        <LongDescription>The persistent objects could be exploited by attacker to read/tamper sensitive information.</LongDescription>
+    <BugPattern type="ENTITY_LEAK">
+        <ShortDescription>Unexpected property leak</ShortDescription>
+        <LongDescription>Unexpected property could be leaked because a persistence class is directly exposed to the client</LongDescription>
         <Details>
             <![CDATA[
 <p>
-    Persistent objects should never be returned/accepted by APIs. They might lead to leaking business logic over the UI, unauthorized tampering of
+    Persistent objects should never be returned by APIs. They might lead to leaking business logic over the UI, unauthorized tampering of
     persistent objects in database.
 </p>
 <p>
-    <b>Persistence Annotations</b><br/>
-    1. javax.persistence.Entity (JPA)<br>
-    2. javax.jdo.spi.PersistenceCapable (JDO)<br>
-    3. org.springframework.data.mongodb.core.mapping.Document (Document database)<br>
-    <br/>
+    <b>Vulnerable Code:</b></br/>
+<pre>
+@javax.persistence.Entity
+class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+}
+
+[...]
+
+    @GetMapping("/user/{id}")
+    public UserEntity getUser(@PathVariable("id") String id) {
+
+        return userService.findById(id).get(); //Return the user entity with ALL fields.
+    }
+</pre>
+</p>
+<p>
+    <b>Solution/Countermeasures:</b><br/>
+    <ul>
+        <li>Data transfer objects should be used instead including only the parameters needed as input/response to/from the API.</li>
+        <li>Sensitive parameters should be removed properly before transferring to UI.</li>
+        <li>Data should be persisted in database only after proper sanitisation checks.</li>
+    </ul>
+</p>
+<br/>
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECELEAK">Spring Entity Leak</BugCode>
+
+
+    <BugPattern type="ENTITY_MASS_ASSIGNMENT">
+        <ShortDescription>Mass assignment</ShortDescription>
+        <LongDescription>The persistent objects could be exploited by attacker to read sensitive information.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+    Persistent objects should never be returned by APIs. They might lead to leaking business logic over the UI, unauthorized tampering of
+    persistent objects in database.
 </p>
 <p>
     <b>Vulnerable Code:</b></br/>
-<pre>@GetMapping("/sample/api")
-    public SampleEntityClass sampleMethod(Principal principal) {
-        Query query = getEntityManager().createQuery("select c from SampleTable c");
-        SampleEntityClass entityObject = query.getResultList().get(0);
-        return entityObject;
-    }</pre>
+<pre>
+@javax.persistence.Entity
+class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private Long role;
+}
+
+[...]
+
+    @UpdateMapping("/user/")
+    public Response update(UserEntity user) {
+
+        return userService.save(user); //ALL fields from the user can be altered
+
+    }
+</pre>
 <br>
 <pre>@GetMapping("/sampletwo/api")
 public void update(SampleEntityClass updateEntity) {
@@ -3742,7 +3801,7 @@ public void update(SampleEntityClass updateEntity) {
             ]]>
         </Details>
     </BugPattern>
-    <BugCode abbrev="SECSEL">Spring Entity Leak</BugCode>
+    <BugCode abbrev="SECSEMA">Spring Entity Leak</BugCode>
 
     <!-- JSP Include -->
     <Detector class="com.h3xstream.findsecbugs.jsp.JspIncludeDetector">

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
@@ -22,6 +22,7 @@ import com.h3xstream.findbugs.test.EasyBugReporter;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
@@ -42,7 +43,7 @@ public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
 		//Assertions
 		verify(reporter).doReportBug(
 				bugDefinition()
-						.bugType("SPRING_ENTITY_LEAK")
+						.bugType("ENTITY_LEAK")
 						.inClass("SpringEntityLeakController")
 						.inMethod("api1")
 						.build()
@@ -50,7 +51,7 @@ public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
 
 		verify(reporter).doReportBug(
 				bugDefinition()
-						.bugType("SPRING_ENTITY_LEAK")
+						.bugType("ENTITY_LEAK")
 						.inClass("SpringEntityLeakController")
 						.inMethod("api2")
 						.build()
@@ -58,9 +59,57 @@ public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
 
 		verify(reporter).doReportBug(
 				bugDefinition()
-						.bugType("SPRING_ENTITY_LEAK")
+						.bugType("ENTITY_LEAK")
+						.inClass("SpringEntityLeakController")
+						.inMethod("api4")
+						.build()
+		);
+
+		//Make sure exactly 3 instances are found
+		verify(reporter, times(3)).doReportBug(
+				bugDefinition()
+						.bugType("ENTITY_LEAK")
+						.inClass("SpringEntityLeakController")
+						.build()
+		);
+	}
+
+
+	@Test
+	public void detectEntityMassAssignment() throws Exception {
+		//Locate test code
+		String[] files = {
+				getClassFilePath("testcode/spring/SpringEntityLeakController"),
+				getClassFilePath("testcode/spring/SampleEntity"),
+				getClassFilePath("testcode/spring/SampleEntityTwo")
+		};
+
+		//Run the analysis
+		EasyBugReporter reporter = spy(new SecurityReporter());
+		analyze(files, reporter);
+
+		//Assertions
+		verify(reporter).doReportBug(
+				bugDefinition()
+						.bugType("ENTITY_MASS_ASSIGNMENT")
 						.inClass("SpringEntityLeakController")
 						.inMethod("api3")
+						.build()
+		);
+
+		verify(reporter).doReportBug(
+				bugDefinition()
+						.bugType("ENTITY_MASS_ASSIGNMENT")
+						.inClass("SpringEntityLeakController")
+						.inMethod("api5")
+						.build()
+		);
+
+		//Make sure exactly 2 instances are found
+		verify(reporter, times(2)).doReportBug(
+				bugDefinition()
+						.bugType("ENTITY_MASS_ASSIGNMENT")
+						.inClass("SpringEntityLeakController")
 						.build()
 		);
 	}

--- a/findsecbugs-samples-java/pom.xml
+++ b/findsecbugs-samples-java/pom.xml
@@ -26,6 +26,19 @@
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>javax.jws</groupId>
+            <artifactId>javax.jws-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/findsecbugs-samples-java/src/test/java/testcode/pathtraversal/PathTraversalConstantValue.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/pathtraversal/PathTraversalConstantValue.java
@@ -2,7 +2,7 @@ package testcode.pathtraversal;
 
 import org.apache.commons.codec.binary.Hex;
 
-import javax.xml.bind.DatatypeConverter;
+
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -19,7 +19,7 @@ public class PathTraversalConstantValue {
     /**
      * All the call below should be consider safe because their inputs are the combination of :
      *  - Constant values
-     *  - SAFE api
+     *  - SAFE API
      *  - SAFE type (int or long)
      * @throws IOException
      */
@@ -48,7 +48,7 @@ public class PathTraversalConstantValue {
         //Typical bytes to hex #1 https://stackoverflow.com/a/41787842/89769
         new File("c:/" + String.format("%032x", new BigInteger(1, out)));
         //Typical bytes to hex #2
-        new File(DatatypeConverter.printHexBinary(out));
+        new File(Hex.encodeHexString(out));
         new File(String.valueOf(Hex.encodeHex(out)));
         new File(String.valueOf(Hex.encodeHex(out,true)));
         new File(Hex.encodeHexString(out));

--- a/findsecbugs-samples-java/src/test/java/testcode/spring/SpringEntityLeakController.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/spring/SpringEntityLeakController.java
@@ -3,6 +3,7 @@ package testcode.spring;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import java.util.List;
 
 @Controller
 public class SpringEntityLeakController {
@@ -21,4 +22,20 @@ public class SpringEntityLeakController {
 		if (sampleEntity.getTest().equals("test"))
 			return;
 	}
+
+	@RequestMapping("/api4")
+	public List<SampleEntity> api4(@RequestParam("active") String active) {
+        if (active.equals("enable")) {
+            return getData();
+        }
+        return null;
+	}
+
+    @RequestMapping("/api5")
+    public void api5(@RequestParam("active") List<SampleEntity> entities) {
+    }
+
+	private List<SampleEntity> getData() { //FP (No request mapping annotation)
+	    return null;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Find Security Bugs root</name>
 
-	<description>Root project file that aggregate the different modules of Find Security Bugs.</description>
+    <description>Root project file that aggregate the different modules of Find Security Bugs.</description>
 
     <properties>
         <!-- Encoding configuration -->

--- a/website/BuildWebPage.groovy
+++ b/website/BuildWebPage.groovy
@@ -15,9 +15,9 @@ outDir = "out_web/"
 
 //Loading detectors
 println "Importing message from messages.xml"
-bugsBindingEn = buildMapping(messagesStreamEn)
+def bugsBindingEn = buildMapping(messagesStreamEn)
 bugsBindingEn['lang'] = 'en'
-bugsBindingJa = buildMapping(messagesStreamJa)
+def bugsBindingJa = buildMapping(messagesStreamJa)
 bugsBindingJa['lang'] = 'ja'
 
 nbSignatures = countSignature("../findsecbugs-plugin/src/main/resources/injection-sinks/") + countSignature("../findsecbugs-plugin/src/main/resources/password-methods/")


### PR DESCRIPTION
 - Detect mass assignment with pattern like `public void updateUsers(List<User> user)`
 - Separate mass assignment (incoming) and data leakage (outgoing).
 - The id and title were rename to avoid mentioning Spring. Other detector could identify such a bug in other framework.
 - Along with the general guidelines, a Spring MVC solution was given (taken from OWASP cheat sheet mass assigment).
