### PR TITLE
Add new detector for NORMALIZATION_AFTER_VALIDATION

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/NormalizationAfterValidationDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/NormalizationAfterValidationDetector.java
@@ -1,0 +1,66 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Method;
+
+import java.util.Set;
+import java.util.HashSet;
+
+public class NormalizationAfterValidationDetector extends OpcodeStackDetector {
+
+    Set<OpcodeStack.Item> validated = new HashSet<OpcodeStack.Item>();
+
+    private BugReporter bugReporter;
+
+    public NormalizationAfterValidationDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void visit(Method obj) {
+        validated.clear();
+        super.visit(obj);
+    }
+
+    private void reportBug() {
+        BugInstance bug = new BugInstance(this, "NORMALIZATION_AFTER_VALIDATION", Priorities.LOW_PRIORITY)
+                .addClass(this).addMethod(this).addSourceLine(this);
+        bugReporter.reportBug(bug);
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals("java/util/regex/Pattern")
+                && getNameConstantOperand().equals("matcher")) {
+            validated.add(stack.getStackItem(0));
+        } else if (seen == Const.INVOKESTATIC && getClassConstantOperand().equals("java/text/Normalizer")
+                       && getNameConstantOperand().equals("normalize")) {
+            if (validated.contains(stack.getStackItem(1))) {
+                reportBug();
+            }
+        }
+    }
+}

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/NormalizeBeforeValidationDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/NormalizeBeforeValidationDetector.java
@@ -1,0 +1,59 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+
+import org.apache.bcel.Const;
+
+import java.util.Set;
+import java.util.HashSet;
+
+public class NormalizeBeforeValidationDetector extends OpcodeStackDetector {
+
+    Set<OpcodeStack.Item> Validated = new HashSet<OpcodeStack.Item>();
+
+    private BugReporter bugReporter;
+
+    public NormalizeBeforeValidationDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    private void reportBug() {
+        BugInstance bug = new BugInstance(this, "NORMALIZE_BEFORE_VALIDATION", Priorities.LOW_PRIORITY)
+                .addClass(this).addMethod(this).addSourceLine(this);
+        bugReporter.reportBug(bug);
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals("java/util/regex/Pattern")
+                && getNameConstantOperand().equals("matcher")) {
+            Validated.add(stack.getStackItem(0));
+        } else if (seen == Const.INVOKESTATIC && getClassConstantOperand().equals("java/text/Normalizer")
+                       && getNameConstantOperand().equals("normalize")) {
+            if (Validated.contains(stack.getStackItem(1))) {
+                reportBug();
+            }
+        }
+    }
+}

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -135,6 +135,7 @@
     <Detector class="com.h3xstream.findsecbugs.password.JschPasswordDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.ImproperHandlingUnicodeDetector" reports="IMPROPER_UNICODE"/>
     <Detector class="com.h3xstream.findsecbugs.ModificationAfterValidationDetector" reports="MODIFICATION_AFTER_VALIDATION"/>
+    <Detector class="com.h3xstream.findsecbugs.NormalizationAfterValidationDetector" reports="NORMALIZATION_AFTER_VALIDATION"/>
 
     <BugPattern type="HTTP_PARAMETER_POLLUTION" abbrev="SECHPP" category="SECURITY"/>
     <BugPattern type="SMTP_HEADER_INJECTION" abbrev="SECSMTP" category="SECURITY"/>
@@ -275,5 +276,5 @@
     <BugPattern type="OVERLY_PERMISSIVE_FILE_PERMISSION" abbrev="SECOPFP" category="SECURITY"/>
     <BugPattern type="IMPROPER_UNICODE" abbrev="SECUNI" category="SECURITY"/>
     <BugPattern type="MODIFICATION_AFTER_VALIDATION" abbrev="SECMOD" category="SECURITY"/>
