### PR TITLE
fix SinkFilesValidationTest fail by adding jakarta to skip check

### DIFF
--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/BaseConfigValidation.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/taintanalysis/BaseConfigValidation.java
@@ -47,6 +47,7 @@ public class BaseConfigValidation {
         if(className.startsWith("play.")) return; //Temporary skip Play
         if(className.startsWith("anorm")) return; //Skipping Scala anorm library classes
         if(className.startsWith("slick")) return; //Skipping Scala slick library classes
+        if(className.startsWith("jakarta")) return; //Skipping Jakarta library classes
         if(className.contains(".log")) return;
         if(className.contains(".Log")) return;
         try {


### PR DESCRIPTION
Since https://github.com/find-sec-bugs/find-sec-bugs/pull/743 the `SinkFilesValidationTest` (src) fails with the following exception:
```
java.lang.AssertionError: Configurations were added for a class that does not exist. It is likely a typographical error or because the API was not tested. [!] Class not found jakarta.activation.FileDataSource (path-traversal-in.txt)

	at org.testng.Assert.fail(Assert.java:111)
	at com.h3xstream.findsecbugs.taintanalysis.BaseConfigValidation.validateClass(BaseConfigValidation.java:57)
	at com.h3xstream.findsecbugs.injection.SinkFilesValidationTest$1.receiveInjectionPoint(SinkFilesValidationTest.java:56)
	at com.h3xstream.findsecbugs.injection.SinksLoader.addSink(SinksLoader.java:101)
	at com.h3xstream.findsecbugs.injection.SinksLoader.loadSink(SinksLoader.java:88)
	at com.h3xstream.findsecbugs.injection.SinksLoader.loadSinks(SinksLoader.java:61)
	at com.h3xstream.findsecbugs.injection.SinksLoader.loadConfiguredSinks(SinksLoader.java:43)
	at com.h3xstream.findsecbugs.injection.SinkFilesValidationTest.validateSinks(SinkFilesValidationTest.java:47)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:687)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:230)
	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:63)
	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:995)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:203)
	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:154)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:134)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.testng.TestRunner.privateRun(TestRunner.java:741)
	at org.testng.TestRunner.run(TestRunner.java:616)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:421)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:413)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:373)
	at org.testng.SuiteRunner.run(SuiteRunner.java:312)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1274)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1208)
	at org.testng.TestNG.runSuites(TestNG.java:1112)
	at org.testng.TestNG.run(TestNG.java:1079)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:65)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
```

This PR adds jakarta library classes to the list of classes to skip during the validation, since FindSecBugs include jakarta and can't find it, just like @jbindel already mentioned in https://github.com/find-sec-bugs/find-sec-bugs/pull/743#issuecomment-2864648715.

With this fix if the `CrlfLogInjectionDetectorTest#detectResponseSplittingKotlin` ([src](https://github.com/find-sec-bugs/find-sec-bugs/blob/master/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/crlf/CrlfLogInjectionDetectorTest.java#L51)) test is disabled or with the changes in https://github.com/find-sec-bugs/find-sec-bugs/pull/769 applied, the `mvn clean install` command runs successfully on my local machine.

On my fork the [ci-with-fixes](https://github.com/JuditKnoll/find-sec-bugs/tree/ci-with-fixes) ([compare with master](https://github.com/find-sec-bugs/find-sec-bugs/compare/master...JuditKnoll:find-sec-bugs:ci-with-fixes)) branch contains the commits from this, https://github.com/find-sec-bugs/find-sec-bugs/pull/769 and https://github.com/find-sec-bugs/find-sec-bugs/pull/771 PRs cherry-picked. There the [ci](https://github.com/JuditKnoll/find-sec-bugs/actions/runs/18687781877/job/53285083665) is successful.