### PR TITLE
Mark Spring Environment.getProperty as SAFE to avoid path traversal false positives

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintDataflowEngine.java
@@ -72,6 +72,7 @@ public class TaintDataflowEngine implements IMethodAnalysisEngine<TaintDataflow>
         "portlet.txt",
         "scala.txt",
         "sonarqube.txt",
+        "spring.txt",
         "struts2-taint.txt",
         "wicket.txt",
     };

--- a/findsecbugs-plugin/src/main/resources/taint-config/spring.txt
+++ b/findsecbugs-plugin/src/main/resources/taint-config/spring.txt
@@ -1,0 +1,19 @@
+- Spring Environment and PropertyResolver return server-side configuration values,
+- not user-supplied input. Marking as SAFE to avoid false positives in path traversal
+- and other injection detectors.
+
+org/springframework/core/env/PropertyResolver.getProperty(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/PropertyResolver.getProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/PropertyResolver.getProperty(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;:SAFE
+org/springframework/core/env/PropertyResolver.getProperty(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Object;)Ljava/lang/Object;:SAFE
+org/springframework/core/env/PropertyResolver.getRequiredProperty(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/PropertyResolver.getRequiredProperty(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;:SAFE
+org/springframework/core/env/PropertyResolver.resolvePlaceholders(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/PropertyResolver.resolveRequiredPlaceholders(Ljava/lang/String;)Ljava/lang/String;:SAFE
+
+org/springframework/core/env/Environment.getProperty(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/Environment.getProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/Environment.getProperty(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;:SAFE
+org/springframework/core/env/Environment.getProperty(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Object;)Ljava/lang/Object;:SAFE
+org/springframework/core/env/Environment.getRequiredProperty(Ljava/lang/String;)Ljava/lang/String;:SAFE
+org/springframework/core/env/Environment.getRequiredProperty(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;:SAFE

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/file/SpringEnvironmentSafeTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/file/SpringEnvironmentSafeTest.java
@@ -1,0 +1,68 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.file;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test that Spring Environment.getProperty() values are treated as SAFE
+ * and do not trigger PATH_TRAVERSAL_IN false positives.
+ * Issue #776: Mark Spring Environment.getProperty as SAFE
+ */
+public class SpringEnvironmentSafeTest extends BaseDetectorTest {
+
+    @Test
+    public void avoidFpWithEnvironmentGetProperty() throws Exception {
+        String[] files = {
+                getClassFilePath("testcode/pathtraversal/SpringEnvironmentSafe")
+        };
+
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("PATH_TRAVERSAL_IN")
+                        .inClass("SpringEnvironmentSafe")
+                        .inMethod("safePropertyUsage")
+                        .build()
+        );
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("PATH_TRAVERSAL_IN")
+                        .inClass("SpringEnvironmentSafe")
+                        .inMethod("safePropertyWithDefault")
+                        .build()
+        );
+
+        verify(reporter, never()).doReportBug(
+                bugDefinition()
+                        .bugType("PATH_TRAVERSAL_IN")
+                        .inClass("SpringEnvironmentSafe")
+                        .inMethod("safeRequiredProperty")
+                        .build()
+        );
+    }
+}

--- a/findsecbugs-samples-deps/src/main/java/org/springframework/core/env/Environment.java
+++ b/findsecbugs-samples-deps/src/main/java/org/springframework/core/env/Environment.java
@@ -1,0 +1,7 @@
+package org.springframework.core.env;
+
+public interface Environment {
+    String getProperty(String key);
+    String getProperty(String key, String defaultValue);
+    String getRequiredProperty(String key);
+}

--- a/findsecbugs-samples-deps/src/main/java/org/springframework/core/env/PropertyResolver.java
+++ b/findsecbugs-samples-deps/src/main/java/org/springframework/core/env/PropertyResolver.java
@@ -1,0 +1,9 @@
+package org.springframework.core.env;
+
+public interface PropertyResolver {
+    String getProperty(String key);
+    String getProperty(String key, String defaultValue);
+    <T> T getProperty(String key, Class<T> targetType);
+    <T> T getProperty(String key, Class<T> targetType, T defaultValue);
+    String getRequiredProperty(String key);
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/pathtraversal/SpringEnvironmentSafe.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/pathtraversal/SpringEnvironmentSafe.java
@@ -1,0 +1,34 @@
+package testcode.pathtraversal;
+
+import org.springframework.core.env.Environment;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+public class SpringEnvironmentSafe {
+
+    private Environment env;
+
+    /**
+     * Using Environment.getProperty() to build a file path is safe because
+     * the value comes from server-side configuration, not user input.
+     */
+    public void safePropertyUsage() throws FileNotFoundException {
+        String basePath = env.getProperty("app.upload.dir");
+        File file = new File(basePath, "report.pdf");
+        new FileInputStream(file);
+    }
+
+    public void safePropertyWithDefault() throws FileNotFoundException {
+        String basePath = env.getProperty("app.data.dir", "/tmp/data");
+        File file = new File(basePath, "output.csv");
+        new FileInputStream(file);
+    }
+
+    public void safeRequiredProperty() throws FileNotFoundException {
+        String basePath = env.getRequiredProperty("app.storage.path");
+        File file = new File(basePath, "archive.zip");
+        new FileInputStream(file);
+    }
+}


### PR DESCRIPTION
## Summary

Adds taint config entries to mark Spring's `Environment.getProperty()` and `PropertyResolver.getProperty()` as SAFE, preventing false positive path traversal warnings when using server-side configuration values.

Fixes #344

## Problem

Code like this triggers a path traversal warning even though the value comes from server-side Spring configuration, not user input:

```java
Environment env = ...;
new File(env.getProperty("serversideconf"), "/test.xml");
```

This is a false positive because `Environment.getProperty()` reads from application properties, system properties, or environment variables - all controlled by the application deployer.

## Changes

- Added `findsecbugs-plugin/src/main/resources/taint-config/spring.txt` with SAFE entries for:
  - `PropertyResolver.getProperty()` (all overloads)
  - `PropertyResolver.getRequiredProperty()` (all overloads)
  - `PropertyResolver.resolvePlaceholders()` / `resolveRequiredPlaceholders()`
  - `Environment.getProperty()` (all overloads)
  - `Environment.getRequiredProperty()` (all overloads)
- Registered `spring.txt` in `TaintDataflowEngine.TAINT_CONFIG_FILENAMES`

## Pattern

Follows the same approach used in `java-lang.txt` where `System.getProperty()` and `System.getenv()` are marked SAFE.

This contribution was developed with AI assistance (Claude Code).