### PR TITLE
Initial version of a Vert.x Sql Client detector

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/sql/SqlInjectionDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/sql/SqlInjectionDetector.java
@@ -34,6 +34,7 @@ public class SqlInjectionDetector extends BasicInjectionDetector {
         loadConfiguredSinks("sql-scala-slick.txt", "SCALA_SQL_INJECTION_SLICK");
         loadConfiguredSinks("sql-scala-anorm.txt", "SCALA_SQL_INJECTION_ANORM");
         loadConfiguredSinks("sql-turbine.txt", "SQL_INJECTION_TURBINE");
+        loadConfiguredSinks("sql-vertx-sql-client.txt", "SQL_INJECTION_VERTX");
         //TODO : Add org.springframework.jdbc.core.simple.SimpleJdbcTemplate (Spring < 3.2.1)
     }
     

--- a/findsecbugs-plugin/src/main/resources/injection-sinks/sql-vertx-sql-client.txt
+++ b/findsecbugs-plugin/src/main/resources/injection-sinks/sql-vertx-sql-client.txt
@@ -1,0 +1,5 @@
+io/vertx/sqlclient/SqlClient.query(Ljava/lang/String;)Lio/vertx/sqlclient/Query;:0
+io/vertx/sqlclient/SqlClient.preparedQuery(Ljava/lang/String;)Lio/vertx/sqlclient/PreparedQuery;:0
+
+io/vertx/sqlclient/SqlConnection.prepare(Ljava/lang/String;Lio/vertx/core/Handler;)Lio/vertx/sqlclient/SqlConnection;:1
+io/vertx/sqlclient/SqlConnection.prepare(Ljava/lang/String;)Lio/vertx/core/Future;:0

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -44,7 +44,7 @@
     <Detector class="com.h3xstream.findsecbugs.csrf.SpringCsrfUnrestrictedRequestMappingDetector" reports="SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING"/>
     <Detector class="com.h3xstream.findsecbugs.injection.custom.CustomInjectionDetector" reports="CUSTOM_INJECTION"/>
     <Detector class="com.h3xstream.findsecbugs.injection.sql.SqlInjectionDetector"
-              reports="SQL_INJECTION,SQL_INJECTION_TURBINE,SQL_INJECTION_HIBERNATE,SQL_INJECTION_JDO,SQL_INJECTION_JPA,SQL_INJECTION_JDBC,SQL_INJECTION_SPRING_JDBC,SCALA_SQL_INJECTION_SLICK,SCALA_SQL_INJECTION_ANORM"/>
+              reports="SQL_INJECTION,SQL_INJECTION_VERTX,SQL_INJECTION_TURBINE,SQL_INJECTION_HIBERNATE,SQL_INJECTION_JDO,SQL_INJECTION_JPA,SQL_INJECTION_JDBC,SQL_INJECTION_SPRING_JDBC,SCALA_SQL_INJECTION_SLICK,SCALA_SQL_INJECTION_ANORM"/>
     <Detector class="com.h3xstream.findsecbugs.injection.sql.AndroidSqlInjectionDetector" reports="SQL_INJECTION_ANDROID"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.BadHexadecimalConversionDetector" reports="BAD_HEXA_CONVERSION"/>
     <Detector class="com.h3xstream.findsecbugs.crypto.HazelcastSymmetricEncryptionDetector"
@@ -193,6 +193,7 @@
     <BugPattern type="SAML_IGNORE_COMMENTS" abbrev="SECSAMLC" category="SECURITY"/>
     <BugPattern type="CUSTOM_INJECTION" abbrev="SECCUSTOMI" category="SECURITY" cweid="74"/>
     <BugPattern type="SQL_INJECTION" abbrev="SECSQLIHIB" category="SECURITY" cweid="564"/>
