### PR TITLE
New detector FindDangerousPermissionCombination for new bug type DANGEROUS_PERMISSION_COMBINATION

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/DangerousPermissionCombination.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/DangerousPermissionCombination.java
@@ -1,0 +1,58 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+
+package com.h3xstream.findsecbugs;
+
+import org.apache.bcel.Const;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+
+public class DangerousPermissionCombination extends OpcodeStackDetector {
+
+    private BugReporter bugReporter;
+
+    public DangerousPermissionCombination(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    private void reportBug(String permission, String target) {
+        BugInstance bug = new BugInstance(this, "DANGEROUS_PERMISSION_COMBINATION", NORMAL_PRIORITY)
+                .addClassAndMethod(this).addString(permission).addString(target).addSourceLine(this);
+        bugReporter.reportBug(bug);
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen == Const.INVOKESPECIAL && Const.CONSTRUCTOR_NAME.equals(getNameConstantOperand())) {
+            ClassDescriptor cd = getClassDescriptorOperand();
+            if (cd != null && "Ljava/lang/reflect/ReflectPermission;".equals(cd.getSignature())) {
+                String stringParam = (String) stack.getStackItem(0).getConstant();
+                if (stringParam != null && "suppressAccessChecks".equals(stringParam)) {
+                    reportBug("ReflectPermission", "suppressAccessChecks");
+                }
+            } else if (cd != null && "Ljava/lang/RuntimePermission;".equals(cd.getSignature())) {
+                String stringParam = (String) stack.getStackItem(0).getConstant();
+                if (stringParam != null && "createClassLoader".equals(stringParam)) {
+                    reportBug("RuntimePermission", "createClassLoader");
+                }
+            }
+        }
+    }
+}

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -136,6 +136,8 @@
     <Detector class="com.h3xstream.findsecbugs.ImproperHandlingUnicodeDetector" reports="IMPROPER_UNICODE"/>
     <Detector class="com.h3xstream.findsecbugs.ModificationAfterValidationDetector" reports="MODIFICATION_AFTER_VALIDATION"/>
     <Detector class="com.h3xstream.findsecbugs.NormalizationAfterValidationDetector" reports="NORMALIZATION_AFTER_VALIDATION"/>
+    <Detector class="com.h3xstream.findsecbugs.DangerousPermissionCombination" reports="DANGEROUS_PERMISSION_COMBINATION"/>
+
 
     <BugPattern type="HTTP_PARAMETER_POLLUTION" abbrev="SECHPP" category="SECURITY"/>
     <BugPattern type="SMTP_HEADER_INJECTION" abbrev="SECSMTP" category="SECURITY"/>
@@ -277,4 +279,5 @@
     <BugPattern type="IMPROPER_UNICODE" abbrev="SECUNI" category="SECURITY" cweid="176"/>
     <BugPattern type="MODIFICATION_AFTER_VALIDATION" abbrev="SECMOD" category="SECURITY" cweid="176"/>
     <BugPattern type="NORMALIZATION_AFTER_VALIDATION" abbrev="SECNORM" category="SECURITY" cweid="176"/>
+    <BugPattern type="DANGEROUS_PERMISSION_COMBINATION" abbrev="SECPERM" category="SECURITY"/>
 </FindbugsPlugin>

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -279,5 +279,5 @@
     <BugPattern type="IMPROPER_UNICODE" abbrev="SECUNI" category="SECURITY" cweid="176"/>
     <BugPattern type="MODIFICATION_AFTER_VALIDATION" abbrev="SECMOD" category="SECURITY" cweid="176"/>
     <BugPattern type="NORMALIZATION_AFTER_VALIDATION" abbrev="SECNORM" category="SECURITY" cweid="176"/>
-    <BugPattern type="DANGEROUS_PERMISSION_COMBINATION" abbrev="SECPERM" category="SECURITY"/>
+    <BugPattern type="DANGEROUS_PERMISSION_COMBINATION" abbrev="SECPERM" category="SECURITY" cweid="732"/>
 </FindbugsPlugin>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6591,8 +6591,8 @@ Certain combinations of permissions can produce significant capability increases
 ReflectPermission on the target suppressAccessChecks is dangerous in that information (possibly confidential) and
 methods normally unavailable would be accessible to malicious code. Similarly, the permission
 java.lang.RuntimePermission applied to target createClassLoader grants code the permission to create a ClassLoader
