### PR TITLE
Add new detector for MODIFICATION_AFTER_VALIDATION

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/ModificationAfterValidationDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/ModificationAfterValidationDetector.java
@@ -1,0 +1,66 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.OpcodeStack;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Method;
+
+import java.util.Set;
+import java.util.HashSet;
+
+public class ModificationAfterValidationDetector extends OpcodeStackDetector {
+
+    Set<OpcodeStack.Item> validated = new HashSet<OpcodeStack.Item>();
+
+    private BugReporter bugReporter;
+
+    public ModificationAfterValidationDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void visit(Method obj) {
+        validated.clear();
+        super.visit(obj);
+    }
+
+    private void reportBug() {
+        BugInstance bug = new BugInstance(this, "MODIFICATION_AFTER_VALIDATION", Priorities.LOW_PRIORITY)
+                .addClass(this).addMethod(this).addSourceLine(this);
+        bugReporter.reportBug(bug);
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals("java/util/regex/Pattern")
+                && getNameConstantOperand().equals("matcher")) {
+            validated.add(stack.getStackItem(0));
+        } else if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals("java/lang/String")
+                       && getNameConstantOperand().startsWith("replace")) {
+            if (validated.contains(stack.getItemMethodInvokedOn(this))) {
+                reportBug();
+            }
+        }
+    }
+}

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -134,6 +134,7 @@
     <Detector class="com.h3xstream.findsecbugs.file.SuspiciousCommandDetector" reports="OVERLY_PERMISSIVE_FILE_PERMISSION"/>
     <Detector class="com.h3xstream.findsecbugs.password.JschPasswordDetector" reports="HARD_CODE_PASSWORD"/>
     <Detector class="com.h3xstream.findsecbugs.ImproperHandlingUnicodeDetector" reports="IMPROPER_UNICODE"/>
+    <Detector class="com.h3xstream.findsecbugs.ModificationAfterValidationDetector" reports="MODIFICATION_AFTER_VALIDATION"/>
 
     <BugPattern type="HTTP_PARAMETER_POLLUTION" abbrev="SECHPP" category="SECURITY"/>
     <BugPattern type="SMTP_HEADER_INJECTION" abbrev="SECSMTP" category="SECURITY"/>
@@ -273,5 +274,6 @@
     <BugPattern type="WICKET_XSS1" abbrev="WICXSS1" category="SECURITY"/>
     <BugPattern type="OVERLY_PERMISSIVE_FILE_PERMISSION" abbrev="SECOPFP" category="SECURITY"/>
     <BugPattern type="IMPROPER_UNICODE" abbrev="SECUNI" category="SECURITY"/>
