### PR TITLE
fix: handle arrays in SignatureParserWithGeneric

### DIFF
--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
@@ -113,8 +113,16 @@ public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
 						.build()
 		);
 
-		//Make sure exactly 3 instances are found
-		verify(reporter, times(3)).doReportBug(
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("ENTITY_MASS_ASSIGNMENT")
+                        .inClass("SpringEntityLeakController")
+                        .inMethod("api7")
+                        .build()
+        );
+
+		//Make sure exactly 4 instances are found
+		verify(reporter, times(4)).doReportBug(
 				bugDefinition()
 						.bugType("ENTITY_MASS_ASSIGNMENT")
 						.inClass("SpringEntityLeakController")

--- a/findsecbugs-samples-java/src/test/java/testcode/spring/SpringEntityLeakController.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/spring/SpringEntityLeakController.java
@@ -39,6 +39,11 @@ public class SpringEntityLeakController {
     public void api6(SampleEntity sampleEntity, Object secondParameter) {
     }
 
+    @RequestMapping("/api7")
+    public String[] api7(Double[] firstParameter, List<SampleEntity>[] sampleEntities) {
+        return new String[0];
+    }
+
 	private List<SampleEntity> getData() { //FP (No request mapping annotation)
 	    return null;
     }


### PR DESCRIPTION
Proposed fix for https://github.com/find-sec-bugs/find-sec-bugs/issues/679
Replace regex parsing of the method signature by `edu.umd.cs.findbugs.ba.generic.GenericUtilities` to handle the case when a type in the method signature is an array.
Updated the unit test to include a case when a paramete and the return type are arrays.