+    <BugPattern type="SQL_INJECTION_VERTX" abbrev="SECSQLIVX" category="SECURITY" cweid="564"/>
     <BugPattern type="SQL_INJECTION_TURBINE" abbrev="SECSQLITU" category="SECURITY" cweid="564"/>
     <BugPattern type="SQL_INJECTION_HIBERNATE" abbrev="SECSQLIHIB" category="SECURITY" cweid="564"/>
     <BugPattern type="SQL_INJECTION_JDO" abbrev="SECSQLIJDO" category="SECURITY" cweid="89"/>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -2507,6 +2507,60 @@ DB.withConnection { implicit c =>
     </BugPattern>
     <BugCode abbrev="SECSSQLA">SQL Injection (Scala - Anorm)</BugCode>
 
+    <!-- SQL Injection Vertx -->
+    <BugPattern type="SQL_INJECTION_VERTX">
+        <ShortDescription>Potential SQL Injection with Vert.x Sql Client</ShortDescription>
+        <LongDescription>This use of {3} can be vulnerable to SQL injection (with Vert.x Sql Client)</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+The input values included in SQL queries need to be passed in safely.
+Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
+Vert.x Sql Client API provide a DSL to build query with Java code.
+</p>
+<p>
+    <b>Vulnerable Code:</b><br/>
+    <pre>
+SqlClient.query( "select * from Customer where id=" + inputId ).execute(ar -> ...);
+</pre>
+</p>
+<p>
+    <b>Solution (using Prepared Statements):</b><br/>
+
+    <pre>
+client
+    .preparedQuery( "SELECT * FROM users WHERE id=$1" )
+    .execute(Tuple.of("julien"))
+    .onSuccess(rows -> ...)
+    .onFailure(err -> ...);
+</pre>
+
+    <b>Solution (using OWASP Encoder):</b><br/>
+
+    <pre>
+import org.owasp.esapi.Encoder;
+
+SqlClient
+    .query( "select * from Customer where id=" + Encoder.encodeForSQL(inputId) )
+    .execute(ar -> ...);
+</pre>
+</p>
+<br/>
+<p>
+<b>References (Vert.x Sql Client)</b><br/>
+<a href="https://vertx.io/docs/#databases">Vertx Database Access Documentation</a><br/>
+<b>References (SQL injection)</b><br/>
+<a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection">WASC-19: SQL Injection</a><br/>
+<a href="https://capec.mitre.org/data/definitions/66.html">CAPEC-66: SQL Injection</a><br/>
+<a href="https://cwe.mitre.org/data/definitions/89.html">CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')</a><br/>
+<a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection">OWASP: Top 10 2013-A1-Injection</a><br/>
+<a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">OWASP: SQL Injection Prevention Cheat Sheet</a><br/>
+<a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet">OWASP: Query Parameterization Cheat Sheet</a><br/>
+</p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECSQLIVX">SQL Injection with Vert.x Client</BugCode>
 
     <!-- Android SQL Injection -->
     <Detector class="com.h3xstream.findsecbugs.injection.sql.AndroidSqlInjectionDetector">

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -2534,16 +2534,6 @@ client
     .onSuccess(rows -> ...)
     .onFailure(err -> ...);
 </pre>
-
-    <b>Solution (using OWASP Encoder):</b><br/>
-
-    <pre>
-import org.owasp.esapi.Encoder;
-
-SqlClient
-    .query( "select * from Customer where id=" + Encoder.encodeForSQL(inputId) )
-    .execute(ar -> ...);
-</pre>
 </p>
 <br/>
 <p>

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/sql/VertxSqlClientSqlDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/sql/VertxSqlClientSqlDetectorTest.java
@@ -1,0 +1,128 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.sql;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+public class VertxSqlClientSqlDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void detectInjection() throws Exception {
+//        FindSecBugsGlobalConfig.getInstance().setDebugPrintInvocationVisited(true);
+
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/sqli/VertxSqlClient")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection1").atLine(9)
+                        .build()
+        );
+
+        //Only 1 bug is expected
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection1")
+                        .build()
+        );
+
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection2").atLine(13)
+                        .build()
+        );
+
+        //Only 1 bug is expected
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection2")
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection3").atLine(17)
+                        .build()
+        );
+
+        //Only 1 bug is expected
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection3")
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection4").atLine(21)
+                        .build()
+        );
+
+        //Only 1 bug is expected
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("injection4")
+                        .build()
+        );
+
+        // False positives
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("falsePositive1")
+                        .build()
+        );
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("SQL_INJECTION_VERTX")
+                        .inClass("VertxSqlClient")
+                        .inMethod("falsePositive2")
+                        .build()
+        );
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/core/AsyncResult.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/core/AsyncResult.java
@@ -1,0 +1,4 @@
+package io.vertx.core;
+
+public interface AsyncResult<T> {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/core/Future.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/core/Future.java
@@ -1,0 +1,4 @@
+package io.vertx.core;
+
+public interface Future<T> {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/core/Handler.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/core/Handler.java
@@ -1,0 +1,4 @@
+package io.vertx.core;
+
+public interface Handler<T> {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/PreparedQuery.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/PreparedQuery.java
@@ -1,0 +1,4 @@
+package io.vertx.sqlclient;
+
+public interface PreparedQuery<T> extends Query<T> {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/PreparedStatement.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/PreparedStatement.java
@@ -1,0 +1,4 @@
+package io.vertx.sqlclient;
+
+public interface PreparedStatement {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/Query.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/Query.java
@@ -1,0 +1,4 @@
+package io.vertx.sqlclient;
+
+public interface Query<T> {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/Row.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/Row.java
@@ -1,0 +1,4 @@
+package io.vertx.sqlclient;
+
+public interface Row {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/RowSet.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/RowSet.java
@@ -1,0 +1,4 @@
+package io.vertx.sqlclient;
+
+public interface RowSet<T> {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/SqlClient.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/SqlClient.java
@@ -1,0 +1,8 @@
+package io.vertx.sqlclient;
+
+public interface SqlClient {
+
+    Query<RowSet<Row>> query(String sql);
+
+    PreparedQuery<RowSet<Row>> preparedQuery(String sql);
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/SqlConnection.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/sqlclient/SqlConnection.java
@@ -1,0 +1,12 @@
+package io.vertx.sqlclient;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public interface SqlConnection extends SqlClient {
+
+    SqlConnection prepare(String sql, Handler<AsyncResult<PreparedStatement>> handler);
+
+    Future<PreparedStatement> prepare(String sql);
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/sqli/VertxSqlClient.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/sqli/VertxSqlClient.java
@@ -1,0 +1,33 @@
+package testcode.sqli;
+
+import io.vertx.sqlclient.SqlClient;
+import io.vertx.sqlclient.SqlConnection;
+
+public class VertxSqlClient {
+
+    public void injection1(SqlClient client, String injection) {
+        client.query(injection);
+    }
+
+    public void injection2(SqlClient client, String injection) {
+        client.preparedQuery(injection);
+    }
+
+    public void injection3(SqlConnection conn, String injection) {
+        conn.prepare(injection);
+    }
+
+    public void injection4(SqlConnection conn, String injection) {
+        conn.prepare(injection, null);
+    }
+
+    public void falsePositive1(SqlClient client) {
+        String constantValue = "SELECT * FROM test";
+        client.query(constantValue);
+    }
+
+    public void falsePositive2(SqlConnection conn) {
+        String constantValue = "SELECT * FROM test";
+        conn.query(constantValue);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

This is a initial pull request to add a sql injection detector for vert.x sql client. The code passes the tests but the build is failing due to missing headers on the mock API.

I am wondering how could one solve the issue, as it seems that the remaining mocks do not have any headers, so I'm a bit lost here how to fix it.