### PR TITLE
Remove array signature from classname

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/common/ByteCode.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/common/ByteCode.java
@@ -169,4 +169,22 @@ public class ByteCode {
         return null;
     }
 
+    /**
+     * Strips the array marker from a class signature, e.g., {@code [Ljava.lang.String;} becomes
+     * {@code java.lang.String}.
+     *
+     * @param className The "classname" string as returned from
+     *          {@link InvokeInstruction#getClassName(ConstantPoolGen)}.
+     * @return The sanitized class name.
+     */
+    public static String stripObjectArrayFromClassName(String className) {
+      if (className.endsWith(";") && className.startsWith("[L")) {
+        className = className.substring(0, className.length() - 1);
+        while (className.indexOf('[') == 0) {
+          className = className.substring(1);
+        }
+        className = className.substring(1);
+      }
+      return className;
+    }
 }

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/common/InterfaceUtils.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/common/InterfaceUtils.java
@@ -52,6 +52,11 @@ public class InterfaceUtils {
      * @return
      */
     public static boolean isSubtype(String className, String... superClasses) {
+        className = ByteCode.stripObjectArrayFromClassName(className);
+        if (className.startsWith("[")) {
+            // an array of a non-object type
+            return false;
+        }
         for(String potentialSuperClass : superClasses) {
             try {
                 if(Hierarchy.isSubtype(className, potentialSuperClass)) {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractInjectionDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/AbstractInjectionDetector.java
@@ -18,6 +18,7 @@
 package com.h3xstream.findsecbugs.injection;
 
 import com.h3xstream.findsecbugs.BCELUtil;
+import com.h3xstream.findsecbugs.common.ByteCode;
 import com.h3xstream.findsecbugs.taintanalysis.Taint;
 import com.h3xstream.findsecbugs.taintanalysis.TaintFrame;
 import edu.umd.cs.findbugs.BugReporter;
@@ -202,11 +203,17 @@ public abstract class AbstractInjectionDetector extends AbstractTaintDetector {
             return getMethodAndSinks(classMethodSignature, sinks);
         }
         try {
-            if (classMethodSignature.getClassName().endsWith("]")) {
+            String className = classMethodSignature.getClassName();
+            if (className.endsWith("]")) {
                 // not a real class
                 return Collections.emptySet();
             }
-            JavaClass javaClass = Repository.lookupClass(classMethodSignature.getClassName());
+            className = ByteCode.stripObjectArrayFromClassName(className);
+            if (className.startsWith("[")) {
+              // an array of a non-object type
+              return Collections.emptySet();
+            }
+            JavaClass javaClass = Repository.lookupClass(className);
             assert javaClass != null;
             return getSuperSinks(javaClass, classMethodSignature);
         } catch (ClassNotFoundException ex) {

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
@@ -19,6 +19,7 @@ package com.h3xstream.findsecbugs.injection;
 
 import com.h3xstream.findsecbugs.BCELUtil;
 import com.h3xstream.findsecbugs.FindSecBugsGlobalConfig;
+import com.h3xstream.findsecbugs.common.ByteCode;
 import com.h3xstream.findsecbugs.taintanalysis.TaintDataflowEngine;
 import com.h3xstream.findsecbugs.taintanalysis.TaintFrameAdditionalVisitor;
 import edu.umd.cs.findbugs.BugReporter;
@@ -35,6 +36,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Signature;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;
@@ -76,7 +78,12 @@ public abstract class BasicInjectionDetector extends AbstractInjectionDetector {
 
         try {
             //2. Verify if the super classes match a known sink
-            JavaClass classDef = Repository.lookupClass(invoke.getClassName(cpg));
+            String className = ByteCode.stripObjectArrayFromClassName(invoke.getClassName(cpg));
+            if (className.startsWith("[")) {
+                // an array of a non-object type
+                return InjectionPoint.NONE;
+            }
+            JavaClass classDef = Repository.lookupClass(className);
             Set<String> parentClassNames = BCELUtil.getParentClassNames(classDef);
             for (String parentClassName : parentClassNames) {
                 classMethodSignature.setClassName(parentClassName);


### PR DESCRIPTION
When looking up a class name, we sometimes mistake an array type for a simple classname, causing a subsequent class lookup to fail.

That failure is reported to Spotbugs, but apparently ignored internally.

Instead of ignoring this, we should try to extract the simple class type, and check this one instead.

Fixes #751