### PR TITLE
Update SpotBugs to 3.1.12

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.spotbugs:spotbugs:3.1.5'
+    compile 'com.github.spotbugs:spotbugs:3.1.12'
     compile 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.9.0'
 }
 


### PR DESCRIPTION
Update SpotBugs to 3.1.12 which include ASM library compatible with Java 11. Fix #512