### PR TITLE
Added missing BugCode for SECXXEVAL abbrev

### DIFF
--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -2063,6 +2063,7 @@ validator.validate(source);
 ]]>
         </Details>
     </BugPattern>
+    <BugCode abbrev="SECXXEVAL">XXE Vulnerability using an XML Validator</BugCode>
 
     <!-- XPath Injection for Javax -->
     <Detector class="com.h3xstream.findsecbugs.xpath.XPathInjectionDetector">


### PR DESCRIPTION
As noted in #727 and https://github.com/spotbugs/sonar-findbugs/issues/983 the detector introduced in #681 declared a new bug code abbreviation but did not provide.
This is causing a crash when the detector reports a bug.

This should fix #727 and https://github.com/spotbugs/sonar-findbugs/issues/983