### PR TITLE
Track taint through chained primitive StringBuilder/StringBuffer.append

### DIFF
--- a/findsecbugs-plugin/src/main/resources/taint-config/java-lang.txt
+++ b/findsecbugs-plugin/src/main/resources/taint-config/java-lang.txt
@@ -81,12 +81,12 @@ java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;:0,1#
 java/lang/StringBuilder.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;:0,1#1
 java/lang/StringBuilder.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;:0,1#1
 java/lang/StringBuilder.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuilder;:2,3#3
-java/lang/StringBuilder.append(Z)Ljava/lang/StringBuilder;:1
-java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;:0,1
-java/lang/StringBuilder.append(D)Ljava/lang/StringBuilder;:2
-java/lang/StringBuilder.append(F)Ljava/lang/StringBuilder;:1
-java/lang/StringBuilder.append(I)Ljava/lang/StringBuilder;:1
-java/lang/StringBuilder.append(J)Ljava/lang/StringBuilder;:2
+java/lang/StringBuilder.append(Z)Ljava/lang/StringBuilder;:1#1
+java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;:0,1#1
+java/lang/StringBuilder.append(D)Ljava/lang/StringBuilder;:2#2
+java/lang/StringBuilder.append(F)Ljava/lang/StringBuilder;:1#1
+java/lang/StringBuilder.append(I)Ljava/lang/StringBuilder;:1#1
+java/lang/StringBuilder.append(J)Ljava/lang/StringBuilder;:2#2
 java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;:0,1#1
 
 java/lang/StringBuilder.insert(ILjava/lang/String;)Ljava/lang/StringBuilder;:0,2#2
@@ -120,12 +120,12 @@ java/lang/StringBuffer.append(Ljava/lang/String;)Ljava/lang/StringBuffer;:0,1#1
 java/lang/StringBuffer.append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuffer;:0,1#1
 java/lang/StringBuffer.append(Ljava/lang/CharSequence;)Ljava/lang/StringBuffer;:0,1#1
 java/lang/StringBuffer.append(Ljava/lang/CharSequence;II)Ljava/lang/StringBuffer;:2,3#3
-java/lang/StringBuffer.append(Z)Ljava/lang/StringBuffer;:1
-java/lang/StringBuffer.append(C)Ljava/lang/StringBuffer;:0,1
-java/lang/StringBuffer.append(D)Ljava/lang/StringBuffer;:2
-java/lang/StringBuffer.append(F)Ljava/lang/StringBuffer;:1
-java/lang/StringBuffer.append(I)Ljava/lang/StringBuffer;:1
-java/lang/StringBuffer.append(J)Ljava/lang/StringBuffer;:2
+java/lang/StringBuffer.append(Z)Ljava/lang/StringBuffer;:1#1
+java/lang/StringBuffer.append(C)Ljava/lang/StringBuffer;:0,1#1
+java/lang/StringBuffer.append(D)Ljava/lang/StringBuffer;:2#2
+java/lang/StringBuffer.append(F)Ljava/lang/StringBuffer;:1#1
+java/lang/StringBuffer.append(I)Ljava/lang/StringBuffer;:1#1
+java/lang/StringBuffer.append(J)Ljava/lang/StringBuffer;:2#2
 java/lang/StringBuffer.append(Ljava/lang/Object;)Ljava/lang/StringBuffer;:0,1#1
 
 java/lang/StringBuffer.insert(ILjava/lang/String;)Ljava/lang/StringBuffer;:0,2#2

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/sql/SqlInjectionStringBuilderChained764Test.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/injection/sql/SqlInjectionStringBuilderChained764Test.java
@@ -1,0 +1,66 @@
+/**
+ * Find Security Bugs
+ * Copyright (c) Philippe Arteau, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+package com.h3xstream.findsecbugs.injection.sql;
+
+import com.h3xstream.findbugs.test.BaseDetectorTest;
+import com.h3xstream.findbugs.test.EasyBugReporter;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression test for https://github.com/find-sec-bugs/find-sec-bugs/issues/764
+ *
+ * SQL_INJECTION_JDBC must be reported when a tainted value is appended as the
+ * second, chained argument of a StringBuilder.append() call (for example
+ * sql.append(',').append(tainted)), not only when the tainted value is appended
+ * first or through a separate statement.
+ */
+public class SqlInjectionStringBuilderChained764Test extends BaseDetectorTest {
+
+    @Test
+    public void detectChainedAppendSqlInjection() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/sqli/SqlInjectionStringBuilderChained764")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        for (String unsafeMethod : Arrays.asList(
+                "chainedAppendTaintedFirst",
+                "chainedAppendTaintedSecond",
+                "usesIteratorOfIntegersWithChainedAppendItemFirst",
+                "usesIteratorOfIntegersWithChainedAppendItemSecond",
+                "usesIteratorOfIntegersWithSeparateAppendItemFirst",
+                "usesIteratorOfIntegersWithSeparateAppendItemSecond")) {
+            verify(reporter).doReportBug(
+                    bugDefinition()
+                            .bugType("SQL_INJECTION_JDBC")
+                            .inClass("SqlInjectionStringBuilderChained764")
+                            .inMethod(unsafeMethod)
+                            .build()
+            );
+        }
+    }
+}

