### PR TITLE
Change STATIC_IV detector to properly handle key wrapping/unwrapping modes

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/crypto/StaticIvDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/crypto/StaticIvDetector.java
@@ -78,7 +78,7 @@ public class StaticIvDetector implements Detector {
         CFG cfg = classContext.getCFG(m);
 
         boolean foundSafeIvGeneration = false;
-        //Detect if the method is doing decryption only. If it is the case, IV should not be generated from this point
+        //Detect if the method is doing decryption/unwrapping only. If it is the case, IV should not be generated from this point
         //therefore it is a false positive
         boolean atLeastOneDecryptCipher = false;
         boolean atLeastOneEncryptCipher = false;
@@ -104,6 +104,13 @@ public class StaticIvDetector implements Detector {
                                 atLeastOneEncryptCipher = true;
                                 break;
                             case Cipher.DECRYPT_MODE:
+                                atLeastOneDecryptCipher = true;
+                                break;
+                                // Wrapping and unwrapping are equivalent to encryption and decryption.
+                            case Cipher.WRAP_MODE:
+                                atLeastOneEncryptCipher = true;
+                                break;
+                            case Cipher.UNWRAP_MODE:
                                 atLeastOneDecryptCipher = true;
                                 break;
                         }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/crypto/StaticIvDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/crypto/StaticIvDetectorTest.java
@@ -115,6 +115,25 @@ public class StaticIvDetectorTest extends BaseDetectorTest {
 
 
     @Test
+    public void avoidFalsePositiveUnwrap() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/crypto/iv/StaticIvUnwrap")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        // Bug should not be detected
+        verify(reporter,never()).doReportBug( //
+                bugDefinition().bugType("STATIC_IV").inClass("StaticIvUnwrap").build()
+        );
+    }
+
+    @Test
     public void avoidFalsePositiveGenerateWithKeyGenerator() throws Exception {
         //Locate test code
         String[] files = {

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/crypto/StaticIvDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/crypto/StaticIvDetectorTest.java
@@ -134,6 +134,30 @@ public class StaticIvDetectorTest extends BaseDetectorTest {
     }
 
     @Test
+    public void detectStaticIvWrap() throws Exception {
+        //Locate test code
+        String[] files = {
+            getClassFilePath("testcode/crypto/iv/StaticIvWrap")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        verify(reporter).doReportBug( //
+            bugDefinition().bugType("STATIC_IV").inClass("StaticIvWrap").inMethod("syntheticTestCase").atLine(17).build()
+        );
+
+        //Only one report of this bug pattern
+        verify(reporter).doReportBug( //
+            bugDefinition().bugType("STATIC_IV").inClass("StaticIvWrap").build()
+        );
+    }
+
+
+    @Test
     public void avoidFalsePositiveGenerateWithKeyGenerator() throws Exception {
         //Locate test code
         String[] files = {

--- a/findsecbugs-samples-java/src/test/java/testcode/crypto/iv/StaticIvUnwrap.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/crypto/iv/StaticIvUnwrap.java
@@ -1,0 +1,24 @@
+package testcode.crypto.iv;
+
+import java.security.Key;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class StaticIvUnwrap {
+    public Key extractSecretKey(
+        String keyEncryptionAlgorithmId,
+        byte[] keyEncryptionAlgorithmParameters,
+        String contentEncryptionAlgorithmId,
+        byte[] derivedKey,
+        byte[] encryptedContentEncryptionKey
+    ) throws Exception {
+        Cipher keyEncryptionCipher = Cipher.getInstance(keyEncryptionAlgorithmId);
+
+        IvParameterSpec ivSpec = new IvParameterSpec(keyEncryptionAlgorithmParameters);
+
+        keyEncryptionCipher.init(Cipher.UNWRAP_MODE, new SecretKeySpec(derivedKey, keyEncryptionCipher.getAlgorithm()), ivSpec);
+
+        return keyEncryptionCipher.unwrap(encryptedContentEncryptionKey, contentEncryptionAlgorithmId, Cipher.SECRET_KEY);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/crypto/iv/StaticIvWrap.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/crypto/iv/StaticIvWrap.java
@@ -1,0 +1,24 @@
+package testcode.crypto.iv;
+
+import java.security.Key;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+// This is a synthetic test case - we use an unsafe IV for decryption (safe) and for key
+// wrapping (unsafe). This is hand-crafted to make sure that key wrapping is handled
+// as encryption (and not ignored).
+public class StaticIvWrap {
+    public void syntheticTestCase(
+        Cipher cipher,
+        byte[] unsafeIv,
+        Key key
+    ) throws Exception {
+        IvParameterSpec ivSpec = new IvParameterSpec(unsafeIv);
+
+        // Safe
+        cipher.init(Cipher.DECRYPT_MODE, key, ivSpec);
+        // Unsafe
+        cipher.init(Cipher.WRAP_MODE, key);
+    }
+}


### PR DESCRIPTION
Fixes #517.

This makes wrapping and unwrapping equivalent to encryption and decryption for the purposes of the `STATIC_IV` check.