### PR TITLE
Recognize \R and \v regex replacements as CRLF sanitizers

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/taintanalysis/TaintFrameModelingVisitor.java
@@ -47,6 +47,16 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
     private static final Logger LOG = Logger.getLogger(TaintFrameModelingVisitor.class.getName());
 
     private static final Map<String, Taint.Tag> REPLACE_TAGS;
+
+    /**
+     * Regex constructs that, when used as the pattern of a regex-based replace
+     * (e.g. {@code String.replaceAll}), match line break characters and therefore
+     * strip both carriage return and line feed at once. {@code \R} matches any
+     * Unicode linebreak sequence (including CR, LF and CRLF) and {@code \v} matches
+     * a vertical whitespace character. Removing either neutralizes CRLF log
+     * injection, so both CR_ENCODED and LF_ENCODED must be set when they appear.
+     */
+    private static final String[] LINEBREAK_REGEX_TOKENS = {"\\R", "\\v"};
     private final MethodDescriptor methodDescriptor;
     private final TaintConfig taintConfig;
     private final TaintMethodConfig analyzedMethodConfig;
@@ -692,6 +702,18 @@ public class TaintFrameModelingVisitor extends AbstractFrameModelingVisitor<Tain
                 if ((objectConfiguration.isAReplaceMethodWithRegexParameter() && toReplace.contains(tagString))
                         || toReplace.equals(tagString)) {
                     taint.addTag(replaceTag.getValue());
+                }
+            }
+
+            // A regex pattern can also strip line breaks without naming \r or \n
+            // explicitly, e.g. replaceAll("\\R", "") removes any Unicode linebreak.
+            // Treat such patterns as encoding both CR and LF.
+            if (objectConfiguration.isAReplaceMethodWithRegexParameter()) {
+                for (String linebreakToken : LINEBREAK_REGEX_TOKENS) {
+                    if (toReplace.contains(linebreakToken)) {
+                        taint.addTag(Taint.Tag.CR_ENCODED);
+                        taint.addTag(Taint.Tag.LF_ENCODED);
+                    }
                 }
             }
 

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/crlf/CrlfLogInjectionDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/crlf/CrlfLogInjectionDetectorTest.java
@@ -43,9 +43,48 @@ public class CrlfLogInjectionDetectorTest extends BaseDetectorTest {
                     .build()
             );
         }
-        verify(reporter, times(49 - 20)).doReportBug(bugDefinition().bugType("CRLF_INJECTION_LOGS").build());
+        // A regex replace that does not strip line breaks is still reported.
+        verify(reporter).doReportBug(
+                bugDefinition()
+                .bugType("CRLF_INJECTION_LOGS")
+                .inClass("Logging").inMethod("crlfRegexReplaceStillInsecure").atLine(71)
+                .build()
+        );
+        verify(reporter, times(49 - 20 + 1)).doReportBug(bugDefinition().bugType("CRLF_INJECTION_LOGS").build());
     }
 
+
+    @Test
+    public void regexLinebreakReplaceIsSanitized() throws Exception {
+        String[] files = {
+            getClassFilePath("testcode/Logging")
+        };
+        SecurityReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        // replaceAll("\\R", "") and replaceAll("\\v", "") strip every line break,
+        // so no CRLF log injection must be reported in this method.
+        verify(reporter, times(0)).doReportBug(
+                bugDefinition()
+                        .bugType("CRLF_INJECTION_LOGS")
+                        .inClass("Logging").inMethod("javaUtilLogging").atLine(61)
+                        .build()
+        );
+        verify(reporter, times(0)).doReportBug(
+                bugDefinition()
+                        .bugType("CRLF_INJECTION_LOGS")
+                        .inClass("Logging").inMethod("javaUtilLogging").atLine(62)
+                        .build()
+        );
+
+        // A regex that does not remove line breaks must still be reported.
+        verify(reporter).doReportBug(
+                bugDefinition()
+                        .bugType("CRLF_INJECTION_LOGS")
+                        .inClass("Logging").inMethod("crlfRegexReplaceStillInsecure")
+                        .build()
+        );
+    }
 
     @Test
     public void detectResponseSplittingKotlin() throws Exception {

--- a/findsecbugs-samples-java/src/test/java/testcode/Logging.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/Logging.java
@@ -58,6 +58,17 @@ public class Logging {
         encoded = "safe" + encoded.toLowerCase();
         logger.warning(encoded.replace("\n", " (new line)"));
         logger.fine(tainted.replaceAll("[\r\n]+", ""));
+        logger.fine(tainted.replaceAll("\\R", "")); // \R matches any Unicode linebreak (CR, LF, CRLF)
+        logger.fine(tainted.replaceAll("\\v", "")); // \v matches a vertical whitespace character
+    }
+
+    @SuppressWarnings( "deprecation" )
+    public void crlfRegexReplaceStillInsecure() {
+        String tainted = req.getParameter("test");
+        Logger logger = Logger.getLogger(Logging.class.getName());
+
+        // The regex "\\d" (any digit) does not strip line breaks, so this is still reported.
+        logger.warning(tainted.replaceAll("\\d", ""));
     }
 
 }


### PR DESCRIPTION
## What this fixes

Fixes #762.

The `CRLF_INJECTION_LOGS` detector cleared its warning when a value reached a
log sink only if that value had been passed through a regex-based replace whose
pattern literally contained a carriage return or a line feed. The taint model
in `TaintFrameModelingVisitor` walks the `REPLACE_TAGS` map and, for a regex
replace such as `String.replaceAll`, checks whether the pattern string
*contains* `\r` or `\n` before setting the `CR_ENCODED` / `LF_ENCODED` tags.

A very common and correct way to strip line breaks does not name those
characters at all:

```java
log.info("User " + val.replaceAll("\\R", "") + " was not authenticated");
```

`\R` is the regex construct that matches any Unicode linebreak sequence,
including CR, LF and CRLF. The pattern string the compiler stores is the two
characters `\R`, which contains neither a literal CR nor a literal LF, so the
detector never set the encoded tags and reported a false positive on code that
is in fact sanitized. The same applies to `\v` (a vertical whitespace
character).

## The change

In the regex-parameter branch of `getConfigWithReplaceTags`, after the existing
literal-character handling, treat `\R` and `\v` in the pattern as removing both
CR and LF and set `CR_ENCODED` and `LF_ENCODED` together. The existing literal
cases (`\r`, `\n`, `"`, `'`, `<`) are untouched, so this only adds recognition
and cannot reintroduce a missed sink.

## Tests

`findsecbugs-samples-java` `testcode/Logging` gains two sanitized calls
(`replaceAll("\\R", "")` and `replaceAll("\\v", "")`) plus a new method that
uses a non-linebreak regex (`replaceAll("\\d", "")`) which must still be
reported. `CrlfLogInjectionDetectorTest` adds `regexLinebreakReplaceIsSanitized`
asserting that the two sanitized calls produce no `CRLF_INJECTION_LOGS` finding
while the non-linebreak replace is still flagged. The pre-existing
`detectResponseSplitting` assertions over the original lines are unchanged.

Run with:

```
mvn -q -Dtest=CrlfLogInjectionDetectorTest test
```
