### PR TITLE
Fix unescape tag #661

### DIFF
--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6499,7 +6499,7 @@ from the input following validation, an attacker may pass the string "&langle;sc
 check fails to detect the &langle;script&rangle; tag, but the subsequent removal of the non-character code pont creates a &langle;script&rangle;
 tag in the input:
 <pre>
-Pattern pattern = Pattern.compile("<script>");
+Pattern pattern = Pattern.compile("&lt;script&gt;");
 Matcher matcher = pattern.matcher(s);
 if (matcher.find()) {
   throw new IllegalArgumentException("Invalid input");
@@ -6514,7 +6514,7 @@ The proper way is to perform the modification before the validation so the passe
 which fails to be validated:
 <pre>
 s = s.replaceAll("[\\p{Cn}]", "\uFFFD");
-Pattern pattern = Pattern.compile("<script>");
+Pattern pattern = Pattern.compile("&lt;script&gt;");
 Matcher matcher = pattern.matcher(s);
 if (matcher.find()) {
   throw new IllegalArgumentException("Invalid input");


### PR DESCRIPTION
Fix broken description.
XML tag that are cited code need to be escaped.

Result:
![2021-11-01 02_33_52-Bug Patterns - Find Security Bugs](https://user-images.githubusercontent.com/593130/139631200-db6ba1a2-2b64-4105-92f6-39e0fd6e2b0c.png)