### PR TITLE
Link to the SpotBugs plugin for IntelliJ

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -137,7 +137,7 @@
             <div class="col-md-4 col-sm-6">
                 <h4><i class="fa fa-plug"></i> Integrate with your IDE</h4>
                 Plugins are available for <a target="_blank" href="http://findbugs.sourceforge.net/manual/eclipse.html">Eclipse</a>,
-                <a target="_blank" href="https://plugins.jetbrains.com/plugin/3847?pr=idea">IntelliJ</a>,
+                <a target="_blank" href="https://plugins.jetbrains.com/plugin/14014-spotbugs">IntelliJ</a>,
                 <a href="https://plugins.jetbrains.com/plugin/3847?pr=idea">Android Studio</a> and
                 <a target="_blank" href="https://netbeans.org/kb/docs/java/code-inspect.html#fb">NetBeans</a>.
                 Command line integration is available with <a href="http://findbugs.sourceforge.net/manual/anttask.html">Ant</a>


### PR DESCRIPTION
The old [FindBugs-IDEA plugin](https://plugins.jetbrains.com/plugin/3847?pr=idea) doesn't work with current versions of IntelliJ.