### PR TITLE
Add build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  [push, pull_request]
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} with Java ${{ matrix.java }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [11, 17, 21]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      - name: Cache Maven local repository
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn clean install


### PR DESCRIPTION
This PR adds a simple build CI job with several Java versions and OSes.
The [spotbugs.yml](https://github.com/find-sec-bugs/find-sec-bugs/blob/master/.github/workflows/spotbugs.yml) job is quite similar, but that one fails on forks, because it can't find the `spotbugsXml.xml` file (error: `Error: HttpError: Resource not accessible by integration`), so it can be a bit misleading.
This ci job also runs on PRs as well, not only on pushes.

Currently this job fails on current master, because some tests are failing. The fixes to those tests can be found in https://github.com/find-sec-bugs/find-sec-bugs/pull/769 and https://github.com/find-sec-bugs/find-sec-bugs/pull/770.
On my fork the [ci-with-fixes](https://github.com/JuditKnoll/find-sec-bugs/tree/ci-with-fixes) ([compare with master](https://github.com/find-sec-bugs/find-sec-bugs/compare/master...JuditKnoll:find-sec-bugs:ci-with-fixes)) branch contains the commits from these PRs cherry-picked. There the [ci](https://github.com/JuditKnoll/find-sec-bugs/actions/runs/18687781877/job/53285083665) is successful.

The goal of this PR is to help prevent merging build failure causing PRs.