### PR TITLE
Add support for jakarta

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/PermissiveCORSDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/PermissiveCORSDetector.java
@@ -35,16 +35,21 @@ import static com.h3xstream.findsecbugs.common.matcher.InstructionDSL.invokeInst
 public class PermissiveCORSDetector extends BasicInjectionDetector {
 
     private static final String PERMISSIVE_CORS = "PERMISSIVE_CORS";
-    private static final String HTTP_SERVLET_RESPONSE_CLASS = "javax.servlet.http.HttpServletResponse";
+    private static final String JAVAX_HTTP_SERVLET_RESPONSE_CLASS = "javax.servlet.http.HttpServletResponse";
+    private static final String JAKARTA_HTTP_SERVLET_RESPONSE_CLASS = "jakarta.servlet.http.HttpServletResponse";
     private static final String HEADER_KEY = "Access-Control-Allow-Origin";
 
     private static final InvokeMatcherBuilder SERVLET_RESPONSE_ADD_HEADER_METHOD = invokeInstruction()
-            .atClass(HTTP_SERVLET_RESPONSE_CLASS).atMethod("addHeader")
+            .atMethod("addHeader")
             .withArgs("(Ljava/lang/String;Ljava/lang/String;)V");
+    private static final InvokeMatcherBuilder JAVAX_SERVLET_RESPONSE_ADD_HEADER_METHOD = SERVLET_RESPONSE_ADD_HEADER_METHOD.atClass(JAVAX_HTTP_SERVLET_RESPONSE_CLASS);
+    private static final InvokeMatcherBuilder JAKARTA_SERVLET_RESPONSE_ADD_HEADER_METHOD = SERVLET_RESPONSE_ADD_HEADER_METHOD.atClass(JAKARTA_HTTP_SERVLET_RESPONSE_CLASS);
 
     private static final InvokeMatcherBuilder SERVLET_RESPONSE_SET_HEADER_METHOD = invokeInstruction()
-            .atClass(HTTP_SERVLET_RESPONSE_CLASS).atMethod("setHeader")
+            .atMethod("setHeader")
             .withArgs("(Ljava/lang/String;Ljava/lang/String;)V");
+    private static final InvokeMatcherBuilder JAVAX_SERVLET_RESPONSE_SET_HEADER_METHOD = SERVLET_RESPONSE_SET_HEADER_METHOD.atClass(JAVAX_HTTP_SERVLET_RESPONSE_CLASS);
+    private static final InvokeMatcherBuilder JAKARTA_SERVLET_RESPONSE_SET_HEADER_METHOD = SERVLET_RESPONSE_SET_HEADER_METHOD.atClass(JAKARTA_HTTP_SERVLET_RESPONSE_CLASS);
 
     public PermissiveCORSDetector(BugReporter bugReporter) {
         super(bugReporter);
@@ -55,14 +60,22 @@ public class PermissiveCORSDetector extends BasicInjectionDetector {
             InstructionHandle handle) {
         assert invoke != null && cpg != null;
 
-        if (SERVLET_RESPONSE_ADD_HEADER_METHOD.matches(invoke, cpg)) {
+        if (isServletResponseAddHeaderMethod(invoke, cpg)) {
             return new InjectionPoint(new int[] { 0 }, PERMISSIVE_CORS);
         }
 
-        if (SERVLET_RESPONSE_SET_HEADER_METHOD.matches(invoke, cpg)) {
+        if (isServletResponseSetHeaderMethod(invoke, cpg)) {
             return new InjectionPoint(new int[] { 0 }, PERMISSIVE_CORS);
         }
         return InjectionPoint.NONE;
+    }
+
+    private boolean isServletResponseSetHeaderMethod(InvokeInstruction invoke, ConstantPoolGen cpg) {
+        return JAVAX_SERVLET_RESPONSE_SET_HEADER_METHOD.matches(invoke, cpg) || JAKARTA_SERVLET_RESPONSE_SET_HEADER_METHOD.matches(invoke, cpg);
+    }
+
+    private boolean isServletResponseAddHeaderMethod(InvokeInstruction invoke, ConstantPoolGen cpg) {
+        return JAVAX_SERVLET_RESPONSE_ADD_HEADER_METHOD.matches(invoke, cpg) || JAKARTA_SERVLET_RESPONSE_ADD_HEADER_METHOD.matches(invoke, cpg);
     }
 
     @Override

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/RedosAnnotationDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/RedosAnnotationDetector.java
@@ -38,7 +38,8 @@ public class RedosAnnotationDetector implements Detector {
 
     private static final String REDOS_TYPE = "REDOS";
 
-    private static final String REGEX_ANNOTATION_TYPES = "Ljavax/validation/constraints/Pattern;";
+    private static final String JAVAX_REGEX_ANNOTATION_TYPES = "Ljavax/validation/constraints/Pattern;";
+    private static final String JAKARTA_REGEX_ANNOTATION_TYPES = "Ljakarta/validation/constraints/Pattern;";
 
     private BugReporter bugReporter;
 
@@ -53,7 +54,7 @@ public class RedosAnnotationDetector implements Detector {
 
             for (AnnotationEntry ae : f.getAnnotationEntries()) {
 
-                if (REGEX_ANNOTATION_TYPES.equals(ae.getAnnotationType())) {
+                if (isRegexAnnotation(ae)) {
 
                     ElementValuePair[] values = ae.getElementValuePairs();
 
@@ -81,6 +82,10 @@ public class RedosAnnotationDetector implements Detector {
                 }
             }
         }
+    }
+
+    private boolean isRegexAnnotation(AnnotationEntry ae) {
+        return JAVAX_REGEX_ANNOTATION_TYPES.equals(ae.getAnnotationType()) || JAKARTA_REGEX_ANNOTATION_TYPES.equals(ae.getAnnotationType());
     }
 
     @Override

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/cookie/CookieReadDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/cookie/CookieReadDetector.java
@@ -36,12 +36,16 @@ public class CookieReadDetector extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals("javax/servlet/http/Cookie")
+        if (seen == Const.INVOKEVIRTUAL && isCookieClass()
                 && (getNameConstantOperand().equals("getName") || getNameConstantOperand().equals("getValue") ||
                 getNameConstantOperand().equals("getPath"))) {
 
             bugReporter.reportBug(new BugInstance(this, COOKIE_USAGE_TYPE, Priorities.LOW_PRIORITY) //
                     .addClass(this).addMethod(this).addSourceLine(this));
         }
+    }
+
+    private boolean isCookieClass() {
+        return getClassConstantOperand().equals("javax/servlet/http/Cookie") || getClassConstantOperand().equals("jakarta/servlet/http/Cookie");
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/cookie/PersistentCookieDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/cookie/PersistentCookieDetector.java
@@ -34,7 +34,7 @@ public class PersistentCookieDetector extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == Const.INVOKEVIRTUAL && getClassConstantOperand().equals("javax/servlet/http/Cookie")
+        if (seen == Const.INVOKEVIRTUAL && isCookieClass()
                 && getNameConstantOperand().equals("setMaxAge")) {
 
             Object maxAge = stack.getStackItem(0).getConstant();
@@ -46,5 +46,9 @@ public class PersistentCookieDetector extends OpcodeStackDetector {
                         .addClass(this).addMethod(this).addSourceLine(this));
             }
         }
+    }
+
+    private boolean isCookieClass() {
+        return getClassConstantOperand().equals("javax/servlet/http/Cookie") || getClassConstantOperand().equals("jakarta/servlet/http/Cookie");
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetector.java
@@ -36,12 +36,16 @@ public class UrlRewritingDetector extends OpcodeStackDetector {
     @Override
     public void sawOpcode(int seen) {
 
-        if (seen == Const.INVOKEINTERFACE && getClassConstantOperand().equals("javax/servlet/http/HttpServletResponse")
+        if (seen == Const.INVOKEINTERFACE && isHttpServletResponseClass()
                 && (getNameConstantOperand().equals("encodeURL") || getNameConstantOperand().equals("encodeUrl") ||
                 getNameConstantOperand().equals("encodeRedirectURL") || getNameConstantOperand().equals("encodeRedirectUrl"))) {
 
             bugReporter.reportBug(new BugInstance(this, URL_REWRITING, Priorities.HIGH_PRIORITY) //
                     .addClass(this).addMethod(this).addSourceLine(this));
         }
+    }
+
+    private boolean isHttpServletResponseClass() {
+        return getClassConstantOperand().equals("javax/servlet/http/HttpServletResponse") || getClassConstantOperand().equals("jakarta/servlet/http/HttpServletResponse");
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/JaxRsEndpointDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/JaxRsEndpointDetector.java
@@ -48,13 +48,17 @@ public class JaxRsEndpointDetector implements Detector {
 
             for (AnnotationEntry ae : m.getAnnotationEntries()) {
 
-                //Every method mark with @javax.ws.rs.Path is mark as an Endpoint
-                if (ae.getAnnotationType().equals("Ljavax/ws/rs/Path;")) {
+                //Every method mark with @javax(or jakarta).ws.rs.Path is mark as an Endpoint
+                if (isRsEndpointAnnotation(ae)) {
                     bugReporter.reportBug(new BugInstance(this, JAXRS_ENDPOINT_TYPE, Priorities.LOW_PRIORITY) //
                             .addClassAndMethod(javaClass, m));
                 }
             }
         }
+    }
+
+    private boolean isRsEndpointAnnotation(AnnotationEntry ae) {
+        return ae.getAnnotationType().equals("Ljavax/ws/rs/Path;") || ae.getAnnotationType().equals("Ljakarta/ws/rs/Path;");
     }
 
     @Override

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/JaxWsEndpointDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/JaxWsEndpointDetector.java
@@ -46,13 +46,17 @@ public class JaxWsEndpointDetector implements Detector {
 
             for (AnnotationEntry ae : m.getAnnotationEntries()) {
 
-                //Every method mark with @javax.jws.WebMethod is mark as an Endpoint
-                if (ae.getAnnotationType().equals("Ljavax/jws/WebMethod;")) {
+                //Every method mark with @javax(or jakarta).jws.WebMethod is mark as an Endpoint
+                if (isJaxWsEndpointAnnotation(ae)) {
                     bugReporter.reportBug(new BugInstance(this, JAXWS_ENDPOINT_TYPE, Priorities.LOW_PRIORITY) //
                             .addClassAndMethod(javaClass, m));
                 }
             }
         }
+    }
+
+    private boolean isJaxWsEndpointAnnotation(AnnotationEntry ae) {
+        return ae.getAnnotationType().equals("Ljavax/jws/WebMethod;") || ae.getAnnotationType().equals("Ljakarta/jws/WebMethod;");
     }
 
     @Override

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/ServletEndpointDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/endpoint/ServletEndpointDetector.java
@@ -51,8 +51,7 @@ public class ServletEndpointDetector extends OpcodeStackDetector {
     public void sawOpcode(int seen) {
 
         //All call to ServletRequest
-        if (seen == Const.INVOKEINTERFACE && (getClassConstantOperand().equals("javax/servlet/ServletRequest") ||
-                getClassConstantOperand().equals("javax/servlet/http/HttpServletRequest"))) {
+        if (seen == Const.INVOKEINTERFACE && isServletRequestOrHttpServletRequestClass()) {
 
             //ServletRequest
 
@@ -106,5 +105,12 @@ public class ServletEndpointDetector extends OpcodeStackDetector {
                 }
             }
         }
+    }
+
+    private boolean isServletRequestOrHttpServletRequestClass() {
+        return getClassConstantOperand().equals("javax/servlet/ServletRequest") ||
+                getClassConstantOperand().equals("jakarta/servlet/ServletRequest") ||
+                getClassConstantOperand().equals("javax/servlet/http/HttpServletRequest") ||
+                getClassConstantOperand().equals("jakarta/servlet/http/HttpServletRequest");
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/redirect/RedirectionSource.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/redirect/RedirectionSource.java
@@ -35,8 +35,7 @@ public class RedirectionSource implements InjectionSource {
         if (ins instanceof INVOKEINTERFACE) {
             String methodName = ins.getMethodName(cpg);
             String className = ins.getReferenceType(cpg).toString();
-            if (className.equals("javax.servlet.http.HttpServletResponse")
-                    || className.equals("javax.servlet.http.HttpServletResponseWrapper")) {
+            if (isHttpServletResponseOrResponseWrapperClass(className)) {
                 if (methodName.equals("sendRedirect")) {
                     InjectionPoint ip = new InjectionPoint(new int[]{0}, UNVALIDATED_REDIRECT_TYPE);
                     //ip.setInjectableMethod(className.concat(".sendRedirect(...)"));
@@ -57,5 +56,12 @@ public class RedirectionSource implements InjectionSource {
             }
         }
         return InjectionPoint.NONE;
+    }
+
+    private boolean isHttpServletResponseOrResponseWrapperClass(String className) {
+        return className.equals("javax.servlet.http.HttpServletResponse") ||
+                className.equals("jakarta.servlet.http.HttpServletResponse") ||
+                className.equals("javax.servlet.http.HttpServletResponseWrapper") ||
+                className.equals("jakarta.servlet.http.HttpServletResponseWrapper");
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/jsp/JspIncludeDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/jsp/JspIncludeDetector.java
@@ -49,7 +49,7 @@ public class JspIncludeDetector extends OpcodeStackDetector {
 
 
         if (seen == Const.INVOKESTATIC && ("org/apache/jasper/runtime/JspRuntimeLibrary".equals(getClassConstantOperand()) || "org/apache/sling/scripting/jsp/jasper/runtime/JspRuntimeLibrary".equals(getClassConstantOperand()))
-                && getNameConstantOperand().equals("include") && getSigConstantOperand().equals("(Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;Ljava/lang/String;Ljavax/servlet/jsp/JspWriter;Z)V")) {
+                && getNameConstantOperand().equals("include") && includeMethodSignatureMatches()) {
 
             if (StackUtils.isVariableString(stack.getStackItem(2))) {
                 bugReporter.reportBug(new BugInstance(this, JSP_INCLUDE_TYPE, Priorities.HIGH_PRIORITY) //
@@ -63,5 +63,10 @@ public class JspIncludeDetector extends OpcodeStackDetector {
                     .addClass(this).addMethod(this).addSourceLine(this));
         }
 
+    }
+
+    private boolean includeMethodSignatureMatches() {
+        return getSigConstantOperand().equals("(Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;Ljava/lang/String;Ljavax/servlet/jsp/JspWriter;Z)V") ||
+                getSigConstantOperand().equals("(Ljakarta/servlet/ServletRequest;Ljakarta/servlet/ServletResponse;Ljava/lang/String;Ljakarta/servlet/jsp/JspWriter;Z)V");
     }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/jsp/JstlOutDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/jsp/JstlOutDetector.java
@@ -67,7 +67,7 @@ public class JstlOutDetector implements Detector {
         JavaClass javaClass = classContext.getJavaClass();
 
         try {
-            if(!Hierarchy.isSubtype(javaClass.getClassName(), "javax.servlet.http.HttpServlet")) {
+            if(!isHttpServletSubtype(javaClass)) {
                 return;
             }
         } catch (ClassNotFoundException e) {
@@ -80,6 +80,11 @@ public class JstlOutDetector implements Detector {
             } catch (DataflowAnalysisException e) {
             }
         }
+    }
+
+    private boolean isHttpServletSubtype(JavaClass javaClass) throws ClassNotFoundException {
+        return Hierarchy.isSubtype(javaClass.getClassName(), "javax.servlet.http.HttpServlet") ||
+                Hierarchy.isSubtype(javaClass.getClassName(), "jakarta.servlet.http.HttpServlet");
     }
 
     private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException, DataflowAnalysisException {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/jsp/XslTransformJspDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/jsp/XslTransformJspDetector.java
@@ -54,7 +54,7 @@ public class XslTransformJspDetector implements Detector {
     public void visitClassContext(ClassContext classContext) {
         JavaClass javaClass = classContext.getJavaClass();
         try {
-            if (!Hierarchy.isSubtype(javaClass.getClassName(), "javax.servlet.http.HttpServlet")) {
+            if (!isHttpServletSubtype(javaClass)) {
                 return;
             }
         } catch (ClassNotFoundException e) {
@@ -67,6 +67,11 @@ public class XslTransformJspDetector implements Detector {
                 AnalysisContext.logError("Cannot analyze method", e);
             }
         }
+    }
+
+    private boolean isHttpServletSubtype(JavaClass javaClass) throws ClassNotFoundException {
+        return Hierarchy.isSubtype(javaClass.getClassName(), "javax.servlet.http.HttpServlet") ||
+                Hierarchy.isSubtype(javaClass.getClassName(), "jakarta.servlet.http.HttpServlet");
     }
 
     private void analyzeMethod(Method m, ClassContext classContext) throws CFGBuilderException, DataflowAnalysisException {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetector.java
@@ -50,6 +50,7 @@ public class SpringEntityLeakDetector implements Detector {
 
 	private static final List<String> ENTITY_ANNOTATION_TYPES = Arrays.asList(
 			"Ljavax/persistence/Entity;",
+			"Ljakarta/persistence/Entity;",
 			"Ljavax/jdo/spi/PersistenceCapable;",
 			"Lorg/springframework/data/mongodb/core/mapping/Document;");
 

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/xss/XSSRequestWrapperDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/xss/XSSRequestWrapperDetector.java
@@ -51,7 +51,8 @@ public class XSSRequestWrapperDetector implements Detector {
         JavaClass javaClass = classContext.getJavaClass();
 
         //The class extends HttpServletRequestWrapper
-        boolean isRequestWrapper = InterfaceUtils.isSubtype(javaClass, "javax.servlet.http.HttpServletRequestWrapper");
+        boolean isRequestWrapper = InterfaceUtils.isSubtype(javaClass, "javax.servlet.http.HttpServletRequestWrapper") ||
+                InterfaceUtils.isSubtype(javaClass, "jakarta.servlet.http.HttpServletRequestWrapper");
 
         //Not the target of this detector
         if (!isRequestWrapper) return;

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/xss/XssServletDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/xss/XssServletDetector.java
@@ -30,10 +30,14 @@ public class XssServletDetector extends BasicInjectionDetector {
 
     private static final String XSS_SERVLET_TYPE = "XSS_SERVLET";
     private static final String[] REQUIRED_CLASSES = {
-        "Ljavax/servlet/http/ServletResponse;",
-        "Ljavax/servlet/http/ServletResponseWrapper;",
+        "Ljavax/servlet/ServletResponse;",
+        "Ljakarta/servlet/ServletResponse;",
+        "Ljavax/servlet/ServletResponseWrapper;",
+        "Ljakarta/servlet/ServletResponseWrapper;",
         "Ljavax/servlet/http/HttpServletResponse;",
+        "Ljakarta/servlet/http/HttpServletResponse;",
         "Ljavax/servlet/http/HttpServletResponseWrapper;",
+        "Ljakarta/servlet/http/HttpServletResponseWrapper;",
         "Lorg/apache/jetspeed/portlet/PortletResponse;",
         "Lorg/apache/jetspeed/portlet/PortletResponseWrapper;",
         "Ljavax/portlet/RenderResponse;",

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/PermissiveCORSDetectorTest.java
@@ -93,4 +93,23 @@ public class PermissiveCORSDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectJakartaPermissiveCORS() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cors/JakartaPermissiveCORS")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("PERMISSIVE_CORS")
+                        .inClass("JakartaPermissiveCORS").inMethod("addPermissiveCORS").atLine(19)
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/ReDosDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/ReDosDetectorTest.java
@@ -112,4 +112,25 @@ public class ReDosDetectorTest extends BaseDetectorTest {
         );
     }
 
+    @Test
+    public void detectJakartaRedosInAnnotation() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/JakartaRedosInPatternAnnotation.java")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Field with a Pattern initialize on instantiation
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("REDOS")
+                        .inClass("JakartaRedosInPatternAnnotation")
+                        .atField("email")
+                        .build()
+        );
+    }
+
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/UnvalidatedRedirectDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/UnvalidatedRedirectDetectorTest.java
@@ -59,4 +59,26 @@ public class UnvalidatedRedirectDetectorTest extends BaseDetectorTest {
                 bugDefinition().bugType("UNVALIDATED_REDIRECT").build()
         );
     }
+
+    @Test
+    public void detectJakartaUnvalidatedRedirect() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/JakartaUnvalidatedRedirectServlet")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("UNVALIDATED_REDIRECT")
+                        .inClass("JakartaUnvalidatedRedirectServlet")
+                        .inMethod("unvalidatedRedirect1")
+                        .withPriority("Medium")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieFlagsDetectorTest.java
@@ -154,4 +154,70 @@ public class CookieFlagsDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectSecureFlagJakartaCookie() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/JakartaInsecureCookieSamples")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("JakartaInsecureCookieSamples").inMethod("unsafeJakartaCookie1")
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("JakartaInsecureCookieSamples").inMethod("unsafeJakartaCookie2")
+                        .build()
+        );
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("INSECURE_COOKIE")
+                        .inClass("JakartaInsecureCookieSamples").inMethod("safeJakartaCookie")
+                        .build()
+        );
+    }
+
+    @Test
+    public void detectHttpOnlyJakartaCookie() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/JakartaHttpOnlyCookieSamples")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("JakartaHttpOnlyCookieSamples").inMethod("unsafeJakartaCookie1")
+                        .build()
+        );
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("JakartaHttpOnlyCookieSamples").inMethod("unsafeJakartaCookie2")
+                        .build()
+        );
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("HTTPONLY_COOKIE")
+                        .inClass("JakartaHttpOnlyCookieSamples").inMethod("safeJakartaCookie")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieReadDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/CookieReadDetectorTest.java
@@ -48,4 +48,25 @@ public class CookieReadDetectorTest extends BaseDetectorTest {
             );
         }
     }
+
+    @Test
+    public void detectJakartaCookieUsage() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/JakartaCookieUsage")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (Integer line : Arrays.asList(15, 16, 17)) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("COOKIE_USAGE")
+                            .inClass("JakartaCookieUsage").inMethod("doGet").atLine(line)
+                            .build()
+            );
+        }
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/PersistentCookieDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/PersistentCookieDetectorTest.java
@@ -57,4 +57,36 @@ public class PersistentCookieDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectJakartaPersistentCookieUsage() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/JakartaPersistentCookie")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("COOKIE_PERSISTENT")
+                        .inClass("JakartaPersistentCookie").inMethod("setCookieFor1DayUnitConfusion").atLine(30)
+                        .build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("COOKIE_PERSISTENT")
+                        .inClass("JakartaPersistentCookie").inMethod("setCookieFor1Year").atLine(35)
+                        .build()
+        );
+
+        //Total bugs found
+        verify(reporter, times(2)).doReportBug(
+                bugDefinition()
+                        .bugType("COOKIE_PERSISTENT")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/cookie/UrlRewritingDetectorTest.java
@@ -73,4 +73,24 @@ public class UrlRewritingDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectJakartaUrlRewriting() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/cookie/JakartaUrlRewriting")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //1rst variation encodeURL(req.getRequestURI())
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("URL_REWRITING")
+                        .inClass("JakartaUrlRewriting").inMethod("encodeURLRewrite").atLine(17)
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/JaxRsEndpointDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/JaxRsEndpointDetectorTest.java
@@ -46,4 +46,25 @@ public class JaxRsEndpointDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectJakartaRsEndpoint() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/endpoint/JakartaRsService")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("JAXRS_ENDPOINT")
+                        .inClass("JakartaRsService").inMethod("hello")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/JaxWsEndpointDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/JaxWsEndpointDetectorTest.java
@@ -52,4 +52,31 @@ public class JaxWsEndpointDetectorTest extends BaseDetectorTest {
                         .build()
         );
     }
+
+    @Test
+    public void detectJakartaWsEndpoint() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/endpoint/JakartaWsService")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("JAXWS_ENDPOINT")
+                        .inClass("JakartaWsService").inMethod("ping")
+                        .build()
+        );
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("JAXWS_ENDPOINT")
+                        .inClass("JakartaWsService").inMethod("hello")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/ServletEndpointDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/endpoint/ServletEndpointDetectorTest.java
@@ -134,4 +134,24 @@ public class ServletEndpointDetectorTest extends BaseDetectorTest {
         }
     }
 
+    @Test
+    public void detectJakartaServletParameter() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/endpoint/JakartaBasicJHttpServlet")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("SERVLET_QUERY_STRING")
+                        .inClass("JakartaBasicJHttpServlet").inMethod("doGet").atLine(13)
+                        .build()
+        );
+    }
+
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/spring/SpringEntityLeakDetectorTest.java
@@ -155,4 +155,26 @@ public class SpringEntityLeakDetectorTest extends BaseDetectorTest {
 						.build()
 		);
 	}
+
+    @Test
+    public void detectJakartaEntityLeak() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/spring/JakartaSpringEntityLeakController"),
+                getClassFilePath("testcode/spring/JakartaSampleEntity")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("ENTITY_LEAK")
+                        .inClass("JakartaSpringEntityLeakController")
+                        .inMethod("jakartaApi")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/xss/XSSRequestWrapperDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/xss/XSSRequestWrapperDetectorTest.java
@@ -77,4 +77,23 @@ public class XSSRequestWrapperDetectorTest extends BaseDetectorTest {
         );
     }
 
+    @Test
+    public void detectJakartaXssWrapper() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/xss/JakartaXSSRequestWrapper")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_REQUEST_WRAPPER")
+                        .inClass("JakartaXSSRequestWrapper")
+                        .build()
+        );
+    }
 }

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/xss/XssServletDetectorTest.java
@@ -208,4 +208,26 @@ public class XssServletDetectorTest extends BaseDetectorTest {
 
         verify(reporter, times(3)).doReportBug(bugDefinition().bugType("XSS_SERVLET").build());
     }
+
+    @Test
+    public void detectJakartaXssServlet() throws Exception {
+        // Locate test code
+        String[] files = {
+                getClassFilePath("testcode/xss/servlets/JakartaXssServlet")
+        };
+
+        // Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("XSS_SERVLET")
+                        .inClass("JakartaXssServlet")
+                        .inMethod("doGet")
+                        .atLine(16)
+                        .build()
+        );
+
+    }
 }