-object. This is an extremely dangerous, because malicious applications that can instantiate their own class loaders
-could then load their own rogue classes into the system. These newly loaded classes could be placed into any protection
+object. This is extremely dangerous, because malicious applications that can instantiate their own class loaders could
+then load their own rogue classes into the system. These newly loaded classes could be placed into any protection
 domain by the class loader, thereby automatically granting the classes the permissions for that domain.
 </p>
 

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6577,4 +6577,31 @@ if (matcher.find()) {
         </Details>
     </BugPattern>
     <BugCode abbrev="SECNORM">Normalize strings before validating them</BugCode>
+
+    <Detector class="com.h3xstream.findsecbugs.DangerousPermissionCombination">
+        <Details>Detector for patterns where combination of dangerous permissions are granted.</Details>
+    </Detector>
+    <BugPattern type="DANGEROUS_PERMISSION_COMBINATION">
+        <ShortDescription>Dangerous combination of permissions granted</ShortDescription>
+        <LongDescription>Granting permission {2} on the target {3} in method {1} is dangerous.</LongDescription>
+        <Details>
+            <![CDATA[
+<p>
+Certain combinations of permissions can produce significant capability increases and should not be granted. Granting
+ReflectPermission on the target suppressAccessChecks is dangerous in that information (possibly confidential) and
+methods normally unavailable would be accessible to malicious code. Similarly, the permission
+java.lang.RuntimePermission applied to target createClassLoader grants code the permission to create a ClassLoader
+object. This is an extremely dangerous, because malicious applications that can instantiate their own class loaders
+could then load their own rogue classes into the system. These newly loaded classes could be placed into any protection
+domain by the class loader, thereby automatically granting the classes the permissions for that domain.
+</p>
+
+<p>References</b><br>
+<a href="https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions">CERT: ENV03-J. Do not grant dangerous combinations of permissions</a><br/>
+</p>
+            ]]>
+    </Details>
+  </BugPattern>
+  <BugCode abbrev="SECPERM">Dangerous Permission Combination</BugCode>
+
 </MessageCollection>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6590,11 +6590,41 @@ if (matcher.find()) {
 Certain combinations of permissions can produce significant capability increases and should not be granted. Granting
 ReflectPermission on the target suppressAccessChecks is dangerous in that information (possibly confidential) and
 methods normally unavailable would be accessible to malicious code. Similarly, the permission
-java.lang.RuntimePermission applied to target createClassLoader grants code the permission to create a ClassLoader
-object. This is extremely dangerous, because malicious applications that can instantiate their own class loaders could
+<code>java.lang.RuntimePermission</code> applied to target createClassLoader grants code the permission to create a
+<code>ClassLoader</code> object.
+This is extremely dangerous, because malicious applications that can instantiate their own class loaders could
 then load their own rogue classes into the system. These newly loaded classes could be placed into any protection
 domain by the class loader, thereby automatically granting the classes the permissions for that domain.
 </p>
+
+
+<p>
+<b>Dangerous permissions:</b><br/>
+
+<pre>
+PermissionCollection pc = super.getPermissions(cs);
+pc.add(new RuntimePermission("getClassLoader"));
+</pre>
+<br/>
+
+<pre>
+PermissionCollection pc = super.getPermissions(cs);
+pc.add(new RuntimePermission("createClassLoader"));
+</pre>
+<br/>
+
+<pre>
+PermissionCollection pc = super.getPermissions(cs);
+pc.add(new ReflectPermission("newProxyInPackage.*"));
+</pre>
+<br/>
+
+<pre>
+PermissionCollection pc = super.getPermissions(cs);
+pc.add(new ReflectPermission("suppressAccessChecks"));
+</pre>
+</p>
+
 
 <p>References</b><br>
 <a href="https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions">CERT: ENV03-J. Do not grant dangerous combinations of permissions</a><br/>

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/DangerousPermissionCombinationTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/DangerousPermissionCombinationTest.java
@@ -1,0 +1,67 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+public class DangerousPermissionCombinationTest extends BaseDetectorTest {
+    @Test
+    public void testReflectPermissionSuppressAccessChecks() throws Exception {
+        verifyDPCBug("ReflectPermissionSuppressAccessChecks", 12, true);
+    }
+
+    @Test
+    public void testReflectPermissionNewProxyInPackage() throws Exception {
+        verifyDPCBug("ReflectPermissionNewProxyInPackage", 12, false);
+    }
+
+    @Test
+    public void testRuntimePermissionCreateClassLoader() throws Exception {
+        verifyDPCBug("RuntimePermissionCreateClassLoader", 11, true);
+    }
+
+    @Test
+    public void testRuntimePermissionGetClassLoader() throws Exception {
+        verifyDPCBug("RuntimePermissionGetClassLoader", 11, false);
+    }
+
+    private void verifyDPCBug(String className, int line, boolean isBug) throws Exception {
+        //Locate test code
+        String[] files = {
+            getClassFilePath("testcode/permission/" + className + ".java")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, isBug ? times(1) : never()).doReportBug(
+            bugDefinition()
+                    .bugType("DANGEROUS_PERMISSION_COMBINATION")
+                    .inClass(className)
+                    .inMethod("getPermissions")
+                    .withPriority("Medium")
+                    .atLine(line)
+                    .build()
+        );
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/permission/ReflectPermissionNewProxyInPackage.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/permission/ReflectPermissionNewProxyInPackage.java
@@ -1,0 +1,16 @@
+package testcode.permission;
+
+import java.lang.reflect.ReflectPermission;
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class ReflectPermissionNewProxyInPackage extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new ReflectPermission("newProxyInPacakge.*"));
+        // Other permissions
+        return pc;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/permission/ReflectPermissionNewProxyInPackage.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/permission/ReflectPermissionNewProxyInPackage.java
@@ -9,7 +9,7 @@ public class ReflectPermissionNewProxyInPackage extends SecureClassLoader {
     @Override
     protected PermissionCollection getPermissions(CodeSource cs) {
         PermissionCollection pc = super.getPermissions(cs);
-        pc.add(new ReflectPermission("newProxyInPacakge.*"));
+        pc.add(new ReflectPermission("newProxyInPackage.*"));
         // Other permissions
         return pc;
     }

--- a/findsecbugs-samples-java/src/test/java/testcode/permission/ReflectPermissionSuppressAccessChecks.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/permission/ReflectPermissionSuppressAccessChecks.java
@@ -1,0 +1,16 @@
+package testcode.permission;
+
+import java.lang.reflect.ReflectPermission;
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class ReflectPermissionSuppressAccessChecks extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new ReflectPermission("suppressAccessChecks"));
+        // Other permissions
+        return pc;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/permission/RuntimePermissionCreateClassLoader.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/permission/RuntimePermissionCreateClassLoader.java
@@ -1,0 +1,15 @@
+package testcode.permission;
+
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class RuntimePermissionCreateClassLoader extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new RuntimePermission("createClassLoader"));
+        // Other permissions
+        return pc;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/permission/RuntimePermissionGetClassLoader.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/permission/RuntimePermissionGetClassLoader.java
@@ -1,0 +1,15 @@
+package testcode.permission;
+
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.SecureClassLoader;
+
+public class RuntimePermissionGetClassLoader extends SecureClassLoader {
+    @Override
+    protected PermissionCollection getPermissions(CodeSource cs) {
+        PermissionCollection pc = super.getPermissions(cs);
+        pc.add(new RuntimePermission("getClassLoader"));
+        // Other permissions
+        return pc;
+    }
+}


### PR DESCRIPTION
This bug is reported thenever ReflectPermission is granted on the target suppressAccessChecks or RuntimePermission on createClassLoader.

See [CEI CERT RULE ENV03-J](https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions)