### PR TITLE
Verbose source line locations report

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
@@ -32,6 +32,7 @@ public class FindSecBugsGlobalConfig {
     private boolean debugPrintInstructionVisited = false;
     private boolean debugPrintInvocationVisited = false;
     private boolean debugTaintState = false;
+    private boolean verboseLocationReport = false;
     
     // set through SystemProperties
     private boolean debugOutputTaintConfigs;
@@ -47,6 +48,7 @@ public class FindSecBugsGlobalConfig {
         taintedMainArgument = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.taintedmainargument", Boolean.TRUE.toString()));
         reportPotentialXssWrongContext = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.reportpotentialxsswrongcontext", Boolean.FALSE.toString()));
         debugTaintState = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.debugtaintstate", Boolean.FALSE.toString()));
+        verboseLocationReport = Boolean.parseBoolean(loadFromSystem("findsecbugs.taint.verboselocationreport", Boolean.FALSE.toString()));
     }
 
     public String loadFromSystem(String key, String defaultValue) {
@@ -92,6 +94,10 @@ public class FindSecBugsGlobalConfig {
 
     public boolean isDebugOutputTaintConfigs() {
         return debugOutputTaintConfigs;
+    }
+
+    public boolean isVerboseLocationReport() {
+        return verboseLocationReport;
     }
 
     public void setDebugOutputTaintConfigs(boolean debugOutputTaintConfigs) {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/InjectionSink.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/InjectionSink.java
@@ -196,13 +196,15 @@ public class InjectionSink {
         }
         Collections.sort(lines);
         SourceLineAnnotation annotation = null;
-        for (Iterator<SourceLineAnnotation> it = lines.iterator(); it.hasNext();) {
-            SourceLineAnnotation prev = annotation;
-            annotation = it.next();
-            if (prev != null && prev.getClassName().equals(annotation.getClassName())
-                    && prev.getStartLine() == annotation.getStartLine()) {
-                // keep only one annotation per line
-                it.remove();
+        if(!FindSecBugsGlobalConfig.getInstance().isVerboseLocationReport()) {
+            for (Iterator<SourceLineAnnotation> it = lines.iterator(); it.hasNext(); ) {
+                SourceLineAnnotation prev = annotation;
+                annotation = it.next();
+                if (prev != null && prev.getClassName().equals(annotation.getClassName())
+                        && prev.getStartLine() == annotation.getStartLine()) {
+                    // keep only one annotation per line
+                    it.remove();
+                }
             }
         }
         for (SourceLineAnnotation sourceLine : lines) {


### PR DESCRIPTION
Hi,

In some cases it is useful to get all the byte code offsets find-sec-bugs aware of related to a single source code line, for example when one would like to get context to a specific location in a line.

We added a config flag that once set will skip the code that responsible for keeping only one SourceLineAnnotation per line.
