### PR TITLE
Local build fails after #740

### DIFF
--- a/findsecbugs-plugin/pom.xml
+++ b/findsecbugs-plugin/pom.xml
@@ -39,7 +39,9 @@
             </plugin>
             <!-- Moving findbugs config to root -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>ant-magic</id>
@@ -194,7 +196,7 @@
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.h3xstream.findsecbugs</groupId>
             <artifactId>findsecbugs-samples-deps</artifactId>


### PR DESCRIPTION
The PR #740 renamed ant `tasks` to maven `target` that requires `maven-antrun-plugin:3.0.0` or higher. 

My local env build fails, mvn doesn't download the latest dependency. Requiring the version manually fixes the problem.