+    <BugPattern type="MODIFICATION_AFTER_VALIDATION" abbrev="SECMOD" category="SECURITY"/>
 
 </FindbugsPlugin>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6475,4 +6475,54 @@ if(Normalizer.normalize(input, Normalizer.Form.NFC).equals("BACKUP")) {
     </BugPattern>
     <BugCode abbrev="SECUNI">Improper handling of Unicode transformations</BugCode>
 
+    <!-- Perform any string modifications before validation -->
+    <Detector class="com.h3xstream.findsecbugs.ModificationAfterValidationDetector">
+        <Details>Identify string modifications after validation and not before it.</Details>
+    </Detector>
+    <BugPattern type="MODIFICATION_AFTER_VALIDATION">
+        <ShortDescription>String is modified after validation and not before it</ShortDescription>
+        <LongDescription>String is modified after validation and not before it. Tricky attackers may pass malicious strings which bypass validation.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+A string must not be modified after validation because it may allow an attacker to bypass validation using a tricky
+string which becomes malicious after the modification. For example, a program may filter out the &langle;script&rangle; tags from
+HTML input to avoid cross-site scripting (XSS) and other vulnerabilities. If non-character code points  are deleted
+from the input following validation, an attacker may pass the string "&langle;scr"+"\uFDEF"+"ipt&rangle;" so that the validation
+check fails to detect the &langle;script&rangle; tag, but the subsequent removal of the non-character code pont creates a &langle;script&rangle;
+tag in the input:
+<pre>
+Pattern pattern = Pattern.compile("<script>");
+Matcher matcher = pattern.matcher(s);
+if (matcher.find()) {
+  throw new IllegalArgumentException("Invalid input");
+}
+
+s = s.replaceAll("[\\p{Cn}]", "");
+</pre>
+</p>
+
+<p>
+The proper way is to perform the modification before the validation so the passed string is first changed to &langle;script&rangle;
+which fails to be validated:
+<pre>
+s = s.replaceAll("[\\p{Cn}]", "\uFFFD");
+Pattern pattern = Pattern.compile("<script>");
+Matcher matcher = pattern.matcher(s);
+if (matcher.find()) {
+  throw new IllegalArgumentException("Invalid input");
+}
+</pre>
+</p>
+
+<p>
+<b>References</b><br/>
+<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS11-J.+Perform+any+string+modifications+before+validation">CERT: IDS11-J. Perform any string modifications before validation</a><br/>
+</p>
+
+            ]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECMOD">String if modified after validation and not before it</BugCode>
+
 </MessageCollection>

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/ModificationAfterValidationTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/ModificationAfterValidationTest.java
@@ -1,0 +1,75 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+public class ModificationAfterValidationTest extends BaseDetectorTest {
+
+    @Test
+    public void detectModificationAfterValidation() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/modify_validate/ModifyAfter.java")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("MODIFICATION_AFTER_VALIDATION")
+                        .inClass("ModifyAfter")
+                        .inMethod("validate")
+                        .withPriority("Low")
+                        .atLine(19)
+                        .build()
+            );
+        
+    }
+
+    @Test
+    public void detectModificationBeforeValidationAvoidFP() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/modify_validate/ModifyBefore.java")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("MODIFY_BEFORE_VALIDATION")
+                        .inClass("ModifyBefore")
+                        .inMethod("validate")
+                        .withPriority("Low")
+                        .atLine(13)
+                        .build()
+            );
+        
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/modify_validate/ModifyAfter.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/modify_validate/ModifyAfter.java
@@ -1,0 +1,27 @@
+package testcode.modify_validate;
+
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+  
+public class ModifyAfter {
+
+    public static String validate(String str) {
+        String s = Normalizer.normalize(str, Form.NFKC);
+ 
+        Pattern pattern = Pattern.compile("<script>");
+        Matcher matcher = pattern.matcher(s);
+        if (matcher.find()) {
+            throw new IllegalArgumentException("Invalid input");
+        }
+ 
+        s = s.replaceAll("[\\p{Cn}]", "");
+        return s;
+    }
+
+    public static void main(String[] args) {
+        String s1 = "<scr" + "\uFDEF" + "ipt>";
+        String s2 = validate(s1);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/modify_validate/ModifyBefore.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/modify_validate/ModifyBefore.java
@@ -1,0 +1,27 @@
+package testcode.modify_validate;
+
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+ 
+public class ModifyBefore {
+
+    public static String validate(String str) {
+        String s = Normalizer.normalize(str, Form.NFKC);
+ 
+        s = s.replaceAll("[\\p{Cn}]", "\uFFFD");
+ 
+        Pattern pattern = Pattern.compile("<script>");
+        Matcher matcher = pattern.matcher(s);
+        if (matcher.find()) {
+            throw new IllegalArgumentException("Invalid input");
+        }
+        return s;
+    }
+
+    public static void main(String[] args) {
+        String s1 = "<scr" + "\uFDEF" + "ipt>";
+        String s2 = validate(s1);
+    }
+}


### PR DESCRIPTION
A string must not be modified after validation because it may allow an
attacker to bypass validation using a tricky string which becomes
malicious after the modification. For example, a program may filter out
the <script> tags from HTML input to avoid cross-site scripting (XSS) and
other vulnerabilities. If non-character code points are deleted from the
input following validation, an attacker may pass the string "<scr"+
"\uFDEF"+"ipt>" so that the validation check fails to detect the <script>
tag, but the subsequent removal of the non-character code pont creates a
<script> tag in the input.

This patch adds a detector for this bug.