### PR TITLE
Add Detector for XXE in XML SchemaFactory

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/xml/SchemaFactoryDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/xml/SchemaFactoryDetector.java
@@ -1,0 +1,164 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.xml;
+
+import com.h3xstream.findsecbugs.common.ByteCode;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.Location;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Const;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.ICONST;
+import org.apache.bcel.generic.INVOKEVIRTUAL;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InvokeInstruction;
+import org.apache.bcel.generic.LDC;
+
+import javax.xml.XMLConstants;
+
+/**
+ * Detector for XML External Entity and External Schema processing in javax.xml.validation.SchemaFactory
+ */
+public class SchemaFactoryDetector extends OpcodeStackDetector {
+
+    private static final String XXE_SCHEMA_FACTORY_TYPE = "XXE_SCHEMA_FACTORY";
+
+    private static final String SCHEMA_FACTORY_CLASS_NAME = "javax/xml/validation/SchemaFactory";
+
+    private static final String SET_FEATURE_METHOD = "setFeature";
+
+    private static final String SET_PROPERTY_METHOD = "setProperty";
+
+    private static final String NEW_SCHEMA_METHOD_NAME = "newSchema";
+
+    private static final Number BOOLEAN_TRUE_VALUE = 1;
+
+    private static final String EXTERNAL_REFERENCES_DISABLED = "";
+
+    private final BugReporter bugReporter;
+
+    public SchemaFactoryDetector(final BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(final int opcode) {
+        if (isNotNewSchemaMethod(opcode)) {
+            return;
+        }
+
+        final ClassContext classContext = getClassContext();
+        final CFG cfg;
+        try {
+            cfg = classContext.getCFG(getMethod());
+        } catch (final CFGBuilderException e) {
+            AnalysisContext.logError("Cannot get CFG", e);
+            return;
+        }
+
+        final ConstantPoolGen cpg = classContext.getConstantPoolGen();
+
+        boolean secureProcessingEnabled = false;
+        boolean accessExternalDtdDisabled = false;
+        boolean accessExternalSchemaDisabled = false;
+
+        for (final Location location : cfg.locations()) {
+            if (isSecureProcessingEnabled(location, cpg)) {
+                secureProcessingEnabled = true;
+            } else if (isAccessPropertyDisabled(location, cpg, XMLConstants.ACCESS_EXTERNAL_DTD)) {
+                accessExternalDtdDisabled = true;
+            } else if (isAccessPropertyDisabled(location, cpg, XMLConstants.ACCESS_EXTERNAL_SCHEMA)) {
+                accessExternalSchemaDisabled = true;
+            }
+        }
+
+        // Enabling Secure Processing or disabling both Access External DTD and Access External Schema are solutions
+        if (secureProcessingEnabled || (accessExternalDtdDisabled && accessExternalSchemaDisabled)) {
+            return;
+        }
+
+        bugReporter.reportBug(new BugInstance(this, XXE_SCHEMA_FACTORY_TYPE, Priorities.HIGH_PRIORITY)
+                .addClass(this).addMethod(this).addSourceLine(this));
+    }
+
+    private boolean isNotNewSchemaMethod(final int opcode) {
+        boolean notValidateInvocation = true;
+
+        if (Const.INVOKEVIRTUAL == opcode) {
+            final String slashedClassName = getClassConstantOperand();
+            final String methodName = getNameConstantOperand();
+            if (SCHEMA_FACTORY_CLASS_NAME.equals(slashedClassName) && NEW_SCHEMA_METHOD_NAME.equals(methodName)) {
+                notValidateInvocation = false;
+            }
+        }
+
+        return notValidateInvocation;
+    }
+
+    private boolean isSecureProcessingEnabled(final Location location, final ConstantPoolGen cpg) {
+        boolean enabled = false;
+        final Instruction instruction = location.getHandle().getInstruction();
+
+        if (instruction instanceof INVOKEVIRTUAL) {
+            final InvokeInstruction invokeInstruction = (InvokeInstruction) instruction;
+            final String instructionMethodName = invokeInstruction.getMethodName(cpg);
+            final InstructionHandle handle = location.getHandle();
+            if (SET_FEATURE_METHOD.equals(instructionMethodName)) {
+                final Object ldcValue = getLdcValue(handle, cpg);
+                if (XMLConstants.FEATURE_SECURE_PROCESSING.equals(ldcValue)) {
+                    final ICONST constant = ByteCode.getPrevInstruction(handle, ICONST.class);
+                    enabled = constant != null && BOOLEAN_TRUE_VALUE.equals(constant.getValue());
+                }
+            }
+        }
+
+        return enabled;
+    }
+
+    private boolean isAccessPropertyDisabled(final Location location, final ConstantPoolGen cpg, final String accessPropertyName) {
+        boolean enabled = false;
+        final Instruction instruction = location.getHandle().getInstruction();
+
+        if (instruction instanceof INVOKEVIRTUAL) {
+            final InvokeInstruction invokeInstruction = (InvokeInstruction) instruction;
+            final String instructionMethodName = invokeInstruction.getMethodName(cpg);
+            final InstructionHandle handle = location.getHandle();
+            if (SET_PROPERTY_METHOD.equals(instructionMethodName)) {
+                final Object propertyName = getLdcValue(handle.getPrev(), cpg);
+                final Object propertyValue = getLdcValue(handle, cpg);
+                if (accessPropertyName.equals(propertyName)) {
+                    enabled = EXTERNAL_REFERENCES_DISABLED.equals(propertyValue);
+                }
+            }
+        }
+
+        return enabled;
+    }
+
+    private Object getLdcValue(final InstructionHandle instructionHandle, final ConstantPoolGen cpg) {
+        final LDC ldc = ByteCode.getPrevInstruction(instructionHandle, LDC.class);
+        return ldc == null ? null : ldc.getValue(cpg);
+    }
+}

--- a/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/findbugs.xml
@@ -36,6 +36,7 @@
     <Detector class="com.h3xstream.findsecbugs.RedosAnnotationDetector" reports="REDOS"/>
     <Detector class="com.h3xstream.findsecbugs.xml.XxeDetector" reports="XXE_SAXPARSER,XXE_XMLREADER,XXE_DOCUMENT,XXE_XPATH"/>
     <Detector class="com.h3xstream.findsecbugs.xml.TransformerFactoryDetector" reports="XXE_DTD_TRANSFORM_FACTORY,XXE_XSLT_TRANSFORM_FACTORY"/>
+    <Detector class="com.h3xstream.findsecbugs.xml.SchemaFactoryDetector" reports="XXE_SCHEMA_FACTORY"/>
     <Detector class="com.h3xstream.findsecbugs.xml.XmlStreamReaderDetector" reports="XXE_XMLSTREAMREADER"/>
     <Detector class="com.h3xstream.findsecbugs.xml.ValidatorDetector" reports="XXE_VALIDATOR"/>
     <Detector class="com.h3xstream.findsecbugs.xpath.XPathInjectionDetector" reports="XPATH_INJECTION"/>
@@ -189,6 +190,7 @@
     <BugPattern type="XXE_XMLREADER" abbrev="SECXXEREAD" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_DOCUMENT" abbrev="SECXXEDOC" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_DTD_TRANSFORM_FACTORY" abbrev="SECXXETFDTD" category="SECURITY" cweid="611"/>
+    <BugPattern type="XXE_SCHEMA_FACTORY" abbrev="SECXXESF" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_XSLT_TRANSFORM_FACTORY" abbrev="SECXXETFXSLT" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_XMLSTREAMREADER" abbrev="SECXXESTR" category="SECURITY" cweid="611"/>
     <BugPattern type="XXE_XPATH" abbrev="SECXXEXPA" category="SECURITY" cweid="611"/>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -1842,6 +1842,114 @@ transformer.transform(input, result);</pre>
     </BugPattern>
     <BugCode abbrev="SECXXETFXSLT">XXE Vulnerability using XSLT in TransformerFactory</BugCode>
 
+    <!-- SchemaFactory XXE -->
+    <Detector class="com.h3xstream.findsecbugs.xml.SchemaFactoryDetector">
+        <Details>Identify SchemaFactory usage vulnerable to XXE</Details>
+    </Detector>
+
+    <BugPattern type="XXE_SCHEMA_FACTORY">
+        <ShortDescription>XML schema processing vulnerable to XXE</ShortDescription>
+        <LongDescription>XML schema processing is vulnerable to XML External Entity attacks</LongDescription>
+        <Details>
+            <![CDATA[
+
+<h4>Summary</h4>
+
+<p>
+XML External Entity attacks can occur when an XML SchemaFactory supports access to external entity references or external schema locations while parsing XML Schema Documents.
+</p>
+
+<h4>Sources</h4>
+
+<p>
+Malicious sources include XML Schema Documents containing entity definitions in the Document Type Declaration (DTD) that reference external locations.
+Documents can also include references to external schema locations using XML Schema include elements.
+</p>
+
+<h5>External Entity in Document Type Declaration</h5>
+
+<pre>
+&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;!DOCTYPE schema [
+  &lt;!ENTITY entity SYSTEM &quot;file:///etc/passwd&quot;&gt;
+]&gt;
+&lt;schema&gt;&amp;entity;&lt;/schema&gt;</pre>
+
+<h5>External Schema Location</h5>
+
+<pre>
+&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;schema xmlns="http://www.w3.org/2001/XMLSchema"&gt;
+  &lt;include schemaLocation="file:///etc/passwd"/&gt;
+&lt;/schema&gt;</pre>
+
+<h4>Vulnerabilities</h4>
+
+<p>
+Vulnerable instances of javax.xml.validation.SchemaFactory attempt to resolve XML External Entity references and External Schema Locations in the default configuration.
+</p>
+
+<pre>
+SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+Schema schema = schemaFactory.newSchema(source);
+</pre>
+
+<h4>Solutions</h4>
+
+<p>
+Protecting instances of java.xml.validation.SchemaFactory requires disabling external access or enabling secure processing.
+</p>
+
+<h5>Disabling External Access</h5>
+
+<p>
+The Java API for XML Processing (JAXP) version 1.5 implementing JEP 185 requires implementations to support properties for disabling external access.
+Java 7 Update 40 and Java 8 incorporated implementations of JAXP 1.5.
+Both <strong>ACCESS_EXTERNAL_DTD</strong> and <strong>ACCESS_EXTERNAL_SCHEMA</strong> must be disabled using an empty string to indicate
+that no external protocols are allowed.
+</p>
+
+<pre>
+SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+Schema schema = schemaFactory.newSchema(source);
+</pre>
+
+<h5>Enabling Secure Processing</h5>
+
+<p>
+JAXP 1.5 and JEP 185 indicate that implementations supporting the secure processing feature flag must restrict external access.
+The <strong>FEATURE_SECURE_PROCESSING</strong> flag restricts external access in supported implementations of JAXP 1.5.
+</p>
+
+<pre>
+SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+Schema schema = schemaFactory.newSchema(source);
+</pre>
+
+<h4>References</h4>
+
+<ul>
+  <li><a href="https://cwe.mitre.org/data/definitions/611.html">CWE-611: Improper Restriction of XML External Entity Reference</a></li>
+  <li><a href="https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing">OWASP: XML External Entity (XXE) Processing</a></li>
+  <li><a href="https://www.ws-attacks.org/index.php/XML_Entity_Expansion">WS-Attacks.org: XML Entity Expansion</a></li>
+  <li><a href="https://www.ws-attacks.org/index.php/XML_External_Entity_DOS">WS-Attacks.org: XML External Entity DOS</a></li>
+  <li><a href="https://www.ws-attacks.org/index.php/XML_Entity_Reference_Attack">WS-Attacks.org: XML Entity Reference Attack</a></li>
+  <li><a href="https://blog.h3xstream.com/2014/06/identifying-xml-external-entity.html">Identifying XML External Entity vulnerability (XXE)</a></li>
+  <li><a href="https://openjdk.java.net/jeps/185">JEP 185: Restrict Fetching of External XML Resources</a></li>
+</ul>
+]]>
+        </Details>
+    </BugPattern>
+    <BugCode abbrev="SECXXESF">XXE Vulnerability using schemas in SchemaFactory</BugCode>
+
     <!-- Validator XXE -->
     <Detector class="com.h3xstream.findsecbugs.xml.ValidatorDetector">
         <Details>Identify Validator usage vulnerable to XXE</Details>

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/xml/SchemaFactoryDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/xml/SchemaFactoryDetectorTest.java
@@ -1,0 +1,97 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.xml;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class SchemaFactoryDetectorTest extends BaseDetectorTest {
+
+    @Test
+    public void vulnerableExternalEntityRef() throws Exception {
+        final String[] files = {
+                getClassFilePath("testcode/xxe/schema/SchemaFactoryVulnerableExternalEntityRef")
+        };
+
+        final EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_SCHEMA_FACTORY")
+                        .inClass("SchemaFactoryVulnerableExternalEntityRef").inMethod("main").atLine(21)
+                        .build()
+        );
+    }
+
+    @Test
+    public void vulnerableExternalSchemaLocation() throws Exception {
+        final String[] files = {
+                getClassFilePath("testcode/xxe/schema/SchemaFactoryVulnerableExternalSchemaLocation")
+        };
+
+        final EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_SCHEMA_FACTORY")
+                        .inClass("SchemaFactoryVulnerableExternalSchemaLocation").inMethod("main").atLine(21)
+                        .build()
+        );
+    }
+
+    @Test
+    public void safeWithSecureProcessing() throws Exception {
+        final String[] files = {
+                getClassFilePath("testcode/xxe/schema/SchemaFactorySafeFeatureSecureProcessing")
+        };
+
+        final EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_SCHEMA_FACTORY")
+                        .inClass("SchemaFactorySafeFeatureSecureProcessing")
+                        .build()
+        );
+    }
+
+    @Test
+    public void safeWithAccessExternalDisabled() throws Exception {
+        final String[] files = {
+                getClassFilePath("testcode/xxe/schema/SchemaFactorySafeAccessExternalDisabled")
+        };
+
+        final EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("XXE_SCHEMA_FACTORY")
+                        .inClass("SchemaFactorySafeAccessExternalDisabled")
+                        .build()
+        );
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactorySafeAccessExternalDisabled.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactorySafeAccessExternalDisabled.java
@@ -1,0 +1,27 @@
+package testcode.xxe.schema;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class SchemaFactorySafeAccessExternalDisabled {
+
+    private static final String EXTERNAL_PROTOCOLS_DISABLED = "";
+
+    public static void main(final String[] args) throws SAXException, IOException {
+        final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, EXTERNAL_PROTOCOLS_DISABLED);
+        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, EXTERNAL_PROTOCOLS_DISABLED);
+
+        final String documentSource = "<?xml version=\"1.0\"?><!DOCTYPE schema [ <!ENTITY entity SYSTEM \"file:///etc/passwd\"> ]><schema>&entity;</schema>";
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(documentSource.getBytes(StandardCharsets.UTF_8));
+        final StreamSource source = new StreamSource(inputStream);
+
+        schemaFactory.newSchema(source);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactorySafeFeatureSecureProcessing.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactorySafeFeatureSecureProcessing.java
@@ -1,0 +1,24 @@
+package testcode.xxe.schema;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class SchemaFactorySafeFeatureSecureProcessing {
+
+    public static void main(final String[] args) throws SAXException, IOException {
+        final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        final String documentSource = "<?xml version=\"1.0\"?><!DOCTYPE schema [ <!ENTITY entity SYSTEM \"file:///etc/passwd\"> ]><schema>&entity;</schema>";
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(documentSource.getBytes(StandardCharsets.UTF_8));
+        final StreamSource source = new StreamSource(inputStream);
+
+        schemaFactory.newSchema(source);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactoryVulnerableExternalEntityRef.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactoryVulnerableExternalEntityRef.java
@@ -1,0 +1,23 @@
+package testcode.xxe.schema;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class SchemaFactoryVulnerableExternalEntityRef {
+
+    public static void main(final String[] args) throws SAXException, IOException {
+        final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+        final String documentSource = "<?xml version=\"1.0\"?><!DOCTYPE schema [ <!ENTITY entity SYSTEM \"file:///etc/passwd\"> ]><schema>&entity;</schema>";
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(documentSource.getBytes(StandardCharsets.UTF_8));
+        final StreamSource source = new StreamSource(inputStream);
+
+        schemaFactory.newSchema(source);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactoryVulnerableExternalSchemaLocation.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/xxe/schema/SchemaFactoryVulnerableExternalSchemaLocation.java
@@ -1,0 +1,23 @@
+package testcode.xxe.schema;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class SchemaFactoryVulnerableExternalSchemaLocation {
+
+    public static void main(final String[] args) throws SAXException, IOException {
+        final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+        final String documentSource = "<?xml version=\"1.0\"?><schema xmlns=\"http://www.w3.org/2001/XMLSchema\"><include schemaLocation=\"file:///etc/passwd\"/></schema>";
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(documentSource.getBytes(StandardCharsets.UTF_8));
+        final StreamSource source = new StreamSource(inputStream);
+
+        schemaFactory.newSchema(source);
+    }
+}


### PR DESCRIPTION
This pull request implements a new Detector for XML External Entity processing with `javax.xml.validation.SchemaFactory` as described in issue #395.

The implementation follows the pattern of Validator XXE Detector and supports solutions that enable Secure Processing or disable access to both External Document Type Declarations and External Schemas.

The documentation provides examples of both external entity references and external schema locations, as well as examples of vulnerable code and potential solutions.