### PR TITLE
fix: added "cash account" to the safe words, not a SHA password

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/password/HashUnsafeEqualsDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/password/HashUnsafeEqualsDetector.java
@@ -81,6 +81,7 @@ public class HashUnsafeEqualsDetector extends BasicInjectionDetector implements 
         ALLOWED_WORDS.add("shad"); //shade shadow
         ALLOWED_WORDS.add("sharp");
         ALLOWED_WORDS.add("shap"); //shape
+        ALLOWED_WORDS.add("cashaccount"); // cash account
     }
 
     public HashUnsafeEqualsDetector(BugReporter bugReporter) {


### PR DESCRIPTION
We have a false positive on UNSAFE_HASH_EQUALS for a variable containing `cashAccount`, it is flagged because the rule looks for `sha`
This PR adds `cashAccount` to the list of safe words