--- a/findsecbugs-samples-deps/src/main/java/jakarta/jws/WebMethod.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/jws/WebMethod.java
@@ -1,0 +1,18 @@
+package jakarta.jws;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface WebMethod {
+
+    String operationName() default "";
+
+    String action() default "";
+
+    boolean exclude() default false;
+
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/jws/WebService.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/jws/WebService.java
@@ -1,0 +1,23 @@
+package jakarta.jws;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.TYPE})
+public @interface WebService {
+
+    String name() default "";
+
+    String targetNamespace() default "";
+
+    String serviceName() default "";
+
+    String portName() default "";
+
+    String wsdlLocation() default "";
+
+    String endpointInterface() default "";
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/persistence/Entity.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/persistence/Entity.java
@@ -1,0 +1,4 @@
+package jakarta.persistence;
+
+public @interface Entity {
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/RequestDispatcher.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/RequestDispatcher.java
@@ -1,0 +1,13 @@
+package jakarta.servlet;
+
+import java.io.IOException;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public interface RequestDispatcher {
+
+    void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException;
+
+    void include(ServletRequest request, ServletResponse response) throws ServletException, IOException;
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/Servlet.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/Servlet.java
@@ -1,0 +1,18 @@
+package jakarta.servlet;
+
+import java.io.IOException;
+
+public interface Servlet {
+
+    public void init(ServletConfig config) throws ServletException;
+
+    public ServletConfig getServletConfig();
+
+    public void service(ServletRequest req, ServletResponse res)
+            throws ServletException, IOException;
+
+    public String getServletInfo();
+
+    public void destroy();
+}
+

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletConfig.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletConfig.java
@@ -1,0 +1,14 @@
+package jakarta.servlet;
+
+import java.util.Enumeration;
+
+public interface ServletConfig {
+
+    public String getServletName();
+
+    public ServletContext getServletContext();
+
+    public String getInitParameter(String name);
+
+    public Enumeration<String> getInitParameterNames();
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletContext.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletContext.java
@@ -1,0 +1,6 @@
+package jakarta.servlet;
+
+public interface ServletContext {
+
+    RequestDispatcher getRequestDispatcher(String path);
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletException.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletException.java
@@ -1,0 +1,8 @@
+package jakarta.servlet;
+
+public class ServletException extends Exception {
+
+    public ServletException() {}
+
+    public ServletException(Exception e) {}
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletOutputStream.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletOutputStream.java
@@ -1,0 +1,11 @@
+package jakarta.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public abstract class ServletOutputStream extends OutputStream {
+
+    public void print(String s) throws IOException { }
+
+    public void println(String s) throws IOException { }
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletRequest.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletRequest.java
@@ -1,0 +1,26 @@
+package jakarta.servlet;
+
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
+public interface ServletRequest {
+
+    String getContentType();
+
+    String getServerName();
+
+    String getParameter(String name);
+
+    Enumeration getParameterNames();
+
+    String[] getParameterValues(String name);
+
+    Map getParameterMap();
+
+    Locale getLocale();
+
+    RequestDispatcher getRequestDispatcher(String path);
+
+    ServletContext getServletContext();
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletRequestWrapper.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletRequestWrapper.java
@@ -1,0 +1,57 @@
+package jakarta.servlet;
+
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
+public class ServletRequestWrapper implements ServletRequest {
+
+    public ServletRequestWrapper(ServletRequest servletRequest) {
+
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public String getServerName() {
+        return null;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration getParameterNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return new String[0];
+    }
+
+    @Override
+    public Map getParameterMap() {
+        return null;
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletResponse.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/ServletResponse.java
@@ -1,0 +1,13 @@
+package jakarta.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public interface ServletResponse {
+
+    PrintWriter getWriter() throws IOException;
+
+    ServletOutputStream getOutputStream() throws IOException;
+
+    void setContentType(String contentType);
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/Cookie.java
@@ -1,0 +1,84 @@
+package jakarta.servlet.http;
+
+public class Cookie {
+
+    private String name;
+    private String value;
+    private String path;
+    private int maxAge;
+    private String domain;
+    private int version;
+    private boolean secure;
+    private boolean httpOnly;
+
+    public Cookie(String name, String value) {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public int getMaxAge() {
+        return maxAge;
+    }
+
+    public void setMaxAge(int maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public boolean getSecure() {
+        return secure;
+    }
+
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+    public void setHttpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServlet.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServlet.java
@@ -1,0 +1,15 @@
+package jakarta.servlet.http;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+
+public class HttpServlet {
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+    }
+
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -1,0 +1,24 @@
+package jakarta.servlet.http;
+
+
+import jakarta.servlet.ServletRequest;
+import java.util.Enumeration;
+
+public interface HttpServletRequest extends ServletRequest {
+
+    String getHeader(String name);
+
+    Enumeration<String> getHeaders(String name);
+
+    String getQueryString();
+
+    String getRequestedSessionId();
+
+    String getRequestURI();
+
+    Cookie[] getCookies();
+
+    HttpSession getSession();
+
+    HttpSession getSession(boolean create);
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
@@ -1,0 +1,51 @@
+package jakarta.servlet.http;
+
+import jakarta.servlet.ServletRequestWrapper;
+import java.util.Enumeration;
+
+public class HttpServletRequestWrapper extends ServletRequestWrapper implements HttpServletRequest {
+
+    public HttpServletRequestWrapper(HttpServletRequest servletRequest) {
+        super(servletRequest);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        return null;
+    }
+
+    @Override
+    public String getQueryString() {
+        return null;
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return null;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return new Cookie[0];
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        return null;
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServletResponse.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpServletResponse.java
@@ -1,0 +1,23 @@
+package jakarta.servlet.http;
+
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+
+public interface HttpServletResponse extends ServletResponse {
+
+    void addCookie(Cookie cookie);
+
+    void addHeader(String header, String value);
+    
+    void setHeader(String header, String value);
+
+    void sendRedirect(String url) throws IOException;
+
+    String encodeURL(String url);
+
+    String encodeUrl(String url);
+
+    String encodeRedirectURL(String url);
+
+    String encodeRedirectUrl(String url);
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpSession.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/servlet/http/HttpSession.java
@@ -1,0 +1,10 @@
+package jakarta.servlet.http;
+
+public interface HttpSession {
+
+    Object getAttribute(String name);
+
+    void setAttribute(String name, Object value);
+
+    void putValue(String name,Object value);
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/validation/constraints/Pattern.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/validation/constraints/Pattern.java
@@ -1,0 +1,6 @@
+package jakarta.validation.constraints;
+
+public @interface Pattern {
+    String regexp();
+
+}

--- a/findsecbugs-samples-deps/src/main/java/jakarta/ws/rs/Path.java
+++ b/findsecbugs-samples-deps/src/main/java/jakarta/ws/rs/Path.java
@@ -1,0 +1,6 @@
+package jakarta.ws.rs;
+
+public @interface Path {
+
+    String value();
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/JakartaRedosInPatternAnnotation.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/JakartaRedosInPatternAnnotation.java
@@ -1,0 +1,16 @@
+package testcode;
+
+import jakarta.validation.constraints.Pattern;
+
+public class JakartaRedosInPatternAnnotation {
+    /**
+     * <code>([ ]+)*</code> will trigger a ReDOS.
+     */
+    @Pattern (regexp = "^[\\w!#$%&’*+/=?`{|}~^-]+(?:\\.[\\w!#$%&’*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,8}$")
+    private String email;
+
+    public JakartaRedosInPatternAnnotation(String e) {
+        email = e;
+    }
+
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/JakartaUnvalidatedRedirectServlet.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/JakartaUnvalidatedRedirectServlet.java
@@ -1,0 +1,24 @@
+package testcode;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class JakartaUnvalidatedRedirectServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String url = req.getParameter("urlRedirect");
+        unvalidatedRedirect1(resp, url);
+    }
+
+    private void unvalidatedRedirect1(HttpServletResponse resp, String url) throws IOException {
+        if (url != null) {
+            resp.sendRedirect(url);
+        }
+    }
+
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaCookieUsage.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaCookieUsage.java
@@ -1,0 +1,22 @@
+package testcode.cookie;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JakartaCookieUsage extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        for (Cookie cookie : req.getCookies()) {
+            cookie.getName();
+            cookie.getValue();
+            cookie.getPath();
+        }
+
+        resp.addCookie(new Cookie("test", "value"));
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaHttpOnlyCookieSamples.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaHttpOnlyCookieSamples.java
@@ -1,0 +1,20 @@
+package testcode.cookie;
+
+import jakarta.servlet.http.Cookie;
+
+public class JakartaHttpOnlyCookieSamples {
+
+    void safeJakartaCookie() {
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setHttpOnly(true);
+    }
+
+    void unsafeJakartaCookie1() {
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setHttpOnly(false);
+    }
+
+    void unsafeJakartaCookie2() {
+        Cookie newCookie = new Cookie("test1","1234");
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaInsecureCookieSamples.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaInsecureCookieSamples.java
@@ -1,0 +1,20 @@
+package testcode.cookie;
+
+import jakarta.servlet.http.Cookie;
+
+public class JakartaInsecureCookieSamples {
+
+    void safeJakartaCookie() {
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setSecure(true);
+    }
+
+    void unsafeJakartaCookie1() {
+        Cookie newCookie = new Cookie("test1","1234");
+        newCookie.setSecure(false);
+    }
+
+    void unsafeJakartaCookie2() {
+        Cookie newCookie = new Cookie("test1","1234");
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaPersistentCookie.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaPersistentCookie.java
@@ -1,0 +1,37 @@
+package testcode.cookie;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JakartaPersistentCookie extends HttpServlet {
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        String email = req.getParameter("email");
+        if(email != null && !email.equals("")) {
+            setCookieFor1Week(email); //OK
+            setCookieFor1DayUnitConfusion(email); //BAD
+            setCookieFor1Year(email); //BAD
+        }
+    }
+
+    //3600 seconds == 1 hour
+    private void setCookieFor1Week(String email) { //Reasonable duration. No warning will be trigger
+        Cookie cookie = new Cookie("emailCookie", email);
+        cookie.setMaxAge(3600*24*7);
+    }
+
+    private void setCookieFor1DayUnitConfusion(String email) { //Example of unit confusion (sec. not ms.)
+        Cookie cookie = new Cookie("emailCookie", email);
+        cookie.setMaxAge(1000*3600*24); //Expect 24 hour, in fact 1000 day
+    }
+
+    private void setCookieFor1Year(String email) { //More than one year will be mark as potentially dangerous/unwanted
+        Cookie cookie = new Cookie("emailCookie", email);
+        cookie.setMaxAge(3600*24*365);
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaUrlRewriting.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cookie/JakartaUrlRewriting.java
@@ -1,0 +1,20 @@
+package testcode.cookie;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JakartaUrlRewriting extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        encodeURLRewrite(resp, req.getRequestURI());
+    }
+
+    private String encodeURLRewrite(HttpServletResponse resp, String url) {
+        return resp.encodeURL(url);
+    }
+
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/cors/JakartaPermissiveCORS.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/cors/JakartaPermissiveCORS.java
@@ -1,0 +1,22 @@
+package testcode.cors;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class JakartaPermissiveCORS extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        addPermissiveCORS(resp);
+    }
+
+    // Overly permissive Cross-domain requests accepted
+    public void addPermissiveCORS(HttpServletResponse resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "*");
+    }
+
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/endpoint/JakartaBasicJHttpServlet.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/endpoint/JakartaBasicJHttpServlet.java
@@ -1,0 +1,16 @@
+package testcode.endpoint;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JakartaBasicJHttpServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("<!--" + req.getQueryString() + "-->");
+    }
+
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/endpoint/JakartaRsService.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/endpoint/JakartaRsService.java
@@ -1,0 +1,16 @@
+package testcode.endpoint;
+
+import jakarta.ws.rs.Path;
+
+@Path("/test")
+public class JakartaRsService {
+
+    public String randomMethod() {
+        return "Nothing to see..";
+    }
+
+    @Path("/hello")
+    public String hello(String user) {
+        return "Hello " + user;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/endpoint/JakartaWsService.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/endpoint/JakartaWsService.java
@@ -1,0 +1,22 @@
+package testcode.endpoint;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+@WebService
+public class JakartaWsService {
+
+    @WebMethod(operationName = "timestamp")
+    public long ping() {
+        return System.currentTimeMillis();
+    }
+
+    @WebMethod
+    public String hello(String user) {
+        return "Hello " + user;
+    }
+
+    public int notAWebMethod() {
+        return 8000;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/spring/JakartaSampleEntity.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/spring/JakartaSampleEntity.java
@@ -1,0 +1,20 @@
+package testcode.spring;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class JakartaSampleEntity {
+	private String test;
+
+	public JakartaSampleEntity(String test) {
+		this.test = test;
+	}
+
+	public String getTest() {
+		return test;
+	}
+
+	public void setTest(String test) {
+		this.test = test;
+	}
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/spring/JakartaSpringEntityLeakController.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/spring/JakartaSpringEntityLeakController.java
@@ -1,0 +1,14 @@
+package testcode.spring;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class JakartaSpringEntityLeakController {
+
+    @RequestMapping("/jakartaApi")
+    public JakartaSampleEntity jakartaApi(@RequestParam("url") String url) {
+        return new JakartaSampleEntity("entity1");
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/xss/JakartaXSSRequestWrapper.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/xss/JakartaXSSRequestWrapper.java
@@ -1,0 +1,69 @@
+package testcode.xss;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.util.regex.Pattern;
+
+
+/**
+ * Taken from :
+ * <a href="http://java.dzone.com/articles/stronger-anti-cross-site"></a>
+ */
+public class JakartaXSSRequestWrapper extends HttpServletRequestWrapper {
+
+    private static Pattern[] patterns = new Pattern[]{
+            // Script fragments
+            Pattern.compile("<script>(.*?)</script>", Pattern.CASE_INSENSITIVE),
+    };
+
+    public JakartaXSSRequestWrapper(HttpServletRequest servletRequest) {
+        super(servletRequest);
+    }
+
+    @Override
+    public String[] getParameterValues(String parameter) {
+        String[] values = super.getParameterValues(parameter);
+
+        if (values == null) {
+            return null;
+        }
+
+        int count = values.length;
+        String[] encodedValues = new String[count];
+        for (int i = 0; i < count; i++) {
+            encodedValues[i] = stripXSS(values[i]);
+        }
+
+        return encodedValues;
+    }
+
+    @Override
+    public String getParameter(String parameter) {
+        String value = super.getParameter(parameter);
+
+        return stripXSS(value);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        String value = super.getHeader(name);
+        return stripXSS(value);
+    }
+
+    private String stripXSS(String value) {
+        if (value != null) {
+            // NOTE: It's highly recommended to use the ESAPI library and uncomment the following line to
+            // avoid encoded attacks.
+            // value = ESAPI.encoder().canonicalize(value);
+
+            // Avoid null characters
+            value = value.replaceAll("\0", "");
+
+            // Remove all sections that match a pattern
+            for (Pattern scriptPattern : patterns) {
+                value = scriptPattern.matcher(value).replaceAll("");
+            }
+        }
+        return value;
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/xss/servlets/JakartaXssServlet.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/xss/servlets/JakartaXssServlet.java
@@ -1,0 +1,18 @@
+package testcode.xss.servlets;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class JakartaXssServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String input1 = req.getParameter("input1");
+
+        resp.getWriter().write(input1);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
                         <exclude>**/java/android/**/**.java</exclude>
                         <exclude>**/com/hazelcast/**/**.java</exclude>
                         <exclude>**/javax/**/**.java</exclude>
+                        <exclude>**/jakarta/**/**.java</exclude>
                         <exclude>**/org/opensaml/xml/**/**.java</exclude>
                         <exclude>**/org/acegisecurity/**/**.java</exclude>
                         <exclude>**/org/apache/**/**.java</exclude>


### PR DESCRIPTION
This PR adds support for  `jakarta.*` for detectors that work with the old `javax.*` classes (Cookie, HttpServlet, Entity, etc.).
Unit tests have been added, except for jsp detectors that I think would require setting up a different jsp compilation (with a newer compiler).