### PR TITLE
Updates to handle string-building taint with invokedynamic concatenation in JDK > 8

### DIFF
--- a/findsecbugs-plugin/pom.xml
+++ b/findsecbugs-plugin/pom.xml
@@ -148,6 +148,12 @@
         </dependency>
         <dependency>
             <groupId>com.h3xstream.findsecbugs</groupId>
+            <artifactId>findsecbugs-samples-java11</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h3xstream.findsecbugs</groupId>
             <artifactId>findsecbugs-samples-jsp</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/FindSecBugsGlobalConfig.java
@@ -98,9 +98,12 @@ public class FindSecBugsGlobalConfig {
         return debugOutputTaintConfigs;
     }
 
-
     public boolean isWorkaroundVisitInvokeDynamic() {
         return workaroundVisitInvokeDynamic;
+    }
+
+    public void setWorkaroundVisitInvokeDynamic(boolean workaroundVisitInvokeDynamic) {
+        this.workaroundVisitInvokeDynamic = workaroundVisitInvokeDynamic;
     }
 
     public boolean isVerboseLocationReport() {

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/StringConcatenationTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/StringConcatenationTest.java
@@ -1,0 +1,121 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.taintanalysis;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests Java 9+ string concatenation that uses invokedynamic.
+ */
+public class StringConcatenationTest extends BaseDetectorTest {
+
+    @Test
+    public void validateStringConcatenation() throws Exception {
+
+        // Enable the Java 9+ workaround
+        FindSecBugsGlobalConfig.getInstance().setWorkaroundVisitInvokeDynamic(true);
+
+        //Locate test code
+        String[] files = { getClassFilePath("testcode/taint/StringConcatenation") };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+
+        analyze(files, reporter);
+
+        // SQL
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC").build());
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC")
+                        .inClass("StringConcatenation").inMethod("unsafeStringSqlConcatenation")
+                        .withPriority("Medium")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC")
+                        .inClass("StringConcatenation").inMethod("safeBooleanSqlConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC")
+                        .inClass("StringConcatenation").inMethod("safeStringSqlConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC")
+                        .inClass("StringConcatenation").inMethod("safeIntSqlConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC")
+                        .inClass("StringConcatenation").inMethod("safeIntLongSqlConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("SQL_INJECTION_JDBC")
+                        .inClass("StringConcatenation").inMethod("safeIntDoubleSqlConcatenation")
+                        .build());
+
+        // File
+
+        verify(reporter, times(2)).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN").build());
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN")
+                        .inClass("StringConcatenation").inMethod("unsafeCharFileConcatenation")
+                        .withPriority("Medium")
+                        .build());
+
+        verify(reporter, times(1)).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN")
+                        .inClass("StringConcatenation").inMethod("unsafeStringFileConcatenation")
+                        .withPriority("Medium")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN")
+                        .inClass("StringConcatenation").inMethod("safeStringFileConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN")
+                        .inClass("StringConcatenation").inMethod("safeIntFileConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN")
+                        .inClass("StringConcatenation").inMethod("safeStringLongFileConcatenation")
+                        .build());
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition().bugType("PATH_TRAVERSAL_IN")
+                        .inClass("StringConcatenation").inMethod("safeStringDoubleFileConcatenation")
+                        .build());
+    }
+}

--- a/findsecbugs-samples-java11/pom.xml
+++ b/findsecbugs-samples-java11/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>findsecbugs-root-pom</artifactId>
+        <groupId>com.h3xstream.findsecbugs</groupId>
+        <version>1.13.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>findsecbugs-samples-java11</artifactId>
+
+    <name>Find Security Bugs Samples Java 11</name>
+
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.h3xstream.findsecbugs</groupId>
+            <artifactId>findsecbugs-samples-deps</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>javax.jws</groupId>
+            <artifactId>javax.jws-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+              <!-- Build the test code as Java 11 bytecode. -->
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.10.0</version>
+              <configuration>
+                <release>11</release>
+              </configuration>
+            </plugin>
+            <!-- Build the test jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+
+</project>

