### PR TITLE
fix CrlfInjectionDetectorTest fail by adding kotlin/jvm/internal/Intrinsics.checkNotNullExpressionValue to taint config

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -67,6 +67,7 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
         "java-lang.txt",
         "java-net.txt",
         "jetty.txt",
+        "kotlin.txt",
         "logging.txt",
         "other.txt",
         "portlet.txt",

--- a/findsecbugs-plugin/src/main/resources/taint-config/kotlin.txt
+++ b/findsecbugs-plugin/src/main/resources/taint-config/kotlin.txt
@@ -1,0 +1,2 @@
+-- Kotlin checks objects for null. A String is immutable, but the signature is java.lang.Object, so we have to tell the engine.
+kotlin/jvm/internal/Intrinsics.checkNotNullExpressionValue(Ljava/lang/Object;Ljava/lang/String;)V:UNKNOWN


### PR DESCRIPTION
Based on @jbindel's comment at https://github.com/find-sec-bugs/find-sec-bugs/issues/736#issuecomment-2469394460 , I added a `kotlin.txt` file to taint config.
There are other methods in `kotlin.jvm.internal.Intrinsics` ([src](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/Intrinsics.java)), which could be added, but I am not familiar enough with taint analysis to add them properly.
This fixes https://github.com/find-sec-bugs/find-sec-bugs/issues/736. Tried it locally and `mvn clean install` was successful if `SinkFilesValidationTest` ([src](https://github.com/find-sec-bugs/find-sec-bugs/blob/master/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/SinkFilesValidationTest.java)) was disabled, but that test is failing on the master as well. 

On my fork the [ci-with-fixes](https://github.com/JuditKnoll/find-sec-bugs/tree/ci-with-fixes) ([compare with master](https://github.com/find-sec-bugs/find-sec-bugs/compare/master...JuditKnoll:find-sec-bugs:ci-with-fixes)) branch contains the commits from this, https://github.com/find-sec-bugs/find-sec-bugs/pull/770 and https://github.com/find-sec-bugs/find-sec-bugs/pull/771 PRs cherry-picked. There the [ci](https://github.com/JuditKnoll/find-sec-bugs/actions/runs/18687781877/job/53285083665) running `mvn clean install` is successful.

Co-authored-by: @jbindel 

Please let me know if I missed anything or something should be different.