### PR TITLE
Add Paths.get(Uri) as source for Path traversal

### DIFF
--- a/findsecbugs-plugin/src/main/resources/injection-sinks/path-traversal-in.txt
+++ b/findsecbugs-plugin/src/main/resources/injection-sinks/path-traversal-in.txt
@@ -8,6 +8,7 @@ java/io/FileReader.<init>(Ljava/lang/String;)V:0
 java/io/FileInputStream.<init>(Ljava/lang/String;)V:0
 
 java/nio/file/Paths.get(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;:0,1
+java/nio/file/Paths.get(Ljava/net/URI;)Ljava/nio/file/Path;:0
 
 java/io/File.createTempFile(Ljava/lang/String;Ljava/lang/String;)Ljava/io/File;:0,1
 java/io/File.createTempFile(Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/io/File;:0,1,2

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/file/NioPathTraversalTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/file/NioPathTraversalTest.java
@@ -43,7 +43,7 @@ public class NioPathTraversalTest extends BaseDetectorTest {
         EasyBugReporter reporter = spy(new SecurityReporter());
         analyze(files, reporter);
 
-        for (Integer line : Arrays.asList(8,9,10,11,12)) {
+        for (Integer line : Arrays.asList(10,11,12,13,14,16,17)) {
             verify(reporter).doReportBug(
                     bugDefinition()
                             .bugType("PATH_TRAVERSAL_IN")
@@ -52,6 +52,6 @@ public class NioPathTraversalTest extends BaseDetectorTest {
             );
         }
 
-        verify(reporter, times(5)).doReportBug(bugDefinition().bugType("PATH_TRAVERSAL_IN").build());
+        verify(reporter, times(7)).doReportBug(bugDefinition().bugType("PATH_TRAVERSAL_IN").build());
     }
 }

--- a/findsecbugs-samples-java/src/test/java/testcode/pathtraversal/NioPathTraversal.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/pathtraversal/NioPathTraversal.java
@@ -1,19 +1,26 @@
 package testcode.pathtraversal;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
 public class NioPathTraversal {
 
-    public void loadFile(String path) {
+    public void loadFile(String path) throws URISyntaxException {
         Paths.get(path);
         Paths.get(path,"foo");
         Paths.get(path,"foo", "bar");
         Paths.get("foo", path);
         Paths.get("foo", "bar", path);
 
+        Paths.get(new URI("file", path, null));
+        Paths.get(new URI("file", path, "foo"));
+
         Paths.get("foo");
         Paths.get("foo","bar");
         Paths.get("foo","bar", "allsafe");
+        Paths.get(new URI("file", "foo", null));
+        Paths.get(new URI("file", "foo", "bar"));
 
     }
 }


### PR DESCRIPTION
This adds the Paths.get(Uri) variant as a follow-up to https://github.com/find-sec-bugs/find-sec-bugs/issues/324
> From the Path instance built, it can be use to load the file using other API (File, FileInputStream, etc..).

This also brings the nio detector in parity with the scala version of the same detector(scala-path-traversal-in.txt) which handles `Uri`s