### PR TITLE
Fix STATIC_IV false positive on parameter-derived IV

### DIFF
--- a/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/crypto/StaticIvDetector.java
+++ b/findsecbugs-plugin/src/main/java/com/h3xstream/findsecbugs/crypto/StaticIvDetector.java
@@ -32,11 +32,19 @@ import java.util.Iterator;
 import javax.crypto.Cipher;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ALOAD;
+import org.apache.bcel.generic.ANEWARRAY;
 import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.GETFIELD;
+import org.apache.bcel.generic.GETSTATIC;
 import org.apache.bcel.generic.ICONST;
 import org.apache.bcel.generic.INVOKESPECIAL;
 import org.apache.bcel.generic.INVOKEVIRTUAL;
 import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.NEW;
+import org.apache.bcel.generic.NEWARRAY;
+import org.apache.bcel.generic.Type;
 
 /**
  * <p>
@@ -83,6 +91,10 @@ public class StaticIvDetector implements Detector {
         boolean atLeastOneDecryptCipher = false;
         boolean atLeastOneEncryptCipher = false;
         boolean ivFetchFromCipher = false;
+        //Track whether this method performs any Cipher.init at all. A method that only builds the
+        //parameter spec (a helper that receives the IV as an argument and returns the spec) has no
+        //encryption context, so an IV taken from a method parameter cannot be assumed to be static.
+        boolean atLeastOneCipherInit = false;
 
         //First pass : it look for encryption and decryption mode to detect if the method does decryption only
         for (Iterator<Location> i = cfg.locationIterator(); i.hasNext(); ) {
@@ -96,6 +108,7 @@ public class StaticIvDetector implements Detector {
                 //INVOKEVIRTUAL javax/crypto/Cipher.init ((ILjava/security/Key;)V)
                 if (("javax.crypto.Cipher").equals(invoke.getClassName(cpg)) &&
                         "init".equals(invoke.getMethodName(cpg))) {
+                    atLeastOneCipherInit = true;
                     ICONST iconst = ByteCode.getPrevInstruction(location.getHandle(), ICONST.class);
                     if (iconst != null) {
                         int mode = iconst.getValue().intValue();
@@ -141,6 +154,15 @@ public class StaticIvDetector implements Detector {
                 if (("javax.crypto.spec.IvParameterSpec").equals(invoke.getClassName(cpg)) &&
                         "<init>".equals(invoke.getMethodName(cpg))) {
 
+                    //When the method performs no encryption/decryption of its own and the IV is
+                    //received as a method parameter, there is no evidence the IV is static (see #765).
+                    //A genuinely static IV is built locally from constants (NEWARRAY) or read from a
+                    //field (GETSTATIC/GETFIELD), so those still get flagged.
+                    if (!atLeastOneCipherInit
+                            && ivLoadedFromMethodParameter(location.getHandle(), m, cpg)) {
+                        continue;
+                    }
+
                     JavaClass clz = classContext.getJavaClass();
                     bugReporter.reportBug(new BugInstance(this, STATIC_IV, Priorities.NORMAL_PRIORITY) //
                             .addClass(clz)
@@ -149,6 +171,59 @@ public class StaticIvDetector implements Detector {
                 }
             }
         }
+    }
+
+    /**
+     * Determine whether the IV array passed to the spec constructor at {@code initHandle} is loaded
+     * from a method parameter (an {@code ALOAD} of a parameter slot), as opposed to being built
+     * locally from constants or read from a field.
+     *
+     * <p>The scan walks backward from the constructor call to the matching {@code NEW} of the spec
+     * class. If a fresh array construction ({@code NEWARRAY}/{@code ANEWARRAY}) or a field read
+     * ({@code GETSTATIC}/{@code GETFIELD}) appears in that window, the IV is treated as potentially
+     * static and this method returns {@code false}. If the only array reference comes from an
+     * {@code ALOAD} of a parameter slot, the IV is parameter-derived and the method returns
+     * {@code true}.</p>
+     */
+    private boolean ivLoadedFromMethodParameter(InstructionHandle initHandle, Method m, ConstantPoolGen cpg) {
+        int parameterSlots = parameterSlotCount(m);
+        boolean parameterArrayLoaded = false;
+        for (InstructionHandle h = initHandle.getPrev(); h != null; h = h.getPrev()) {
+            Instruction ins = h.getInstruction();
+            if (ins instanceof NEW) {
+                NEW newIns = (NEW) ins;
+                String createdClass = newIns.getLoadClassType(cpg).getClassName();
+                if ("javax.crypto.spec.IvParameterSpec".equals(createdClass)
+                        || "javax.crypto.spec.GCMParameterSpec".equals(createdClass)) {
+                    //Reached the start of the spec construction.
+                    break;
+                }
+            } else if (ins instanceof NEWARRAY || ins instanceof ANEWARRAY) {
+                //The array is built locally; it may be a hardcoded constant IV.
+                return false;
+            } else if (ins instanceof GETSTATIC || ins instanceof GETFIELD) {
+                //The array comes from a field; treat it as potentially static.
+                return false;
+            } else if (ins instanceof ALOAD) {
+                int slot = ((ALOAD) ins).getIndex();
+                if (slot < parameterSlots) {
+                    parameterArrayLoaded = true;
+                }
+            }
+        }
+        return parameterArrayLoaded;
+    }
+
+    /**
+     * Number of local-variable slots occupied by the method parameters (including {@code this} for
+     * instance methods). {@code long} and {@code double} parameters each take two slots.
+     */
+    private int parameterSlotCount(Method m) {
+        int slots = m.isStatic() ? 0 : 1;
+        for (Type t : m.getArgumentTypes()) {
+            slots += t.getSize();
+        }
+        return slots;
     }
 
     private Location nextLocation(Iterator<Location> i,ConstantPoolGen cpg) {

--- a/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/crypto/StaticIvDetectorTest.java
+++ b/findsecbugs-plugin/src/test/java/com/h3xstream/findsecbugs/crypto/StaticIvDetectorTest.java
@@ -158,6 +158,25 @@ public class StaticIvDetectorTest extends BaseDetectorTest {
 
 
     @Test
+    public void avoidFalsePositiveParameterIv() throws Exception {
+        //Locate test code
+        String[] files = {
+                getClassFilePath("testcode/crypto/iv/ParameterIv")
+        };
+
+        //Run the analysis
+        EasyBugReporter reporter = spy(new SecurityReporter());
+        analyze(files, reporter);
+
+        //Assertions
+
+        //The IV is a method parameter, not a static/constant array (issue #765)
+        verify(reporter,never()).doReportBug( //
+                bugDefinition().bugType("STATIC_IV").inClass("ParameterIv").build()
+        );
+    }
+
+    @Test
     public void avoidFalsePositiveGenerateWithKeyGenerator() throws Exception {
         //Locate test code
         String[] files = {

--- a/findsecbugs-samples-java/src/test/java/testcode/crypto/iv/ParameterIv.java
+++ b/findsecbugs-samples-java/src/test/java/testcode/crypto/iv/ParameterIv.java
@@ -1,0 +1,34 @@
+package testcode.crypto.iv;
+
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * Reproduction for issue #765.
+ *
+ * The IV is received as a method parameter (it is filled by a SecureRandom or
+ * provided by a caller for decryption elsewhere). Building an IvParameterSpec or
+ * GCMParameterSpec from a parameter array is not a static IV, so STATIC_IV must
+ * not be reported here.
+ */
+public class ParameterIv {
+
+    private String algorithmMode = "GCM";
+
+    private String getAlgorithmMode() {
+        return algorithmMode;
+    }
+
+    private AlgorithmParameterSpec getKeyParameters(byte[] iv) {
+        if ("GCM".equals(getAlgorithmMode())) {
+            return new GCMParameterSpec(128, iv, 0, iv.length);
+        } else {
+            return new IvParameterSpec(iv, 0, iv.length);
+        }
+    }
+
+    public AlgorithmParameterSpec buildFromParameter(byte[] iv) {
+        return getKeyParameters(iv);
+    }
+}


### PR DESCRIPTION
Fixes #765

## Problem

`STATIC_IV` fires on a helper method that only builds an IV/GCM parameter spec from an IV it receives as a method argument, even though the array is not static. The reproduction from the issue:

```java
private AlgorithmParameterSpec getKeyParameters(byte[] iv) {
    if ("GCM".equals(getAlgorithmMode()))
        return new GCMParameterSpec(128, iv, 0, iv.length);
    else
        return new IvParameterSpec(iv, 0, iv.length);
}
```

The `iv` here is either filled by a `SecureRandom` or passed in by a caller for decryption, so there is no static IV. The detector still reports `STATIC_IV` on the `IvParameterSpec` branch.

## Root cause

`StaticIvDetector` deliberately does no backtracking on the IV bytes (see its class javadoc). Instead it reports a spec construction unless the same method shows a "safe" signal: a `SecureRandom.nextBytes` call, a decrypt/unwrap-only cipher, or an IV fetched from a `KeyGenerator` via `Cipher.getIV()`.

A pure spec-builder helper has none of those signals because it performs no `Cipher.init` at all. With no cipher in the method, the guard `(!atLeastOneDecryptCipher || atLeastOneEncryptCipher)` evaluates to true and the construction is reported. So a method that only assembles the spec and hands it back gets flagged with no encryption context to justify it.

## Fix

When a method performs no `Cipher.init` of any kind and the IV array passed to the spec constructor is loaded from a method parameter (an `ALOAD` of a parameter slot), the detector no longer reports `STATIC_IV`. A parameter is not known to be constant, and without a cipher operation in the method there is no evidence the IV is reused.

The check is local to the bytecode around the constructor. It scans back from the spec `<init>` to the matching `NEW`:
- a fresh array (`NEWARRAY`/`ANEWARRAY`) or a field read (`GETSTATIC`/`GETFIELD`) in that window keeps the report, since those are how a genuinely static/hardcoded IV is produced,
- only an `ALOAD` of a parameter slot suppresses it.

What still gets flagged (unchanged):
- a hardcoded array such as `new byte[]{1,2,...}` or `new byte[16]` (`ConstantIv`),
- an IV held in a static field (`StaticVariableIv`),
- a parameter IV that is actually consumed by an encrypt/wrap cipher in the same method (`StaticIvWrap`), because that method does call `Cipher.init`.

## Verification

Added `ParameterIv` sample (the issue's pattern) and an `avoidFalsePositiveParameterIv` test asserting no `STATIC_IV`.

Before the source change the new test fails (the FP is reported):

```
[ERROR] avoidFalsePositiveParameterIv  <<< FAILURE!
bugType="STATIC_IV",className="ParameterIv"
[ERROR] Tests run: 8, Failures: 1
```

After the fix the full `StaticIvDetectorTest` passes, including the existing true-positive and false-positive cases:

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

The wider `com.h3xstream.findsecbugs.crypto` test package was also run and shows no new failures versus a pristine build of the same revision.