--- a/findsecbugs-samples-java/src/test/java/testcode/sqli/SqlInjectionStringBuilderChained764.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/sqli/SqlInjectionStringBuilderChained764.java
@@ -1,0 +1,140 @@
+package testcode.sqli;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Reproduces https://github.com/find-sec-bugs/find-sec-bugs/issues/764
+ *
+ * SQL_INJECTION_JDBC was missed when a tainted value is appended as the second,
+ * chained argument of a StringBuilder.append() call, for example
+ * sql.append(',').append(tainted). The intermediate append() return value sits
+ * on the operand stack and has no local variable index, so the taint written
+ * back by the second append() never reached the original StringBuilder local.
+ * The single-argument primitive append() summaries did not mark the builder as
+ * a mutable argument, which is what anchored the writeback to the variable.
+ */
+public class SqlInjectionStringBuilderChained764 {
+    private static Connection _conn;
+
+    protected static Connection getConnection() {
+        return _conn;
+    }
+
+    public static void usesIteratorOfIntegersWithChainedAppendItemFirst(Collection<Integer> ids) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+
+        StringBuilder sql = new StringBuilder("UPDATE table SET field=0 WHERE id IN (NULL, ");
+        for (Iterator<Integer> iterator = ids.iterator(); iterator.hasNext(); ) {
+            sql.append(iterator.next()).append(',');
+        }
+        sql.append(')');
+
+        try {
+            conn = getConnection();
+            ps = conn.prepareStatement(sql.toString());
+            ps.executeUpdate();
+        } catch (SQLException sqle) {
+            // Do nothing
+        } finally {
+            close(conn, ps);
+        }
+    }
+
+    public static void usesIteratorOfIntegersWithChainedAppendItemSecond(Collection<Integer> ids) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+
+        StringBuilder sql = new StringBuilder("UPDATE table SET field=0 WHERE id IN (NULL, ");
+        for (Iterator<Integer> iterator = ids.iterator(); iterator.hasNext(); ) {
+            sql.append(',').append(iterator.next());
+        }
+        sql.append(')');
+
+        try {
+            conn = getConnection();
+            ps = conn.prepareStatement(sql.toString());
+            ps.executeUpdate();
+        } catch (SQLException sqle) {
+            // Do nothing
+        } finally {
+            close(conn, ps);
+        }
+    }
+
+    public static void usesIteratorOfIntegersWithSeparateAppendItemFirst(Collection<Integer> ids) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+
+        StringBuilder sql = new StringBuilder("UPDATE table SET field=0 WHERE id IN (NULL, ");
+        for (Iterator<Integer> iterator = ids.iterator(); iterator.hasNext(); ) {
+            sql.append(iterator.next());
+            sql.append(',');
+        }
+        sql.append(')');
+
+        try {
+            conn = getConnection();
+            ps = conn.prepareStatement(sql.toString());
+            ps.executeUpdate();
+        } catch (SQLException sqle) {
+            // Do nothing
+        } finally {
+            close(conn, ps);
+        }
+    }
+
+    public static void usesIteratorOfIntegersWithSeparateAppendItemSecond(Collection<Integer> ids) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+
+        StringBuilder sql = new StringBuilder("UPDATE table SET field=0 WHERE id IN (NULL, ");
+        for (Iterator<Integer> iterator = ids.iterator(); iterator.hasNext(); ) {
+            sql.append(',');
+            sql.append(iterator.next());
+        }
+        sql.append(')');
+
+        try {
+            conn = getConnection();
+            ps = conn.prepareStatement(sql.toString());
+            ps.executeUpdate();
+        } catch (SQLException sqle) {
+            // Do nothing
+        } finally {
+            close(conn, ps);
+        }
+    }
+
+    // Minimal, loop-free variants that isolate the chained-append behaviour.
+
+    public static void chainedAppendTaintedFirst(String input) {
+        try {
+            StringBuilder sql = new StringBuilder("SELECT 1 WHERE x=");
+            sql.append(input).append(',');
+            getConnection().prepareStatement(sql.toString()).executeUpdate();
+        } catch (SQLException sqle) {
+            // Do nothing
+        }
+    }
+
+    public static void chainedAppendTaintedSecond(String input) {
+        try {
+            StringBuilder sql = new StringBuilder("SELECT 1 WHERE x=");
+            sql.append(',').append(input);
+            getConnection().prepareStatement(sql.toString()).executeUpdate();
+        } catch (SQLException sqle) {
+            // Do nothing
+        }
+    }
+
+    private static void close(Connection conn, Statement s) {
+        if (null != s) try { s.close(); } catch (SQLException sqle) { }
+        if (null != conn) try { conn.close(); } catch (SQLException sqle) { }
+    }
+}


