### PR TITLE
update SEI Cert links in docs

### DIFF
--- a/findsecbugs-plugin/src/main/resources/metadata/messages.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages.xml
@@ -6777,7 +6777,7 @@ if (matcher.find()) {
 
 <p>
 <b>References</b><br/>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS11-J.+Perform+any+string+modifications+before+validation">CERT: IDS11-J. Perform any string modifications before validation</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-validation-and-data-sanitization-ids/ids11-j/">CERT: IDS11-J. Perform any string modifications before validation</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/179.html">CWE-179: Incorrect Behavior Order: Early Validation</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/182.html">CWE-182: Collapse of Data into Unsafe Value</a><br/>
 </p>
@@ -6828,7 +6828,7 @@ if (matcher.find()) {
 
 <p>
 <b>References</b><br/>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS01-J.+Normalize+strings+before+validating+them">CERT: IDS01-J. Normalize strings before validating them</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-validation-and-data-sanitization-ids/ids01-j/">CERT: IDS01-J. Normalize strings before validating them</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/179.html">CWE-179: Incorrect Behavior Order: Early Validation</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/180.html">CWE-180: Incorrect Behavior Order: Validate Before Canonicalize</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/289.html">CWE-289: Authentication Bypass by Alternate Name</a><br/>
@@ -6876,7 +6876,7 @@ pc.add(new RuntimePermission("createClassLoader"));
 
 
 <p>References</b><br>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions">CERT: ENV03-J. Do not grant dangerous combinations of permissions</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/runtime-environment-env/env03-j/">CERT: ENV03-J. Do not grant dangerous combinations of permissions</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/732.html">CWE-732: Incorrect Permission Assignment for Critical Resource</a><br/>
 </p>
             ]]>
@@ -6924,7 +6924,7 @@ phone for 1 singe dollar.
 </p>
 
 <p>References</b><br>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS16-J.+Prevent+XML+Injection">IDS16-J. Prevent XML Injection</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-validation-and-data-sanitization-ids/ids16-j/">IDS16-J. Prevent XML Injection</a><br/>
 </p>
         ]]>
         </Details>

--- a/findsecbugs-plugin/src/main/resources/metadata/messages_ja.xml
+++ b/findsecbugs-plugin/src/main/resources/metadata/messages_ja.xml
@@ -6403,7 +6403,7 @@ if (matcher.find()) {
 
 <p>
 <b>References</b><br/>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS11-J.+Perform+any+string+modifications+before+validation">CERT: IDS11-J. Perform any string modifications before validation</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-validation-and-data-sanitization-ids/ids11-j/">CERT: IDS11-J. Perform any string modifications before validation</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/179.html">CWE-179: Incorrect Behavior Order: Early Validation</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/180.html">CWE-180: Incorrect Behavior Order: Validate Before Canonicalize</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/289.html">CWE-289: Authentication Bypass by Alternate Name</a><br/>
@@ -6455,7 +6455,7 @@ if (matcher.find()) {
 
 <p>
 <b>References</b><br/>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS01-J.+Normalize+strings+before+validating+them">CERT: IDS01-J. Normalize strings before validating them</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-validation-and-data-sanitization-ids/ids01-j/">CERT: IDS01-J. Normalize strings before validating them</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/179.html">CWE-179: Incorrect Behavior Order: Early Validation</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/182.html">CWE-182: Collapse of Data into Unsafe Value</a><br/>
 </p>
@@ -6502,7 +6502,7 @@ pc.add(new RuntimePermission("createClassLoader"));
 
 
 <p>References</b><br>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/ENV03-J.+Do+not+grant+dangerous+combinations+of+permissions">CERT: ENV03-J. Do not grant dangerous combinations of permissions</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/runtime-environment-env/env03-j/">CERT: ENV03-J. Do not grant dangerous combinations of permissions</a><br/>
 <a href="https://cwe.mitre.org/data/definitions/732.html">CWE-732: Incorrect Permission Assignment for Critical Resource</a><br/>
 </p>
             ]]>
@@ -6550,7 +6550,7 @@ phone for 1 singe dollar.
 </p>
 
 <p>References</b><br>
-<a href="https://wiki.sei.cmu.edu/confluence/display/java/IDS16-J.+Prevent+XML+Injection">IDS16-J. Prevent XML Injection</a><br/>
+<a href="https://cmu-sei.github.io/secure-coding-standards/sei-cert-oracle-coding-standard-for-java/rules/input-validation-and-data-sanitization-ids/ids16-j/">IDS16-J. Prevent XML Injection</a><br/>
 </p>
         ]]>
         </Details>


### PR DESCRIPTION
It looks like SEI Cert Standard got migrated to a new website. This PR updates the links in `messages.xml` and `messages-ja.xml` files, so this is only a docs change. The build failure is unrelated, the same already present on master.