### PR TITLE
Misinterpreting invokedynamic causes "missing class" warning

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractTaintDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractTaintDetector.java
@@ -32,6 +32,7 @@ import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import java.util.Iterator;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -114,7 +115,7 @@ public abstract class AbstractTaintDetector implements Detector {
             Location location = i.next();
             InstructionHandle handle = location.getHandle();
             Instruction instruction = handle.getInstruction();
-            if (!(instruction instanceof InvokeInstruction)) {
+            if (!(instruction instanceof InvokeInstruction) || instruction instanceof INVOKEDYNAMIC) {
                 continue;
             }
             InvokeInstruction invoke = (InvokeInstruction) instruction;

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/serial/ObjectDeserializationDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/serial/ObjectDeserializationDetector.java
@@ -30,6 +30,7 @@ import edu.umd.cs.findbugs.ba.bcp.Invoke;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.INVOKEDYNAMIC;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -98,7 +99,7 @@ public class ObjectDeserializationDetector implements Detector {
             Instruction inst = location.getHandle().getInstruction();
 
             //
-            if (inst instanceof InvokeInstruction) {
+            if (inst instanceof InvokeInstruction && !(inst instanceof INVOKEDYNAMIC)) {
                 InvokeInstruction invoke = (InvokeInstruction) inst;
 
                 String className = invoke.getClassName(cpg);


### PR DESCRIPTION
When analyzing Java bytecode for "invoke" instructions, we assumed that there always was a valid class name specified when calling InvokeInstruction#getClassName.

Unfortunately, this is not true for "invokedynamic" calls, where BCEL repurposes this method to get the method name.

This leads to confusing warnings of the type "The following classes needed for analysis were missing: makeConcatWithConstants", etc.

Add code that checks for the INVOKEDYNAMIC subclass, skipping these instructions whenever necessary.

Fixes #332