### PR TITLE
update SpotBugs and SpotBugs maven plugin versions

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -20,7 +20,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build with Maven
-      run: mvn clean install -DskipTests com.github.spotbugs:spotbugs-maven-plugin:4.8.6.1:spotbugs
+      run: mvn clean install -DskipTests com.github.spotbugs:spotbugs-maven-plugin:4.9.3.0:spotbugs
     - uses: jwgmeligmeyling/spotbugs-github-action@master
       with:
         path: '**/spotbugsXml.xml'

--- a/cli/gradle.properties
+++ b/cli/gradle.properties
@@ -1,2 +1,2 @@
 fsbVersion=1.12.0
-spotbugsVersion=4.8.6
+spotbugsVersion=4.9.3

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.8.6.1</version>
+                        <version>4.9.3.0</version>
                         <configuration>
                             <xmlOutput>true</xmlOutput>
                             <failOnError>false</failOnError>
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs</artifactId>
-                <version>4.8.6</version>
+                <version>4.9.3</version>
             </dependency>
 
             <!-- Artefact definition of the module -->


### PR DESCRIPTION
The latest SpotBugs and SpotBugs maven plugin versions are [4.9.3](https://github.com/spotbugs/spotbugs/releases/tag/4.9.3) and [4.9.3.0](https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.9.3.0). This PR updates to these versions.