### PR TITLE
Add support for Vert.x web Oauth2 + CSRF handlers

### DIFF
--- a/findsecbugs-plugin/src/main/resources/password-methods/password-methods-all.txt
+++ b/findsecbugs-plugin/src/main/resources/password-methods/password-methods-all.txt
@@ -1,3 +1,6 @@
+io/vertx/ext/auth/oauth2/OAuth2Options.setClientSecret(Ljava/lang/String;)Lio/vertx/ext/auth/oauth2/OAuth2Options;#0
+io/vertx/ext/web/handler/CSRFHandler.create(Lio/vertx/core/Vertx;Ljava/lang/String;)Lio/vertx/ext/web/handler/CSRFHandler;#0
+
 java/sql/DriverManager.getConnection(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/sql/Connection;#0
 java/security/KeyStore$PasswordProtection.<init>([C)V#0
 org/springframework/security/oauth2/config/annotation/builders/ClientDetailsServiceBuilder$ClientBuilder.secret(Ljava/lang/String;)Lorg/springframework/security/oauth2/config/annotation/builders/ClientDetailsServiceBuilder$ClientBuilder;#0

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/password/ConstantPasswordDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/password/ConstantPasswordDetectorTest.java
@@ -31,7 +31,8 @@ public class ConstantPasswordDetectorTest extends BaseDetectorTest {
     public void detectHardCodePasswordsAndKeys() throws Exception {
         String[] files = {
                 getClassFilePath("testcode/password/ConstantPasswords"),
-                getClassFilePath("testcode/oauth/SpringServerConfig")
+                getClassFilePath("testcode/oauth/SpringServerConfig"),
+                getClassFilePath("testcode/oauth/VertxOauth2Config")
         };
 
         EasyBugReporter reporter = spy(new SecurityReporter());
@@ -39,7 +40,7 @@ public class ConstantPasswordDetectorTest extends BaseDetectorTest {
 
         List<Integer> linesPasswords = Arrays.asList(
                 44, 52, 57, 62, 67, 72, 80, 86, 87, 88, 89, 91, 92, 93, 94,
-                121, 123, 159, 171
+                121, 123, 159, 171, 181
         );
         List<Integer> linesKeys = Arrays.asList(
                 100, 101, 102, 104, 105, 106, 107, 108, 109, 110, 116, 129,
@@ -68,9 +69,16 @@ public class ConstantPasswordDetectorTest extends BaseDetectorTest {
                         .inClass("SpringServerConfig").atLine(22)
                         .build()
         );
-        
-        // +1 for OAuth and +1 for hard coded public key field
-        verify(reporter, times(linesPasswords.size() + 1)).doReportBug(
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("HARD_CODE_PASSWORD")
+                        .inClass("VertxOauth2Config").atLine(13)
+                        .build()
+        );
+
+        // +2 for OAuth and +1 for hard coded public key field
+        verify(reporter, times(linesPasswords.size() + 2)).doReportBug(
                 bugDefinition().bugType("HARD_CODE_PASSWORD").build());
         verify(reporter, times(linesKeys.size() + 1)).doReportBug(
                 bugDefinition().bugType("HARD_CODE_KEY").build());

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/core/Vertx.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/core/Vertx.java
@@ -1,0 +1,4 @@
+package io.vertx.core;
+
+public interface Vertx {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
@@ -1,0 +1,12 @@
+package io.vertx.ext.auth.oauth2;
+
+public class OAuth2Options {
+
+    public OAuth2Options setClientID(String clientID) {
+        return this;
+    }
+
+    public OAuth2Options setClientSecret(String clientID) {
+        return this;
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -1,0 +1,4 @@
+package io.vertx.ext.web;
+
+public interface RoutingContext {
+}

--- a/findsecbugs-samples-deps/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
+++ b/findsecbugs-samples-deps/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
@@ -1,0 +1,12 @@
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.RoutingContext;
+
+public interface CSRFHandler extends Handler<RoutingContext>  {
+
+    static CSRFHandler create(Vertx vertx, String secret) {
+        return null;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/oauth/VertxOauth2Config.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/oauth/VertxOauth2Config.java
@@ -1,0 +1,21 @@
+package testcode.oauth;
+
+import io.vertx.ext.auth.oauth2.OAuth2Options;
+
+import java.util.Properties;
+
+public class VertxOauth2Config {
+    private Properties config;
+
+    public void configure(OAuth2Options oAuth2OptionsOptions) {
+        oAuth2OptionsOptions
+                .setClientID("client")
+                .setClientSecret("secret");
+    }
+
+    public void configureFalsePositive(OAuth2Options oAuth2OptionsOptions) {
+        oAuth2OptionsOptions
+                .setClientID("client")
+                .setClientSecret(config.getProperty("secretKey"));
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/password/ConstantPasswords.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/password/ConstantPasswords.java
@@ -170,7 +170,17 @@ public class ConstantPasswords {
         }
         return DriverManager.getConnection("url", "user", pwd);
     }
-    
+
+    public void bad15(io.vertx.core.Vertx vertx) throws Exception {
+        String pwd;
+        if (PWD2[2] % 2 == 1) { // non-trivial condition
+            pwd = "hardcoded1";
+        } else { // different constant but still hard coded
+            pwd = "hardcoded2";
+        }
+        io.vertx.ext.web.handler.CSRFHandler.create(vertx, pwd);
+    }
+
     private byte[] pwd4; // not considered hard coded
     private char[] pwd5 = null;
     private char[] pwd6 = new char[7];


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

This PR add support for identifying hardcoded password used in OAuth2 and CSRF handlers.

These checks were not detected automatically with the general password detector.