### PR TITLE
Add JDK17 support

### DIFF
--- a/cli/gradle.properties
+++ b/cli/gradle.properties
@@ -1,2 +1,2 @@
-fsbVersion=1.10.1
-spotbugsVersion=3.1.12
+fsbVersion=1.12.0
+spotbugsVersion=4.5.3

--- a/findsecbugs-plugin/pom.xml
+++ b/findsecbugs-plugin/pom.xml
@@ -157,7 +157,13 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/ReDosDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/ReDosDetectorTest.java
@@ -19,18 +19,10 @@ package com.h3xstream.findsecbugs;
 
 import com.h3xstream.findbugs.test.BaseDetectorTest;
 import com.h3xstream.findbugs.test.EasyBugReporter;
-import com.h3xstream.findbugs.test.matcher.BugInstanceMatcher;
-import edu.umd.cs.findbugs.BugInstance;
-import edu.umd.cs.findbugs.BugReporter;
-import edu.umd.cs.findbugs.Priorities;
-import org.mockito.Matchers;
-import org.testng.Assert;
 import org.testng.annotations.Test;
-import testcode.android.R;
 
 import java.util.Arrays;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/common/ByteCodeTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/common/ByteCodeTest.java
@@ -19,7 +19,7 @@ package com.h3xstream.findsecbugs.common;
 
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InvokeInstruction;
-import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.PrintStream;
@@ -44,9 +44,9 @@ public class ByteCodeTest {
             InvokeInstruction ins = mock(InvokeInstruction.class);
             ConstantPoolGen cpg = mock(ConstantPoolGen.class);
 
-            when(ins.getClassName(Matchers.<ConstantPoolGen>any())).thenReturn("ClassTest");
-            when(ins.getMethodName(Matchers.<ConstantPoolGen>any())).thenReturn("method");
-            when(ins.getSignature(Matchers.<ConstantPoolGen>any())).thenReturn("(Lsignature)Lblah");
+            when(ins.getClassName(Mockito.any(ConstantPoolGen.class))).thenReturn("ClassTest");
+            when(ins.getMethodName(Mockito.any(ConstantPoolGen.class))).thenReturn("method");
+            when(ins.getSignature(Mockito.any(ConstantPoolGen.class))).thenReturn("(Lsignature)Lblah");
 
             //Print invocation
             ByteCode.printOpCode(ins, cpg);

--- a/findsecbugs-samples-kotlin/pom.xml
+++ b/findsecbugs-samples-kotlin/pom.xml
@@ -12,7 +12,7 @@
     <name>Find Security Bugs Samples Kotlin</name>
 
     <properties>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.2.51</kotlin.version>
         <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
 

--- a/findsecbugs-samples-kotlin/pom.xml
+++ b/findsecbugs-samples-kotlin/pom.xml
@@ -12,7 +12,7 @@
     <name>Find Security Bugs Samples Kotlin</name>
 
     <properties>
-        <kotlin.version>1.2.51</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
         <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
 

--- a/findsecbugs-test-util/pom.xml
+++ b/findsecbugs-test-util/pom.xml
@@ -45,7 +45,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/findsecbugs-test-util/src/test/java/com/h3xstream/findbugs/test/BaseDetectorTest.java
+++ b/findsecbugs-test-util/src/test/java/com/h3xstream/findbugs/test/BaseDetectorTest.java
@@ -22,7 +22,7 @@ import edu.umd.cs.findbugs.BugReporter;
 import com.h3xstream.findbugs.test.matcher.BugInstanceMatcherBuilder;
 import com.h3xstream.findbugs.test.service.ClassFileLocator;
 import com.h3xstream.findbugs.test.service.FindBugsLauncher;
-import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -126,7 +126,7 @@ public class BaseDetectorTest {
     }
 
     public static BugInstance anyBugs() {
-        return Matchers.<BugInstance>any();
+        return Mockito.any(BugInstance.class);
     }
 
     public static List<Integer> range(int from, int to) {

--- a/findsecbugs-test-util/src/test/java/com/h3xstream/findbugs/test/matcher/BugInstanceMatcher.java
+++ b/findsecbugs-test-util/src/test/java/com/h3xstream/findbugs/test/matcher/BugInstanceMatcher.java
@@ -20,6 +20,7 @@ package com.h3xstream.findbugs.test.matcher;
 import edu.umd.cs.findbugs.*;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.mockito.ArgumentMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +29,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class BugInstanceMatcher extends BaseMatcher<BugInstance> {
-
+public class BugInstanceMatcher extends BaseMatcher<BugInstance> implements ArgumentMatcher
+{
     private static final Logger log = LoggerFactory.getLogger(BugInstanceMatcherBuilder.class);
 
     private static final Pattern ANON_FUNCTION_SCALA_PATTERN = Pattern.compile("\\$\\$anonfun\\$([^\\$]+)\\$");

--- a/findsecbugs-test-util/src/test/java/com/h3xstream/findbugs/test/matcher/BugInstanceMatcherBuilder.java
+++ b/findsecbugs-test-util/src/test/java/com/h3xstream/findbugs/test/matcher/BugInstanceMatcherBuilder.java
@@ -22,7 +22,7 @@ import com.h3xstream.findbugs.test.jsp.SmapParser;
 import com.h3xstream.findbugs.test.service.ClassFileLocator;
 import edu.umd.cs.findbugs.BugInstance;
 import org.apache.commons.io.IOUtils;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +129,7 @@ public class BugInstanceMatcherBuilder {
             }
         }
 
-        return Matchers.argThat(new BugInstanceMatcher(bugType, className, methodName, fieldName, lineNumber, lineNumberApprox, priority, jspFile, multipleChoicesLine,unknownSources));
+        return (BugInstance) ArgumentMatchers.argThat(new BugInstanceMatcher(bugType, className, methodName, fieldName, lineNumber, lineNumberApprox, priority, jspFile, multipleChoicesLine,unknownSources));
     }
 
     private static List<Integer>  mapJspToJavaLine(String jspFile, Integer jspLine) {

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>3.1.12</version>
+                        <version>4.5.3</version>
                         <configuration>
                             <xmlOutput>true</xmlOutput>
                             <failOnError>false</failOnError>
@@ -229,7 +229,7 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs</artifactId>
-                <version>3.1.12</version>
+                <version>4.5.3</version>
             </dependency>
 
             <!-- Artefact definition of the module -->
@@ -276,8 +276,8 @@
 
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.10.19</version>
+                <artifactId>mockito-core</artifactId>
+                <version>4.3.1</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Adds support for building on and analyzing on JDK17. Upgrades spot bugs to 4.5.3 (therefore upgrading ASM to the latest version).

I also had to upgrade Hamcrest and Mockito to deal with reflection based issues on later JDKs

Fixes https://github.com/find-sec-bugs/find-sec-bugs/issues/656.

I analyzed this branch with Sonatype Lift to make I haven't introduced any other issues (no new issues found): https://lift.sonatype.com/results/github.com/jlstephens89/find-sec-bugs/01FV0EF97XHCAXVFAY6E0NBCXE?tab=results
