### PR TITLE
Replace deprecated tasks with target in maven-antrun-plugin

### DIFF
--- a/findsecbugs-plugin/pom.xml
+++ b/findsecbugs-plugin/pom.xml
@@ -48,11 +48,11 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <copy todir="${project.build.outputDirectory}">
                                     <fileset dir="${project.build.outputDirectory}/metadata" />
                                 </copy>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
When I tried to run `mvn clean install` locally, the build failed and maven complained about `tasks` being deprecated and removed:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (ant-magic) on project findsecbugs-plugin: You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and 
refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site. -> [Help 1]
```
See https://maven.apache.org/plugins/maven-antrun-plugin/
This PR solves this issue.