-
+    <BugPattern type="NORMALIZATION_AFTER_VALIDATION" abbrev="SECNORM" category="SECURITY"/>
 </FindbugsPlugin>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6525,4 +6525,52 @@ if (matcher.find()) {
     </BugPattern>
     <BugCode abbrev="SECMOD">String if modified after validation and not before it</BugCode>
 
+    <!-- Normalize strings before validating them -->
+    <Detector class="com.h3xstream.findsecbugs.NormalizationAfterValidationDetector">
+        <Details>Identify string normalization after validation and not before it.</Details>
+    </Detector>
+    <BugPattern type="NORMALIZATION_AFTER_VALIDATION">
+        <ShortDescription>String is normalzied after validation and not before it</ShortDescription>
+        <LongDescription>String is normalzied after validation and not before it. Tricky attackers may pass malicious strings which bypass validation.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+A string must not be normalized after validation because it may allow an attacker to bypass validation using a tricky
+string which becomes malicious after the normalization. For example, a program may filter out the &langle;script&rangle; tags from
+HTML input to avoid cross-site scripting (XSS) and other vulnerabilities. However, in unicode, the same string can have
+many different representations. For example, \uFE64 is normalized to &langle; and \uFE65 is normalized to &rangle;. Thus the
+if an attacker passes the string "\uFE64" + "script" + "\uFE65" the validation check fails to detect the &langle;script&rangle; tag,
+but thereafter the string is normalized to the &langle;script&rangle; tag in the input:
+<pre>
+Pattern pattern = Pattern.compile("[<>]"); // Check for angle brackets
+Matcher matcher = pattern.matcher(s);
+if (matcher.find()) {
+  throw new IllegalStateException();
+}
+s = Normalizer.normalize(s, Form.NFKC);
+</pre>
+</p>
+
+<p>
+The proper way is to do the normalization before the validation so the passed string is first changed to &langle;script&rangle;
+which fails to be validated:
+<pre>
+s = Normalizer.normalize(s, Form.NFKC);
+Pattern pattern = Pattern.compile("[<>]");
+Matcher matcher = pattern.matcher(s);
+if (matcher.find()) {
+  throw new IllegalStateException();
+}
+</pre>
+</p>
+
+<p>
+<b>References</b><br/>
+<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS01-J.+Normalize+strings+before+validating+them">CERT: IDS01-J. Normalize strings before validating them</a><br/>
+</p>
+
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECNORM">Normalize strings before validating them</BugCode>
 </MessageCollection>

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/NormalizeBeforeValidationTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/NormalizeBeforeValidationTest.java
@@ -1,0 +1,75 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+public class NormalizeBeforeValidationTest extends BaseDetectorTest {
+
+    @Test
+    public void detectNormalizationAfterValidation() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/normalize/NormalizeAfter.java")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("NORMALIZE_BEFORE_VALIDATION")
+                        .inClass("NormalizeAfter")
+                        .inMethod("validate")
+                        .withPriority("Low")
+                        .atLine(19)
+                        .build()
+            );
+        
+    }
+
+    @Test
+    public void detectNormalizationBeforeValidationAvoidFP() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/normalize/NormalizeBefore.java")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("NORMALIZE_BEFORE_VALIDATION")
+                        .inClass("NormalizeBefore")
+                        .inMethod("validate")
+                        .withPriority("Low")
+                        .atLine(7)
+                        .build()
+            );
+        
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/normalize/NormalizeAfter.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/normalize/NormalizeAfter.java
@@ -1,0 +1,26 @@
+package testcode.normalize;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+
+public class NormalizeAfter {
+
+    public static String validate(String s) {
+ 
+        // Validate
+        Pattern pattern = Pattern.compile("[<>]");
+        Matcher matcher = pattern.matcher(s);
+        if (matcher.find()) {
+            throw new IllegalStateException();
+        }
+        
+        return Normalizer.normalize(s, Form.NFKC);
+    }
+
+    public static void main(String[] args) {
+        String s1 = "\uFE64" + "script" + "\uFE65";
+        String s2 = validate(s1);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/normalize/NormalizeBefore.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/normalize/NormalizeBefore.java
@@ -1,0 +1,28 @@
+package testcode.normalize;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+
+public class NormalizeBefore {
+
+    public static String validate(String s) {
+ 
+        s = Normalizer.normalize(s, Form.NFKC);
+
+        // Validate
+        Pattern pattern = Pattern.compile("[<>]");
+        Matcher matcher = pattern.matcher(s);
+        if (matcher.find()) {
+            throw new IllegalStateException();
+        }
+
+        return s;
+    }
+
+    public static void main(String[] args) {
+        String s1 = "\uFE64" + "script" + "\uFE65";
+        String s2 = validate(s1);
+    }
+}


### PR DESCRIPTION
On untrusted input strings applications must employ input filtering and
validation mechanisms based on the strings' character data. For example,
to avoid cross-site scripting (XSS) vulnerabilities the <script> tag
must be forbidden in the input. Unicode strings must also be normalized
the same string can have many different representations. However, this
normalization must happen before validation and not after.

This patch adds a detector for this bug.