### PR TITLE
New option to handle parameters of public methods of public classes as tainted data

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
@@ -36,6 +36,7 @@ public class FindSecBugsGlobalConfig {
     // set through SystemProperties
     private boolean debugOutputTaintConfigs;
     private boolean taintedSystemVariables;
+    private boolean taintedPublicMethodParameters;
     private String customConfigFile;
     private boolean taintedMainArgument;
     private boolean reportPotentialXssWrongContext;
@@ -43,6 +44,7 @@ public class FindSecBugsGlobalConfig {
     protected FindSecBugsGlobalConfig() {
         debugOutputTaintConfigs = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.outputconfigs", Boolean.FALSE.toString()));
         taintedSystemVariables = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.taintedsystemvariables", Boolean.FALSE.toString()));
+        taintedPublicMethodParameters = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.taintedpublicmethodparameters", Boolean.FALSE.toString()));
         customConfigFile = loadFromSystem("findsecbugs.taint.customconfigfile", null);
         taintedMainArgument = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.taintedmainargument", Boolean.TRUE.toString()));
         reportPotentialXssWrongContext = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.reportpotentialxsswrongcontext", Boolean.FALSE.toString()));
@@ -128,6 +130,14 @@ public class FindSecBugsGlobalConfig {
 
     public void setTaintedSystemVariables(boolean taintedSystemVariables) {
         this.taintedSystemVariables = taintedSystemVariables;
+    }
+
+    public boolean isTaintedPublicMethodParameters() {
+        return taintedPublicMethodParameters;
+    }
+
+    public void setTaintedPublicMethodParameters(boolean taintedPublicMethodParameters) {
+        this.taintedPublicMethodParameters = taintedPublicMethodParameters;
     }
 
     public String getCustomConfigFile() {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
@@ -128,7 +128,7 @@ public class TaintAnalysis extends FrameDataflowAnalysis<Taint, TaintFrame> {
                             value = new Taint(Taint.State.SAFE);
                         }
                     } else if (FindSecBugsGlobalConfig.getInstance().isTaintedPublicMethodParameters()
-                            && inPublicMethod) {
+                            && i > 0 && inPublicMethod) {
                         value = new Taint(Taint.State.TAINTED);
                     } else {
                         value.addParameter(stackOffset);

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -122,6 +122,9 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
             loadTaintConfig(TAINT_CONFIG_PATH.concat("tainted-system-variables.txt"), false);
             LOGGER.info("System variables are considered to be tainted");
         }
+        if (CONFIG.isTaintedPublicMethodParameters()) {
+            LOGGER.info("Parameters of public methods are considered to be tainted");
+        }
         String customConfigFile = CONFIG.getCustomConfigFile();
         if (customConfigFile != null && !customConfigFile.isEmpty()) {
             for (String configFile : customConfigFile.split(File.pathSeparator)) {

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngineTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngineTest.java
@@ -50,4 +50,50 @@ public class TaintDataflowEngineTest extends BaseDetectorTest {
 
         FindSecBugsGlobalConfig.getInstance().setDebugOutputTaintConfigs(false);
     }
+
+    @Test
+    public void testTaintedPublicMethodParametersOff() throws Exception {
+        TaintDataflowEngine.writer = mock(Writer.class);
+
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/command/CommandInjection"),
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new BaseDetectorTest.SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COMMAND_INJECTION")
+                            .inClass("CommandInjection").atLine(44)
+                            .withPriority("Medium")
+                            .build());
+    }
+
+    @Test
+    public void testTaintedPublicMethodParametersOn() throws Exception {
+        FindSecBugsGlobalConfig.getInstance().setTaintedPublicMethodParameters(true);
+
+        TaintDataflowEngine.writer = mock(Writer.class);
+
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/command/CommandInjection"),
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new BaseDetectorTest.SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COMMAND_INJECTION")
+                            .inClass("CommandInjection").atLine(44)
+                            .withPriority("High")
+                            .build());
+
+        FindSecBugsGlobalConfig.getInstance().setTaintedPublicMethodParameters(false);
+    }
 }


### PR DESCRIPTION
Libraries accessing sensitive data must be protected against malicious usage. Therefore, the parameters of the public methods in its public classes must be handles as tainted data. This patch implements this behavior by introducing a new option `findescbugs.taint.taintedpublicmethodparameters`.