### PR TITLE
Add example for sql_injection_spring_jdbc with annotation

### DIFF
--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -2350,11 +2350,24 @@ Bind variables in prepared statements can be used to easily mitigate the risk of
     <pre>JdbcTemplate jdbc = new JdbcTemplate();
 int count = jdbc.queryForObject("select count(*) from Users where name = '"+paramName+"'", Integer.class);
 </pre>
+    <pre>@Value("properties")
+private String sql;
+
+public function count() {
+    JdcbOperation jdbc = new JdcbOperation();
+    int count = jdbc.query(sql);
+}</pre>
 </p>
 <p>
     <b>Solution:</b><br/>
     <pre>JdbcTemplate jdbc = new JdbcTemplate();
 int count = jdbc.queryForObject("select count(*) from Users where name = ?", Integer.class, paramName);</pre>
+    <pre>private final static String sql = "select count(*) from Users";
+
+public function count() {
+    JdcbOperation jdbc = new JdcbOperation();
+    int count = jdbc.query(sql);
+}</pre>
 </p>
 <br/>
 


### PR DESCRIPTION
This is an open discussion as the description can be also given for @Value without additional information.

It still can be vulnerable if the annotation use some SpEL voodoo but I'm not sure if how exactly.

Example of a "vulnerable" application : 
```java
public class ClientRepository {
    @Value("${jdbc.query.create.client}")
    private String reqCreateClient;  // INSERT INTO client (no_client, name, mail, date_inscrit) VALUES (?, ?, ?, ?);
    @Autowired
    private JdbcTemplate jdbcTemplate;
     
    public int createClient(Client client) {
        Assert.notNull(client, "entity cannot be null");
        try {
            return jdbcTemplate.update(reqCreateClient, ps -> {
                Assert.notNull(client.getId(), "embedded id clientId cannot be null");
                ps.setInt(1, client.getId());
                ps.setString(2, client.getName());
                ps.setString(3, client.getMail());
                ps.setTimestamp(4, client.getDateInscription());
            });
        } catch (DuplicateKeyException e) {
            return update(e);
        }
    }
}
```