--- a/findsecbugs-samples-java11/src/test/java/testcode/taint/StringConcatenation.java
+++ b/findsecbugs-samples-java11/src/test/java/testcode/taint/StringConcatenation.java
@@ -1,0 +1,77 @@
+package testcode.taint;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Java 11 String concaenation uses invokedynamic by default.
+ */
+public class StringConcatenation {
+
+    // SQL
+
+    public static boolean unsafeStringSqlConcatenation(Connection conn, String flag) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            return stmt.execute("SELECT " + flag + " FROM foo;");
+        }
+    }
+
+    public static boolean safeBooleanSqlConcatenation(Connection conn, boolean flag) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            return stmt.execute("SELECT " + (flag ? "*" : "1") + " FROM foo;");
+        }
+    }
+
+    public static boolean safeStringSqlConcatenation(Connection conn) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            return stmt.execute("SELECT " + Integer.toString(10000) + " FROM bar;");
+        }
+    }
+
+    public static boolean safeIntSqlConcatenation(Connection conn, int foo) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            return stmt.execute("SELECT " + foo + " FROM bar;");
+        }
+    }
+
+    public static boolean safeIntLongSqlConcatenation(Connection conn, int foo, long bar) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            return stmt.execute("SELECT " + foo + ", " + bar + " FROM bar;");
+        }
+    }
+
+    public static boolean safeIntDoubleSqlConcatenation(Connection conn, int foo, double bar) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            return stmt.execute("SELECT " + foo + ", " + bar + " FROM bar;");
+        }
+    }
+
+    // File
+
+    public static FileInputStream unsafeCharFileConcatenation(char foo) throws FileNotFoundException {
+        return new FileInputStream("Hello" + foo);
+    }
+
+    public static FileInputStream unsafeStringFileConcatenation(String file) throws FileNotFoundException {
+        return new FileInputStream("Hello" + file);
+    }
+
+    public static FileInputStream safeStringFileConcatenation(boolean flag) throws FileNotFoundException {
+        return new FileInputStream("some" + (flag ? "Temp " : "") + "File");
+    }
+
+    public static FileInputStream safeIntFileConcatenation(int foo) throws FileNotFoundException {
+        return new FileInputStream("some" + foo + "File");
+    }
+
+    public static FileInputStream safeStringLongFileConcatenation(int foo, long bar) throws FileNotFoundException {
+        return new FileInputStream("some" + Integer.toString(foo) + "_" + bar + "File");
+    }
+
+    public static FileInputStream safeStringDoubleFileConcatenation(String blah, int foo, double bar) throws FileNotFoundException {
+        return new FileInputStream("some" + "blah" + "_"  + bar + ", " + Integer.toString(foo) + "File");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
         <module>findsecbugs-samples-deps</module>
         <module>findsecbugs-samples-kotlin</module>
         <module>findsecbugs-samples-java</module>
+        <module>findsecbugs-samples-java11</module>
         <module>findsecbugs-samples-jsp</module>
     </modules>
 
@@ -249,6 +250,12 @@
             <dependency>
                 <groupId>com.h3xstream.findsecbugs</groupId>
                 <artifactId>findsecbugs-samples-java</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.h3xstream.findsecbugs</groupId>
+                <artifactId>findsecbugs-samples-java11</artifactId>
                 <type>test-jar</type>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Pull Request https://github.com/find-sec-bugs/find-sec-bugs/pull/690 adds handling of JDK > 8 string concatenation with invokedynamic and `makeConcatWithConstants`.  There are some cases it does not handle such as concat of long or double values.  This pull request address the parameter offsets affected by long and double, which take two spots on the stack.

It also fixes issues where taint on a stack object is modified when we do not want that.

In order to test this change, we need some sample classes built with a JDK > 8, and using JDK11 on the current `findsecbugs-samples-java` introduces errors in the unit tests so there is a build submodule that builds specific classes to a JDK 11 target.