### PR TITLE
remove usages of deprecated `edu.umd.cs.findbugs.io.IO#close(InputStream)`

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/injection/BasicInjectionDetector.java
@@ -24,7 +24,6 @@ import com.h3xstream.findsecbugs.taintanalysis.TaintDataflowEngine;
 import com.h3xstream.findsecbugs.taintanalysis.TaintFrameAdditionalVisitor;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.ba.AnalysisContext;
-import edu.umd.cs.findbugs.io.IO;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,7 +35,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
-import org.apache.bcel.classfile.Signature;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InvokeInstruction;

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintAnalysis.java
@@ -30,7 +30,6 @@ import edu.umd.cs.findbugs.ba.generic.GenericSignatureParser;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
 import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 import edu.umd.cs.findbugs.classfile.analysis.MethodInfo;
-import edu.umd.cs.findbugs.io.IO;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.IAnalysisCache;
 import edu.umd.cs.findbugs.classfile.IMethodAnalysisEngine;
 import edu.umd.cs.findbugs.classfile.MethodDescriptor;
-import edu.umd.cs.findbugs.io.IO;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -148,14 +147,10 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
     }
     
     private void addCustomConfig(String path) {
-        InputStream stream = null;
-        try {
-            File file = new File(path);
-            if (file.exists()) {
-                stream = new FileInputStream(file);
-            } else {
-                stream = getClass().getClassLoader().getResourceAsStream(path);
-            }
+        File file = new File(path);
+        try (InputStream stream = file.exists()
+                ? new FileInputStream(file)
+                : getClass().getClassLoader().getResourceAsStream(path)) {
             if (stream == null) {
                 String message = String.format("Could not add custom config. "
                         + "Neither file %s nor resource matching %s found.",
@@ -166,8 +161,6 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
             LOGGER.log(Level.INFO, "Custom taint config loaded from {0}", path);
         } catch (IOException ex) {
             throw new RuntimeException("Cannot load custom taint config from " + path, ex);
-        } finally {
-            IO.close(stream);
         }
     }
     


### PR DESCRIPTION
In SpotBugs the `edu.umd.cs.findbugs.io.IO#close(InputStream)` function was removed a bit too eagerly causing https://github.com/find-sec-bugs/find-sec-bugs/issues/766, then it was added back as deprecated. This PR removes the usages of this function, so it won't cause problems later on. The `edu.umd.cs.findbugs.io.IO` imports in the `BasicInjectionDetector` and the `TaintAnalysis` classes were unused ones, so I also removed them. Other than these, I couldn't find other usages of `edu.umd.cs.findbugs.io`.
So this PR fixes https://github.com/find-sec-bugs/find-sec-bugs/issues/766 .

The [io-close-remove-with-ci](https://github.com/JuditKnoll/find-sec-bugs/tree/io-close-remove-with-ci) branch ([compare with master](https://github.com/find-sec-bugs/find-sec-bugs/compare/master...JuditKnoll:find-sec-bugs:io-close-remove-with-ci)) on my fork contains the build fixes from https://github.com/find-sec-bugs/find-sec-bugs/pull/669 and https://github.com/find-sec-bugs/find-sec-bugs/pull/770, and the build ci from https://github.com/find-sec-bugs/find-sec-bugs/pull/771 with the commits from this PR cherry-picked. See [here](https://github.com/JuditKnoll/find-sec-bugs/actions/runs/18879375395/job/53877878523) that the ci build is successful.