### PR TITLE
Fix the examples in the documentation of DANGEROUS_PERMISSION_COMBINATION

### DIFF
--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6599,29 +6599,17 @@ domain by the class loader, thereby automatically granting the classes the permi
 
 
 <p>
-<b>Dangerous permissions:</b><br/>
+<b>Dangerous permission combinations:</b><br/>
 
 <pre>
 PermissionCollection pc = super.getPermissions(cs);
-pc.add(new RuntimePermission("getClassLoader"));
+pc.add(new ReflectPermission("suppressAccessChecks"));
 </pre>
 <br/>
 
 <pre>
 PermissionCollection pc = super.getPermissions(cs);
 pc.add(new RuntimePermission("createClassLoader"));
-</pre>
-<br/>
-
-<pre>
-PermissionCollection pc = super.getPermissions(cs);
-pc.add(new ReflectPermission("newProxyInPackage.*"));
-</pre>
-<br/>
-
-<pre>
-PermissionCollection pc = super.getPermissions(cs);
-pc.add(new ReflectPermission("suppressAccessChecks"));
 </pre>
 </p>
 


### PR DESCRIPTION
`ReflectPermission("newProxyInPackage.*")` and `RuntimePermission("getClassLoader")` are the negative tests, thus they are considered safe. This  PR removes them from the documentation. This is a fix for #652.