### PR TITLE
update gha actions/cache from v1 to v4

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
The `Java CI with SpotBugs` gha [fails](https://github.com/find-sec-bugs/find-sec-bugs/actions/runs/13926749724/job/38973199255) with the following message:
```
Error: Missing download info for actions/cache@v1
```

This is because the actions/cache v1 and v2 got [deprecated](https://github.com/actions/cache/discussions/1510) and [closed down](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down).
This PR updates the version of this cache service.

The job still fails on my fork, but at a later stage, when running the spotbugs gha. If I'm not mistaken, it's because I don't have some token set up or the appropriate permissions.