### PR TITLE
Supporting com/google/common/escape/Escaper as sanitizer

### DIFF
--- a/findsecbugs-plugin/src/main/resources/safe-encoders/other.txt
+++ b/findsecbugs-plugin/src/main/resources/safe-encoders/other.txt
@@ -30,3 +30,6 @@ org/apache/commons/codec/binary/Hex.encodeHex([B)[C:SAFE
 org/apache/commons/codec/binary/Hex.encodeHex([BZ)[C:SAFE
 org/apache/commons/codec/binary/Hex.encodeHexString([B)Ljava/lang/String;:SAFE
 org/apache/commons/codec/binary/Hex.encodeHexString([BZ)Ljava/lang/String;:SAFE
+
+--Google Guava
+com/google/common/escape/Escaper.escape(Ljava/lang/String;)Ljava/lang/String;:0|+URL_ENCODED,+XSS_SAFE

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/http/HttpParameterPollutionDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/http/HttpParameterPollutionDetectorTest.java
@@ -38,7 +38,7 @@ public class HttpParameterPollutionDetectorTest extends BaseDetectorTest {
         EasyBugReporter reporter = spy(new SecurityReporter());
         analyze(files, reporter);
 
-        for (Integer line : Arrays.asList(19, 21, 22)) {
+        for (Integer line : Arrays.asList(21, 24, 25)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("HTTP_PARAMETER_POLLUTION")
@@ -47,7 +47,7 @@ public class HttpParameterPollutionDetectorTest extends BaseDetectorTest {
             );
         }
 
-        //Out of 4 calls, 3 are suspicious
+        //Out of 5 calls, 3 are suspicious
         verify(reporter, times(3)).doReportBug(
                 bugDefinition().bugType("HTTP_PARAMETER_POLLUTION").build()
         );

--- a/findsecbugs-samples-deps/src/main/java/com/google/common/escape/Escaper.java
+++ b/findsecbugs-samples-deps/src/main/java/com/google/common/escape/Escaper.java
@@ -1,0 +1,5 @@
+package com.google.common.escape;
+
+public abstract class Escaper {
+    public abstract String escape(String string);
+}

--- a/findsecbugs-samples-deps/src/main/java/com/google/common/net/PercentEscaper.java
+++ b/findsecbugs-samples-deps/src/main/java/com/google/common/net/PercentEscaper.java
@@ -1,0 +1,10 @@
+package com.google.common.net;
+
+import com.google.common.escape.Escaper;
+
+public class PercentEscaper extends Escaper {
+    @Override
+    public String escape(String string) {
+        return null;
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/com/google/common/net/UrlEscapers.java
+++ b/findsecbugs-samples-deps/src/main/java/com/google/common/net/UrlEscapers.java
@@ -1,0 +1,9 @@
+package com.google.common.net;
+
+import com.google.common.escape.Escaper;
+
+public final class UrlEscapers {
+    public static Escaper urlPathSegmentEscaper() {
+        return new PercentEscaper();
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/HttpParameterPollution.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/HttpParameterPollution.java
@@ -8,6 +8,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URLEncoder;
 
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
+
 public class HttpParameterPollution extends HttpServlet{
    @SuppressWarnings( "deprecation" ) //URLEncoder.encode is deprecated but use to specially test this API.
    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
@@ -17,7 +19,8 @@ public class HttpParameterPollution extends HttpServlet{
            //in HttpClient 4.x, there is no GetMethod anymore. Instead there is HttpGet
            HttpGet httpget = new HttpGet("http://host.com?param=" + URLEncoder.encode(item)); //OK
            HttpGet httpget2 = new HttpGet("http://host.com?param=" + item); //BAD
-           
+           HttpGet httpget3 = new HttpGet("http://host.com?param=" + urlPathSegmentEscaper().escape(item)); //OK
+
            GetMethod get = new GetMethod("http://host.com?param=" + item); //BAD
            get.setQueryString("item=" + item); //BAD
            //get.execute();


### PR DESCRIPTION
Added Google Guava's `Escaper` as a sanitizer. Updated the `HttpParameterPollution` to include a HttpGet object construction passing a escaped string using `urlPathSegmentEscaper`. Added stub classes for the Google Guava classes - `Escaper`, `PercentEscaper` and `UrlEscapers`.

#504 