### PR DESCRIPTION
Fixes #764

## Problem

`SQL_INJECTION_JDBC` (and the other taint-based detectors that read from a `StringBuilder`/`StringBuffer`) miss the injection when a tainted value is appended as the second, chained argument of an `append()` call:

```java
StringBuilder sql = new StringBuilder("SELECT 1 WHERE x=");
sql.append(',').append(tainted);          // missed
getConnection().prepareStatement(sql.toString()).executeUpdate();
```

The same construct is detected when the tainted value comes first (`sql.append(tainted).append(',')`) or through a separate statement (`sql.append(','); sql.append(tainted);`). The issue reports this for `usesIteratorOfIntegersWithChainedAppendItemSecond`.

## Root cause

The taint summaries for the single-argument primitive appends did not mark the builder receiver as a mutable argument:

```
java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;:0,1
java/lang/StringBuilder.append(I)Ljava/lang/StringBuilder;:1
...
```

The String/CharSequence/Object overloads already carry the `#index` writeback (`...:0,1#1`). For a chained call, the receiver of the second `append()` is the return value of the first `append()`, which lives on the operand stack and has no local variable index. The mutable-argument writeback is what propagates the merged taint back to the original `StringBuilder` local variable. Without it on the primitive overloads, the chain `append(safeChar).append(tainted)` never updates the `sql` local, so the later `sql.toString()` reads an untainted value and the sink is not flagged.

## Fix

Add the `#index` mutable-argument marker to the primitive `append()` summaries for both `StringBuilder` and `StringBuffer`, matching the existing String/Object overloads. Appending a safe primitive to a safe builder still merges to a safe value, so no new false positives are introduced.

```
java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;:0,1#1
java/lang/StringBuilder.append(I)Ljava/lang/StringBuilder;:1#1
...
```

## Reproduction and verification

A new sample `testcode/sqli/SqlInjectionStringBuilderChained764` and test `SqlInjectionStringBuilderChained764Test` cover the chained-append item-first and item-second variants from the issue plus minimal loop-free cases.

Before the fix, the test fails because the chained item-second cases are not reported:

```
Wanted but not invoked:
securityReporter.doReportBug(BugInstance with:
  bugType="SQL_INJECTION_JDBC",
  className="SqlInjectionStringBuilderChained764",
  methodName="chainedAppendTaintedSecond")
```

After the fix the test passes, and the full `findsecbugs-plugin` suite shows no new failures introduced by this change.
