### PR TITLE
Correctly parse method signatures with generic types

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SignatureParserWithGeneric.java
@@ -17,10 +17,12 @@
  */
 package com.h3xstream.findsecbugs.spring;
 
+import edu.umd.cs.findbugs.ba.generic.GenericSignatureParser;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,15 +35,15 @@ import java.util.regex.Pattern;
  */
 public class SignatureParserWithGeneric {
 
-    private String[] argumentsTypes;
-    private String returnType;
+    private final List<String> argumentsTypes;
+    private final String returnType;
 
     public SignatureParserWithGeneric(String signature) {
-        String sigOnlyArgs = signature.substring(signature.indexOf("(")+1);
-        String[] paramAndReturn = sigOnlyArgs.split("\\)");
-        argumentsTypes = paramAndReturn[0].split(",");
-
-        returnType = paramAndReturn[1];
+        GenericSignatureParser delegate = new GenericSignatureParser(signature);
+        List<String> arguments = new ArrayList<>();
+        delegate.parameterSignatureIterator().forEachRemaining(arguments::add);
+        this.argumentsTypes = Collections.unmodifiableList(arguments);
+        this.returnType = delegate.getReturnTypeSignature();
     }
 
     public List<JavaClass[]> getArgumentsClasses() {

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
@@ -105,8 +105,16 @@ public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
 						.build()
 		);
 
-		//Make sure exactly 2 instances are found
-		verify(reporter, times(2)).doReportBug(
+		verify(reporter).doReportBug(
+				bugDefinition()
+						.bugType("ENTITY_MASS_ASSIGNMENT")
+						.inClass("SpringEntityLeakController")
+						.inMethod("api6")
+						.build()
+		);
+
+		//Make sure exactly 3 instances are found
+		verify(reporter, times(3)).doReportBug(
 				bugDefinition()
 						.bugType("ENTITY_MASS_ASSIGNMENT")
 						.inClass("SpringEntityLeakController")

--- a/findsecbugs-samples-java/src/test/java/testcode/spring/SpringEntityLeakController.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/spring/SpringEntityLeakController.java
@@ -35,6 +35,10 @@ public class SpringEntityLeakController {
     public void api5(@RequestParam("active") List<SampleEntity> entities) {
     }
 
+    @RequestMapping("/api6")
+    public void api6(SampleEntity sampleEntity, Object secondParameter) {
+    }
+
 	private List<SampleEntity> getData() { //FP (No request mapping annotation)
 	    return null;
     }


### PR DESCRIPTION
Currently, the implementation assumes the signature will be of the format
`(Ljava/lang/Object,Ljava/lang/Object)`, using a comma `,` separator.
This is not the case for compiled classes. Compiled signatures use a
semicolon `;` as the separator as described in [JVMS 4.2](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-ParameterDescriptor).

This commit delegates the `SpotBugs'` signature parser to ensure the parser
expects the format it is to be provided & reduces the maintenance overhead here.

Ref #668 