### PR TITLE
modify spotbugs-maven-plugin from nonexistent version to existing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.8.6</version>
+                        <version>4.8.6.6</version>
                         <configuration>
                             <xmlOutput>true</xmlOutput>
                             <failOnError>false</failOnError>


### PR DESCRIPTION
There is no 4.8.6 version in spotbugs-maven-plugin (modified in https://github.com/find-sec-bugs/find-sec-bugs/commit/ba1fa607d0640fda8a26e5479c87c1a98394c6d3). The latest spotbugs-maven-plugin supporting SpotBugs 4.8.6 is [4.8.6.6](https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.8.6.6).
There are already newer versions of both SpotBugs and SpotBugs maven plugin, but SpotBugs 4.9.0 requires Java 11 for the build, and that may need other modifications.
Run `mvn clean install` locally on both master and the branch. In both cases two tests failed with the same reasons, `CrlfLogInjectionDetectorTest` and `SinkFilesValidationTest`.