### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ jdk:
 
 # Activate container based infra https://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
-install: mvn clean -B -V
-script: mvn clean test -Pjacoco -Ptravisci -B -V
+install: mvn -T 1C clean -B -V
+script: mvn -T 1C clean test -Pjacoco -Ptravisci -B -V
 
 
 after_success:
 # Codecov.io
 # Report available here : https://codecov.io/gh/find-sec-bugs/find-sec-bugs
-# The tests are runned with the script command (mvn clean test...)
+# The tests are runned with the script command (mvn -T 1C clean test...)
 # Docs: https://docs.codecov.io/v1.0/docs/about-the-codecov-bash-uploader
   - bash <(curl -s https://codecov.io/bash)

--- a/findsecbugs-plugin/pom.xml
+++ b/findsecbugs-plugin/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>com.h3xstream.findsecbugs</groupId>
         <artifactId>findsecbugs-root-pom</artifactId>
@@ -20,7 +19,9 @@
 
     <build>
         <plugins>
-            <!-- Jar packaging -->
+            
+<!-- Jar packaging -->
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
@@ -46,7 +47,7 @@
                         <configuration>
                             <tasks>
                                 <copy todir="${project.build.outputDirectory}">
-                                    <fileset dir="${project.build.outputDirectory}/metadata" />
+                                    <fileset dir="${project.build.outputDirectory}/metadata"/>
                                 </copy>
                             </tasks>
                         </configuration>
@@ -81,7 +82,7 @@
                         <!-- Needed for coveralls plugin -->
                         <format>xml</format>
                     </formats>
-                    <check />
+                    <check/>
                 </configuration>
             </plugin>
 
@@ -167,23 +168,11 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>com.h3xstream.findsecbugs</groupId>
-            <artifactId>findsecbugs-samples-deps</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
+        
+        
+        
 
     </dependencies>
 

--- a/findsecbugs-samples-kotlin/pom.xml
+++ b/findsecbugs-samples-kotlin/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>findsecbugs-root-pom</artifactId>
         <groupId>com.h3xstream.findsecbugs</groupId>
@@ -25,11 +24,7 @@
         </dependency>
 
 
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
+        
 
     </dependencies>
 
@@ -66,7 +61,9 @@
             </plugin>
 
 
-            <!-- Build the test jar -->
+            
+<!-- Build the test jar -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/findsecbugs-test-util/pom.xml
+++ b/findsecbugs-test-util/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>com.h3xstream.findsecbugs</groupId>
         <artifactId>findsecbugs-root-pom</artifactId>
@@ -22,7 +21,9 @@
 
     <build>
         <plugins>
-            <!-- Build the test jar -->
+            
+<!-- Build the test jar -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -49,11 +50,7 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
 
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.h3xstream.findsecbugs</groupId>
@@ -12,9 +12,7 @@
     <description>Root project file that aggregate the different modules of Find Security Bugs.</description>
 
     <properties>
-        
-<!-- Encoding configuration -->
-
+        <!-- Encoding configuration -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -132,10 +130,11 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.20</version>
                         <configuration>
+		            <parallel>all<parallel>
                             <argLine>@{argLine} -Xmx3000m -Dbcel.dontCache=true</argLine>
 		           <enableAssertions>true</enableAssertions>
                         </configuration>
-                    <configuration><parallel>all</parallel></configuration></plugin>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -341,7 +340,7 @@
             <name>GNU Lesser General Public License</name>
             <url>http://www.gnu.org/copyleft/lesser.html</url>
             <distribution>repo</distribution>
-            <comments/>
+            <comments />
         </license>
     </licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.h3xstream.findsecbugs</groupId>
@@ -12,7 +12,9 @@
     <description>Root project file that aggregate the different modules of Find Security Bugs.</description>
 
     <properties>
-        <!-- Encoding configuration -->
+        
+<!-- Encoding configuration -->
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -133,7 +135,7 @@
                             <argLine>@{argLine} -Xmx3000m -Dbcel.dontCache=true</argLine>
 		           <enableAssertions>true</enableAssertions>
                         </configuration>
-                    </plugin>
+                    <configuration><parallel>all</parallel></configuration></plugin>
                 </plugins>
             </build>
         </profile>
@@ -339,7 +341,7 @@
             <name>GNU Lesser General Public License</name>
             <url>http://www.gnu.org/copyleft/lesser.html</url>
             <distribution>repo</distribution>
-            <comments />
+            <comments/>
         </license>
     </licenses>
 


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
findsecbugs-root-pom
findsecbugs-test-util
{groupId='org.hamcrest', artifactId='hamcrest-core', version='2.1', scope='test'}
findsecbugs-samples-deps
findsecbugs-samples-kotlin
{groupId='org.jetbrains.kotlin', artifactId='kotlin-stdlib-jdk8', version='1.2.51', scope='compile'}
findsecbugs-samples-java
findsecbugs-samples-jsp
findsecbugs-plugin
{groupId='com.h3xstream.findsecbugs:findsecbugs-samples-kotlin', artifactId='test-jar', version='1.12.0-SNAPSHOT', scope='test'}
{groupId='com.h3xstream.findsecbugs:findsecbugs-samples-java', artifactId='test-jar', version='1.12.0-SNAPSHOT', scope='test'}
{groupId='com.h3xstream.findsecbugs:findsecbugs-samples-jsp', artifactId='test-jar', version='1.12.0-SNAPSHOT', scope='test'}
{groupId='ch.qos.logback', artifactId='logback-classic', version='1.2.3', scope='test'}
{groupId='commons-io', artifactId='commons-io', version='2.6', scope='test'}
{groupId='com.h3xstream.findsecbugs', artifactId='findsecbugs-samples-deps', version='1.12.0-SNAPSHOT', scope='provided'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
