### PR TITLE
Update test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,14 +284,14 @@
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.9.10</version>
+                <version>7.4.0</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Minor updates to dependencies.

Note: SpotBugs update is causing major crashs. Most tests would failed is updating. This is probably due to test utility class use built around SpotBugs API.