### PR TITLE
update dependency versions and fix dep vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,21 +286,21 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.3.1</version>
+                <version>5.17.0</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
-                <version>2.2</version>
+                <version>3.0</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.4.0</version>
+                <version>7.11.0</version>
                 <scope>test</scope>
             </dependency>
 
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.19.0</version>
                 <scope>test</scope>
             </dependency>
 
@@ -324,7 +324,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.3</version>
+                <version>1.5.18</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Updating dependencies to the latest versions and with this getting rid of the following vulnerabilities from dependencies:
CVE-2024-47554 in Apache Commons IO 
CVE-2023-6378 in ch.qos.logback:logback-classic
CVE-2022-4065 in org.testng:testng