### PR TITLE
Upgrade the build to run on JDK 11

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
The build currently fails because it runs on JDK 8 but the findsecbugs-samples-java11 module requires java 11